### PR TITLE
use pooled allocator

### DIFF
--- a/examples/wave-eager-mpi.py
+++ b/examples/wave-eager-mpi.py
@@ -36,6 +36,7 @@ from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 from mirgecom.integrators import rk4_step
 from mirgecom.wave import wave_operator
+import pyopencl.tools as cl_tools
 from mpi4py import MPI
 
 
@@ -60,7 +61,8 @@ def bump(actx, discr, t=0):
 def main():
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue,
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)))
 
     comm = MPI.COMM_WORLD
     num_parts = comm.Get_size()

--- a/examples/wave-eager.py
+++ b/examples/wave-eager.py
@@ -31,6 +31,7 @@ from mirgecom.wave import wave_operator
 from mirgecom.integrators import rk4_step
 from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.dof_array import thaw
+import pyopencl.tools as cl_tools
 
 
 def bump(actx, discr, t=0):
@@ -54,7 +55,7 @@ def bump(actx, discr, t=0):
 def main():
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)))
 
     dim = 2
     nel_1d = 16

--- a/examples/wave-eager.py
+++ b/examples/wave-eager.py
@@ -55,7 +55,8 @@ def bump(actx, discr, t=0):
 def main():
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue, allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)))
+    actx = PyOpenCLArrayContext(queue,
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)))
 
     dim = 2
     nel_1d = 16


### PR DESCRIPTION
Reduces memory allocations from 300,000 to 160.
15% speedup.
Addresses #66.