### PR TITLE
Doc for flux shapes

### DIFF
--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -199,12 +199,12 @@ def inviscid_flux(discr, eos, q):
     $(\rho\vec{V},(\rho{E}+p)\vec{V},\rho(\vec{V}\otimes\vec{V})
     +p\mathbf{I}, \rho{Y_s}\vec{V})$
 
-    The fluxes are returned as 2D object array with shape:
-    np.ndarray.shape = (num_equations, ndim).  Each entry in the
+    The fluxes are returned as a 2D object array with shape:
+    ``(num_equations, ndim)``.  Each entry in the
     flux array is a :class:`~meshmode.dof_array.DOFArray`.  This
     form and shape for the flux data is required by the built-in
     state data handling mechanism in :mod:`mirgecom.euler`. That
-    mechanism includes at least
+    mechanism is used by at least
     :class:`mirgecom.euler.ConservedVars`, and
     :func:`mirgecom.euler.join_conserved`, and
     :func:`mirgecom.euler.split_conserved`.

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -202,8 +202,12 @@ def inviscid_flux(discr, eos, q):
     The fluxes are returned as 2D object array with shape:
     np.ndarray.shape = (num_equations, ndim).  Each entry in the
     flux array is a :class:`~meshmode.dof_array.DOFArray`.  This
-    form and shape for the flux data is required by
-    :mod:`mirgecom.euler`.
+    form and shape for the flux data is required by the built-in
+    state data handling mechanism in :mod:`mirgecom.euler`. That
+    mechanism includes the dataclass
+    :class:`mirgecom.euler.ConservedVars`, and module methods
+    :meth:`mirgecom.euler.join_conserved`, and
+    :meth:`mirgecom.euler.split_conserved`.
     """
     dim = discr.dim
     cv = split_conserved(dim, q)

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -204,10 +204,10 @@ def inviscid_flux(discr, eos, q):
     flux array is a :class:`~meshmode.dof_array.DOFArray`.  This
     form and shape for the flux data is required by the built-in
     state data handling mechanism in :mod:`mirgecom.euler`. That
-    mechanism includes the dataclass
-    :class:`mirgecom.euler.ConservedVars`, and module methods
-    :meth:`mirgecom.euler.join_conserved`, and
-    :meth:`mirgecom.euler.split_conserved`.
+    mechanism includes at least
+    :class:`mirgecom.euler.ConservedVars`, and
+    :func:`mirgecom.euler.join_conserved`, and
+    :func:`mirgecom.euler.split_conserved`.
     """
     dim = discr.dim
     cv = split_conserved(dim, q)

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -198,6 +198,12 @@ def inviscid_flux(discr, eos, q):
     The inviscid fluxes are
     $(\rho\vec{V},(\rho{E}+p)\vec{V},\rho(\vec{V}\otimes\vec{V})
     +p\mathbf{I}, \rho{Y_s}\vec{V})$
+
+    The fluxes are returned as 2D object array with shape:
+    np.ndarray.shape = (num_equations, ndim).  Each entry in the
+    flux array is a :class:`~meshmode.dof_array.DOFArray`.  This
+    form and shape for the flux data is required by
+    :mod:`mirgecom.euler`.
     """
     dim = discr.dim
     cv = split_conserved(dim, q)


### PR DESCRIPTION
This is an attempt to add some documentation for the expected shape for the flux data.  As fluxes are typically internal-only data, folks adding new capabilities (e.g. new numerical flux routines) will need to know the expected shape of the arrays.

It is easy to run afoul of the expectation.  Here's an example of that from @w-hagen:
```
vol_flux = inviscid_flux(discr, eos, q)
    print(vol_flux.shape)
    print(vol_flux[0].shape)
```
> returns (4,2), (2,) not (4,), (2,) like my arrays do