### PR TITLE
Refactor some common utilities into simutils

### DIFF
--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -89,9 +89,9 @@ def main(ctx_factory=cl.create_some_context):
     rank = comm.Get_rank()
 
     from meshmode.mesh.generation import generate_regular_rect_mesh
-    grid_generator = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
-                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
-    local_mesh, global_nelements = create_parallel_grid(comm, grid_generator)
+    generate_grid = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
+                            b=(box_ur,) * dim, n=(nel_1d,) * dim)
+    local_mesh, global_nelements = create_parallel_grid(comm, generate_grid)
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -39,7 +39,7 @@ from mirgecom.euler import inviscid_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    create_parallel_box_grid,
+    create_parallel_grid,
     ExactSolutionMismatch
 )
 from mirgecom.io import make_init_message
@@ -88,8 +88,10 @@ def main(ctx_factory=cl.create_some_context):
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
 
-    local_mesh, global_nelements = create_parallel_box_grid(comm, dim, box_ll,
-                                                            box_ur, nel_1d)
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    grid_generator = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
+                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
+    local_mesh, global_nelements = create_parallel_grid(comm, grid_generator)
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -38,7 +38,8 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import inviscid_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    exact_sim_checkpoint,
+    sim_checkpoint,
+    create_parallel_box_grid,
     ExactSolutionMismatch
 )
 from mirgecom.io import make_init_message
@@ -85,34 +86,10 @@ def main(ctx_factory=cl.create_some_context):
     box_ur = 5.0
 
     comm = MPI.COMM_WORLD
-    nproc = comm.Get_size()
     rank = comm.Get_rank()
-    num_parts = nproc
 
-    from meshmode.distributed import (
-        MPIMeshDistributor,
-        get_partition_by_pymetis,
-    )
-
-    mesh_dist = MPIMeshDistributor(comm)
-    global_nelements = 0
-    local_nelements = 0
-    if mesh_dist.is_mananger_rank():
-        from meshmode.mesh.generation import generate_regular_rect_mesh
-
-        mesh = generate_regular_rect_mesh(
-            a=(box_ll,) * dim, b=(box_ur,) * dim, n=(nel_1d,) * dim
-        )
-        global_nelements = mesh.nelements
-        logging.info(f"Total {dim}d elements: {global_nelements}")
-
-        part_per_element = get_partition_by_pymetis(mesh, num_parts)
-
-        local_mesh = mesh_dist.send_mesh_parts(mesh, part_per_element, num_parts)
-        del mesh
-
-    else:
-        local_mesh = mesh_dist.receive_mesh_part()
+    local_mesh, global_nelements = create_parallel_box_grid(comm, dim, box_ll,
+                                                            box_ur, nel_1d)
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(
@@ -144,10 +121,10 @@ def main(ctx_factory=cl.create_some_context):
                                  boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        return exact_sim_checkpoint(discr, initializer, visualizer, eos,
-                            q=state, vizname=casename, step=step, t=t, dt=dt,
-                            nstatus=nstatus, nviz=nviz, exittol=exittol,
-                            constant_cfl=constant_cfl, comm=comm)
+        return sim_checkpoint(discr, visualizer, eos, q=state,
+                              exact_soln=initializer, vizname=casename, step=step,
+                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -87,9 +87,9 @@ def main(ctx_factory=cl.create_some_context):
     rank = comm.Get_rank()
 
     from meshmode.mesh.generation import generate_regular_rect_mesh
-    grid_generator = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
-                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
-    local_mesh, global_nelements = create_parallel_grid(comm, grid_generator)
+    generate_grid = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
+                            b=(box_ur,) * dim, n=(nel_1d,) * dim)
+    local_mesh, global_nelements = create_parallel_grid(comm, generate_grid)
 
     local_nelements = local_mesh.nelements
 

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -38,7 +38,7 @@ from mirgecom.euler import inviscid_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    create_parallel_box_grid,
+    create_parallel_grid,
     ExactSolutionMismatch,
 )
 from mirgecom.io import make_init_message
@@ -86,8 +86,10 @@ def main(ctx_factory=cl.create_some_context):
 
     rank = comm.Get_rank()
 
-    local_mesh, global_nelements = create_parallel_box_grid(comm, dim, box_ll,
-                                                            box_ur, nel_1d)
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    grid_generator = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
+                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
+    local_mesh, global_nelements = create_parallel_grid(comm, grid_generator)
 
     local_nelements = local_mesh.nelements
 

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -37,7 +37,8 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import inviscid_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    exact_sim_checkpoint,
+    sim_checkpoint,
+    create_parallel_box_grid,
     ExactSolutionMismatch,
 )
 from mirgecom.io import make_init_message
