### PR TITLE
Trick vortex test case to hand out EOC data

### DIFF
--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -448,7 +448,7 @@ def test_uniform_rhs(actx_factory, dim, order):
     eoc_rec0 = EOCRecorder()
     eoc_rec1 = EOCRecorder()
     # for nel_1d in [4, 8, 12]:
-    for nel_1d in [4, 8]:
+    for nel_1d in [4, 8, 12]:
         from meshmode.mesh.generation import generate_regular_rect_mesh
         mesh = generate_regular_rect_mesh(
             a=(-0.5,) * dim, b=(0.5,) * dim, n=(nel_1d,) * dim
@@ -587,18 +587,20 @@ def test_vortex_rhs(actx_factory, order):
             q=vortex_soln, t=0.0)
 
         err_max = discr.norm(inviscid_rhs, np.inf)
-        eoc_rec.add_data_point(1.0 / nel_1d, err_max)
+        eoc_rec.add_data_point(10.0 / (nel_1d - 1), err_max)
 
     message = (
         f"Error for (dim,order) = ({dim},{order}):\n"
         f"{eoc_rec}"
     )
+    print(message)
     logger.info(message)
 
     assert (
         eoc_rec.order_estimate() >= order - 0.5
         or eoc_rec.max_error() < 1e-11
     )
+    assert(False)
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])


### PR DESCRIPTION
PR for discussion of EOC data from Euler module.  Here's the results of a test of the 2D isentropic vortex case wherein the Euler RHS is checked against the expected (0) for p-order elements:

P = 1
```
Error for (dim,order) = (2,1):
h                   | Error              | Running EOC        
--------------------+--------------------+---------------------
0.6666666666666666  | 1.7441922831117675 |                    
0.3225806451612903  | 1.2752916875582745 | 0.43132757391751286
0.15873015873015872 | 0.7730956445395745 | 0.7058156701834725 
0.0392156862745098   | 0.1999643584725899  | 0.9835017611718138 
0.019569471624266144 | 0.10002099667222199 | 0.9966234897505581 

Overall EOC: 0.8310439764884241
```

P = 2
```
Error for (dim,order) = (2,2):
h                   | Error               | Running EOC       
--------------------+---------------------+--------------------
0.6666666666666666  | 1.5100385589115102  |                   
0.3225806451612903  | 0.6358166704048114  | 1.1915361711120815
0.15873015873015872 | 0.18214371452252343 | 1.762840894708582 
0.0392156862745098   | 0.011578972118560385 | 1.993129088795829 
0.019569471624266144 | 0.002890081385315724 | 1.996682451335228 

Overall EOC: 1.8102480740269564
```

P = 3
```
Error for (dim,order) = (2,3):
h                   | Error                | Running EOC       
--------------------+----------------------+--------------------
0.6666666666666666  | 1.2701267782526717   |                   
0.3225806451612903  | 0.20144842140730326  | 2.5364991945997173
0.15873015873015872 | 0.029276332895191895 | 2.719820456639534 
0.0392156862745098   | 0.0004708729157645916 | 2.9934626226993455
0.019569471624266144 | 5.862347020965949e-05 | 2.997316916791445 

Overall EOC: 2.84291826358655
```

These tests pass due to the line:
```
    assert (
        eoc_rec.order_estimate() >= order - 0.5
        or eoc_rec.max_error() < 1e-11
    )
```
