### PR TITLE
vortex-mpi: Don't run in 3D, fix warning

### DIFF
--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -94,7 +94,7 @@ def main(ctx_factory=cl.create_some_context):
     rank = comm.Get_rank()
 
     if dim != 2:
-        raise RuntimeError("This example must be run with dim = 2.")
+        raise ValueError("This example must be run with dim = 2.")
 
     from meshmode.mesh.generation import generate_regular_rect_mesh
     generate_grid = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -93,6 +93,9 @@ def main(ctx_factory=cl.create_some_context):
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
 
+    if dim != 2:
+        raise RuntimeError("This example must be run with dim = 2.")
+
     from meshmode.mesh.generation import generate_regular_rect_mesh
     generate_grid = partial(generate_regular_rect_mesh, a=(box_ll,) * dim,
                             b=(box_ur,) * dim, n=(nel_1d,) * dim)
@@ -105,8 +108,8 @@ def main(ctx_factory=cl.create_some_context):
     nodes = thaw(actx, discr.nodes())
     current_state = initializer(0, nodes)
 
-    visualizer = make_visualizer(discr, discr.order + 3
-                                 if discr.dim == 2 else discr.order)
+    visualizer = make_visualizer(discr, order + 3 if dim == 2 else order)
+
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,


### PR DESCRIPTION
Background: Running this with `dim=3` just hangs.