### PR TITLE
Test new DOFArrays

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@ pyvisfile
 pymetis
 
 git+https://github.com/inducer/pymbolic.git#egg=pymbolic
-git+https://github.com/inducer/pyopencl.git#egg=pyopencl
+git+https://github.com/inducer/pyopencl.git@array-distinctive-repr#egg=pyopencl
 git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/dagrt.git#egg=dagrt
 git+https://github.com/inducer/leap.git#egg=leap
 git+https://github.com/inducer/modepy.git#egg=modepy
-git+https://github.com/inducer/meshmode.git#egg=meshmode
+git+https://github.com/inducer/meshmode.git@dofarray-not-ndarray-subclass#egg=meshmode
 git+https://github.com/inducer/grudge.git#egg=grudge
 
 # Toy Fortran parser for Loopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ git+https://github.com/inducer/dagrt.git#egg=dagrt
 git+https://github.com/inducer/leap.git#egg=leap
 git+https://github.com/inducer/modepy.git#egg=modepy
 git+https://github.com/inducer/meshmode.git@dofarray-not-ndarray-subclass#egg=meshmode
-git+https://github.com/inducer/grudge.git#egg=grudge
+git+https://github.com/inducer/grudge.git@dofarray-not-ndarray-subclass#egg=grudge
 
 # Toy Fortran parser for Loopy
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyvisfile
 pymetis
 
 git+https://github.com/inducer/pymbolic.git#egg=pymbolic
-git+https://github.com/inducer/pyopencl.git@array-distinctive-repr#egg=pyopencl
+git+https://github.com/inducer/pyopencl.git#egg=pyopencl
 git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/dagrt.git#egg=dagrt
 git+https://github.com/inducer/leap.git#egg=leap


### PR DESCRIPTION
We'll use this to test mirgecom against new dof arrays in meshmode, pyopencl, et al. @inducer @majosm 

~~To merge:~~
- [ ] https://github.com/inducer/meshmode/pull/77 must have landed
- [ ] https://github.com/inducer/grudge/pull/29 must have landed
- [ ] Point both branches back to `master` in `requirements.txt`