### PR TITLE
batch script fixes

### DIFF
--- a/examples/lassen.bsub.sh
+++ b/examples/lassen.bsub.sh
@@ -33,4 +33,6 @@ $jsrun_cmd js_task_info
 
 echo "----------------------------"
 
-$jsrun_cmd python -m mpi4py ./vortex-mpi.py
+# Run application
+# -O: switch on optimizations
+$jsrun_cmd python -O -m mpi4py examples/vortex-mpi.py

--- a/examples/lassen.bsub.sh
+++ b/examples/lassen.bsub.sh
@@ -35,4 +35,4 @@ echo "----------------------------"
 
 # Run application
 # -O: switch on optimizations
-$jsrun_cmd python -O -m mpi4py examples/vortex-mpi.py
+$jsrun_cmd python -O -m mpi4py ./vortex-mpi.py

--- a/examples/lassen.bsub.sh
+++ b/examples/lassen.bsub.sh
@@ -9,16 +9,28 @@
 # source ../../config/activate_env.sh
 
 # OpenCL device selection:
-# export PYOPENCL_CTX="port:tesla"    # Run on Nvidia GPU with pocl
+export PYOPENCL_CTX="port:tesla"      # Run on Nvidia GPU with pocl
 # export PYOPENCL_CTX="port:pthread"  # Run on CPU with pocl
 
 nnodes=$(echo $LSB_MCPU_HOSTS | wc -w)
 nnodes=$((nnodes/2-1))
 nproc=$((4*nnodes)) # 4 ranks per node, 1 per GPU
 
+echo nnodes=$nnodes nproc=$nproc
+
+# -a 1: 1 task per resource set
+# -g 1: 1 GPU per resource set
+# -n $nproc: $nproc resource sets
+jsrun_cmd="jsrun -g 1 -a 1 -n $nproc"
+
 # See
 # https://mirgecom.readthedocs.io/en/latest/running.html#avoiding-overheads-due-to-caching-of-kernels
 # on why this is important
 export XDG_CACHE_HOME="/tmp/$USER/xdg-scratch"
 
-lrun -g 1 -n $nproc python -m mpi4py ./vortex-mpi.py
+# Print task allocation
+$jsrun_cmd js_task_info
+
+echo "----------------------------"
+
+$jsrun_cmd python -m mpi4py ./vortex-mpi.py

--- a/examples/quartz.sbatch.sh
+++ b/examples/quartz.sbatch.sh
@@ -14,6 +14,8 @@
 nnodes=$SLURM_JOB_NUM_NODES
 nproc=$nnodes # 1 rank per node
 
+echo nnodes=$nnodes nproc=$nproc
+
 # See
 # https://mirgecom.readthedocs.io/en/latest/running.html#avoiding-overheads-due-to-caching-of-kernels
 # on why this is important

--- a/examples/quartz.sbatch.sh
+++ b/examples/quartz.sbatch.sh
@@ -21,4 +21,6 @@ echo nnodes=$nnodes nproc=$nproc
 # on why this is important
 export XDG_CACHE_HOME="/tmp/$USER/xdg-scratch"
 
-srun -n $nproc python -m mpi4py ./vortex-mpi.py
+# Run application
+# -O: switch on optimizations
+srun -n $nproc python -O -m mpi4py ./vortex-mpi.py


### PR DESCRIPTION
Lassen+Quartz:
- Print nnodes/nproc to aid in reproducing runs
- add -O option to Python command line (Fixes #195)

Lassen:
- Use jsrun instead of lrun
- Use GPU by default
- Print task allocation to aid in checking that it is doing what we expect