@@ -82,33 +83,12 @@ def main(ctx_factory=cl.create_some_context):
     box_ur = 5.0
 
     comm = MPI.COMM_WORLD
-    nproc = comm.Get_size()
+
     rank = comm.Get_rank()
-    num_parts = nproc
 
-    from meshmode.distributed import (
-        MPIMeshDistributor,
-        get_partition_by_pymetis,
-    )
+    local_mesh, global_nelements = create_parallel_box_grid(comm, dim, box_ll,
+                                                            box_ur, nel_1d)
 
-    mesh_dist = MPIMeshDistributor(comm)
-    global_nelements = 0
-    local_nelements = 0
-    if mesh_dist.is_mananger_rank():
-
-        from meshmode.mesh.generation import generate_regular_rect_mesh
-        mesh = generate_regular_rect_mesh(
-            a=(box_ll,) * dim, b=(box_ur,) * dim, n=(nel_1d,) * dim
-        )
-        global_nelements = mesh.nelements
-        logging.info(f"Total {dim}d elements: {global_nelements}")
-
-        part_per_element = get_partition_by_pymetis(mesh, num_parts)
-        local_mesh = mesh_dist.send_mesh_parts(mesh, part_per_element, num_parts)
-        del mesh
-
-    else:
-        local_mesh = mesh_dist.receive_mesh_part()
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(
@@ -140,10 +120,10 @@ def main(ctx_factory=cl.create_some_context):
                                  boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        return exact_sim_checkpoint(discr, initializer, visualizer, eos,
-                            q=state, vizname=casename, step=step, t=t, dt=dt,
-                            nstatus=nstatus, nviz=nviz, exittol=exittol,
-                            constant_cfl=constant_cfl, comm=comm)
+        return sim_checkpoint(discr, visualizer, eos, q=state,
+                              exact_soln=initializer, vizname=casename, step=step,
+                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -39,7 +39,7 @@ from mirgecom.euler import inviscid_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    create_parallel_box_grid,
+    create_parallel_grid,
     ExactSolutionMismatch,
 )
 from mirgecom.io import make_init_message
@@ -89,8 +89,10 @@ def main(ctx_factory=cl.create_some_context):
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
 
-    local_mesh, global_nelements = create_parallel_box_grid(comm, dim, box_ll,
-                                                            box_ur, nel_1d)
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    grid_generator = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
+                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
+    local_mesh, global_nelements = create_parallel_grid(comm, grid_generator)
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -90,9 +90,9 @@ def main(ctx_factory=cl.create_some_context):
     rank = comm.Get_rank()
 
     from meshmode.mesh.generation import generate_regular_rect_mesh
-    grid_generator = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
-                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
-    local_mesh, global_nelements = create_parallel_grid(comm, grid_generator)
+    generate_grid = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
+                            b=(box_ur,) * dim, n=(nel_1d,) * dim)
+    local_mesh, global_nelements = create_parallel_grid(comm, generate_grid)
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -38,7 +38,8 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import inviscid_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    exact_sim_checkpoint,
+    sim_checkpoint,
+    create_parallel_box_grid,
     ExactSolutionMismatch,
 )
 from mirgecom.io import make_init_message
@@ -86,34 +87,10 @@ def main(ctx_factory=cl.create_some_context):
     box_ur = 5.0
 
     comm = MPI.COMM_WORLD
-    nproc = comm.Get_size()
     rank = comm.Get_rank()
-    num_parts = nproc
 
