### PR TITLE
Update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mirgecom
 
-[![CI test](https://github.com/illinois-ceesd/mirgecom/workflows/CI%20test/badge.svg)](https://github.com/illinois-ceesd/mirgecom/actions?query=workflow%3A%22CI+test%22+branch%3Amaster)
+[![CI](https://github.com/illinois-ceesd/mirgecom/workflows/CI/badge.svg)](https://github.com/illinois-ceesd/mirgecom/actions?query=workflow%3ACI+branch%3Amaster)
 [![Documentation Status](https://readthedocs.org/projects/mirgecom/badge/?version=latest)](https://mirgecom.readthedocs.io/en/latest/?badge=latest)
 
 mirgecom aims to be the workhorse simulation library for the


### PR DESCRIPTION
I guess the CI workflow was renamed at some point ("CI test" -> "CI"), but the badge wasn't updated?