### PR TITLE
Work around pip breakage

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             pip install -r requirements.txt
-            pip install -e .
+            python setup.py install
 
         - name: Run tests
           shell: bash -l {0}


### PR DESCRIPTION
Use 'python setup.py install' rather than 'pip install .' to avoid spurious installation of old loopy.

x-ref: https://gitlab.tiker.net/inducer/ci-support/-/commit/fc8c4b779b34404832b0426aa8f49c445d3e3a2a