-    from meshmode.distributed import (
-        MPIMeshDistributor,
-        get_partition_by_pymetis,
-    )
-
-    mesh_dist = MPIMeshDistributor(comm)
-    global_nelements = 0
-    local_nelements = 0
-    if mesh_dist.is_mananger_rank():
-        from meshmode.mesh.generation import generate_regular_rect_mesh
-
-        mesh = generate_regular_rect_mesh(
-            a=(box_ll,) * dim, b=(box_ur,) * dim, n=(nel_1d,) * dim
-        )
-        global_nelements = mesh.nelements
-        logging.info(f"Total {dim}d elements: {global_nelements}")
-
-        part_per_element = get_partition_by_pymetis(mesh, num_parts)
-
-        local_mesh = mesh_dist.send_mesh_parts(mesh, part_per_element, num_parts)
-        del mesh
-
-    else:
-        local_mesh = mesh_dist.receive_mesh_part()
+    local_mesh, global_nelements = create_parallel_box_grid(comm, dim, box_ll,
+                                                            box_ur, nel_1d)
     local_nelements = local_mesh.nelements
 
     discr = EagerDGDiscretization(
@@ -145,10 +122,10 @@ def main(ctx_factory=cl.create_some_context):
                                  boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        return exact_sim_checkpoint(discr, initializer, visualizer, eos,
-                            q=state, vizname=casename, step=step, t=t, dt=dt,
-                            nstatus=nstatus, nviz=nviz, exittol=exittol,
-                            constant_cfl=constant_cfl, comm=comm)
+        return sim_checkpoint(discr, visualizer, eos, q=state,
+                              exact_soln=initializer, vizname=casename, step=step,
+                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
     try:
         (current_step, current_t, current_state) = \

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -24,7 +24,6 @@ THE SOFTWARE.
 import logging
 
 import numpy as np
-from mpi4py import mpi_communicator # noqa
 from meshmode.dof_array import thaw
 from mirgecom.io import make_status_message
 from mirgecom.euler import (
@@ -165,7 +164,8 @@ def create_parallel_grid(comm, generate_grid):
 
     Parameters
     ----------
-    comm: :class:mpi_communicator
+    comm:
+        MPI communicator over which to partition the grid
 
     generate_grid:
         Grid generation function should return a :class:meshmode.mesh

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -41,7 +41,7 @@ building simulation applications.
 .. autofunction:: inviscid_sim_timestep
 .. autoexception:: ExactSolutionMismatch
 .. autofunction:: sim_checkpoint
-.. autofunction:: create_parallel_box_grid
+.. autofunction:: create_parallel_grid
 """
 
 
@@ -171,7 +171,7 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
         raise ExactSolutionMismatch(step, t=t, state=q)
 
 
-def create_parallel_box_grid(comm, dim=2, box_ll=-0.5, box_ur=0.5, npoints_side=2):
+def create_parallel_grid(comm, grid_generator):
 
     from meshmode.distributed import (
         MPIMeshDistributor,
@@ -182,11 +182,9 @@ def create_parallel_box_grid(comm, dim=2, box_ll=-0.5, box_ur=0.5, npoints_side=
     global_nelements = 0
 
     if mesh_dist.is_mananger_rank():
-        from meshmode.mesh.generation import generate_regular_rect_mesh
 
-        mesh = generate_regular_rect_mesh(
-            a=(box_ll,) * dim, b=(box_ur,) * dim, n=(npoints_side,) * dim
-        )
+        mesh = grid_generator()
+
         global_nelements = mesh.nelements
 
         part_per_element = get_partition_by_pymetis(mesh, num_parts)

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -24,6 +24,7 @@ THE SOFTWARE.
 import logging
 
 import numpy as np
+from mpi4py import mpi_communicator # noqa
 from meshmode.dof_array import thaw
 from mirgecom.io import make_status_message
 from mirgecom.euler import (

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -158,24 +158,23 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
 
 def create_parallel_grid(comm, generate_grid):
     """
-    Create a grid using the grid generator specified by (generate_grid)
+    Create a grid using the grid generator specified by *generate_grid*,
     partition, and distribute it to every rank in the provided MPI
-    communicator (comm).
+    communicator *comm*.
 
     Parameters
     ----------
     comm:
         MPI communicator over which to partition the grid
-
     generate_grid:
-        Grid generation function should return a :class:meshmode.mesh
+        Callable of zero arguments returning a :class:`meshmode.mesh.Mesh`.
+        Will only be called on one (undetermined) rank.
 
     Returns
     -------
-    local_mesh: :class:meshmode.mesh
-        The local partition of the grid
-
-    global_nelements: int
+    local_mesh : :class:`meshmode.mesh.Mesh`
+        The local partition of the the mesh returned by *generate_grid*.
+    global_nelements : :class:`int`
         The number of elements in the serial grid
     """
     from meshmode.distributed import (

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -40,7 +40,8 @@ building simulation applications.
 .. autofunction:: check_step
 .. autofunction:: inviscid_sim_timestep
 .. autoexception:: ExactSolutionMismatch
-.. autofunction:: exact_sim_checkpoint
+.. autofunction:: sim_checkpoint
+.. autofunction:: create_parallel_box_grid
 """
 
 


### PR DESCRIPTION
* Adds parallel grid generator common to all examples
* Generalizes checkpoint to be used even for sims without exact soln (needed for Y0/Y1 )
* Adds a placeholder for profiling util (also used in Y0/Y1 example)

Note: Y0/Y1 Euler example will follow in a separate PR