### PR TITLE
Drop meshpy from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/loopy.git#egg=loo.py
 git+https://github.com/inducer/dagrt.git#egg=dagrt
 git+https://github.com/inducer/leap.git#egg=leap
-git+https://github.com/inducer/meshpy.git#egg=meshpy
 git+https://github.com/inducer/modepy.git#egg=modepy
 git+https://github.com/inducer/meshmode.git#egg=meshmode
 git+https://github.com/inducer/grudge.git#egg=grudge


### PR DESCRIPTION
x-ref: https://github.com/inducer/meshpy/issues/50

I don't think we need it for anything. (We use gmsh for mesh generation after all.)

cc @majosm 