### PR TITLE
doc: number sections

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ Table of Contents
 
 .. toctree::
     :maxdepth: 2
+    :numbered:
 
     model
     operators


### PR DESCRIPTION
Makes it easier to refer people to specific parts of the documentation.