### PR TITLE
Avoid hwloc version conflicts by forcing pocl to load before mpi4py

### DIFF
--- a/mirgecom/mpi.py
+++ b/mirgecom/mpi.py
@@ -50,6 +50,12 @@ def mpi_entry_point(func):
             raise RuntimeError("mpi4py.MPI imported before designated MPI entry "
                         "point. Check for prior imports.")
 
+        # Avoid hwloc version conflicts by forcing pocl to load before mpi4py
+        # (don't ask). See https://github.com/illinois-ceesd/emirge/issues/73
+        # for details.
+        import pyopencl as cl
+        cl.get_platforms()
+
         # Avoid https://github.com/illinois-ceesd/mirgecom/issues/132 on
         # some MPI runtimes.
         import mpi4py

--- a/mirgecom/mpi.py
+++ b/mirgecom/mpi.py
@@ -51,7 +51,7 @@ def mpi_entry_point(func):
                         "point. Check for prior imports.")
 
         # Avoid hwloc version conflicts by forcing pocl to load before mpi4py
-        # (don't ask). See https://github.com/illinois-ceesd/emirge/issues/73
+        # (don't ask). See https://github.com/illinois-ceesd/mirgecom/pull/169
         # for details.
         import pyopencl as cl
         cl.get_platforms()


### PR DESCRIPTION
Fixes https://github.com/illinois-ceesd/emirge/issues/73

Fixes pocl-related crashes of the type:

```
Not enough memory to run on this device.
```

at startup.

These happen only when running with mpi4py, e.g. 

```
$ python wave-eager.py
``` 

works fine with the "wrong" libhwloc version, but

```
$ python -m mpi4py wave-eager-mpi.py
```

does not. 

The reason for the error is that since we are building mpi4py from source against the system MPI and hwloc, but pocl against conda's hwloc, the two hwloc versions might be different (v1 vs. v2). Since libhwloc v1/v2 internally use the same version number, only one version can be loaded at a time, which means that the first package that loads hwloc determines the hwloc version for everyone else. 

This seems to be especially problematic when pocl is built agains hwloc v1, but runs with hwloc v2 (e.g. on dunkel). 

This PR makes sure that we are running with pocl's hwloc version.

Tested on dunkel and lassen.