### PR TITLE
work around Python 3.9/conda clusterfsck

### DIFF
--- a/.rtd-env-py3.yml
+++ b/.rtd-env-py3.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+- python=3.8
 - mpi4py
 - pip:
   - "git+https://github.com/inducer/pymbolic.git#egg=pymbolic"

--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -10,7 +10,7 @@ dependencies:
 - islpy
 - pyopencl
 - pymetis
-- python=3
+- python=3.8
 - gmsh
 - pip
 - pytest


### PR DESCRIPTION
Python 3.9 seems to have broken many of our installation/readthedocs/CI workflows. As an example, the documentation CI shows:

```
The following packages will be SUPERSEDED by a higher-priority channel:
  pytest             conda-forge/linux-64::pytest-6.1.1-py~ --> conda-forge/noarch::pytest-3.2.2-py_0
```

See also https://github.com/majosm/squirm/commit/ecfb9b48f698dd2ce0fd21e46c3e52ffd9f0b36b