### PR TITLE
Remove source term documentation in Euler

### DIFF
--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -220,7 +220,7 @@ def inviscid_flux(discr, eos, q):
     return join_conserved(dim,
             mass=mom,
             energy=mom * (cv.energy + p) / cv.mass,
-            momentum=np.outer(mom, mom) / cv.mass + np.eye(dim) * p,
+            momentum=np.outer(mom, mom) / cv.mass + np.eye(dim)*p,
             species_mass=(  # reshaped: (nspecies, dim)
                 (mom / cv.mass) * cv.species_mass.reshape(-1, 1)))
 
@@ -286,7 +286,7 @@ def inviscid_operator(discr, eos, boundaries, q, t=0.0):
 
         .. math::
 
-            \dot{\mathbf{q}} = \mathbf{S} - \nabla\cdot\mathbf{F} +
+            \dot{\mathbf{q}} = - \nabla\cdot\mathbf{F} +
                 (\mathbf{F}\cdot\hat{n})_{\partial\Omega}
 
     Parameters
@@ -342,7 +342,8 @@ def inviscid_operator(discr, eos, boundaries, q, t=0.0):
 
     return discr.inverse_mass(
         dflux - discr.face_mass(interior_face_flux + domain_boundary_flux
-                                + partition_boundary_flux))
+                                + partition_boundary_flux)
+    )
 
 
 def get_inviscid_cfl(discr, eos, dt, q):

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -5,7 +5,7 @@ Euler's equations of gas dynamics:
 .. math::
 
     \partial_t \mathbf{Q} = -\nabla\cdot{\mathbf{F}} +
-    (\mathbf{F}\cdot\hat{n})_{\partial\Omega} + \mathbf{S}
+    (\mathbf{F}\cdot\hat{n})_{\partial\Omega}
 
 where:
 
@@ -13,7 +13,6 @@ where:
 -  flux $\mathbf{F} = [\rho\vec{V},(\rho{E} + p)\vec{V},
    (\rho(\vec{V}\otimes\vec{V}) + p*\mathbf{I}), \rho{Y}_\alpha\vec{V}]$,
 -  unit normal $\hat{n}$ to the domain boundary $\partial\Omega$,
--  sources $\mathbf{S} = [{s}_\rho, {s}_e, \mathbf{s}_p, \mathbf{s}_s]$
 -  vector of species mass fractions ${Y}_\alpha$,
    with $1\le\alpha\le\mathtt{nspecies}$.
 
@@ -277,7 +276,7 @@ def _facial_flux(discr, eos, q_tpair, local=False):
     return flux_weak
 
 
-def inviscid_operator(discr, eos, boundaries, q, t=0.0, sources=None):
+def inviscid_operator(discr, eos, boundaries, q, t=0.0):
     r"""Compute RHS of the Euler flow equations.
 
     Returns
@@ -308,9 +307,6 @@ def inviscid_operator(discr, eos, boundaries, q, t=0.0, sources=None):
     eos: mirgecom.eos.GasEOS
         Implementing the pressure and temperature functions for
         returning pressure and temperature as a function of the state q.
-
-    sources
-        Dictionary of source functions, one for each source
 
     Returns
     -------
@@ -344,13 +340,9 @@ def inviscid_operator(discr, eos, boundaries, q, t=0.0, sources=None):
         for part_pair in cross_rank_trace_pairs(discr, q)
     )
 
-    source_terms = 0
-    if sources is not None:
-        source_terms = sum(source(discr, q=q, eos=eos) for source in sources)
-
     return discr.inverse_mass(
         dflux - discr.face_mass(interior_face_flux + domain_boundary_flux
-                                + partition_boundary_flux)) + source_terms
+                                + partition_boundary_flux))
 
 
 def get_inviscid_cfl(discr, eos, dt, q):


### PR DESCRIPTION
This just removes the documentation of sources from Euler, per the plan to leave source terms up to the user.