### PR TITLE
Mark tests needing Octave

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    octave: test requires Octave

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -328,6 +328,7 @@ def test_diffusion_accuracy(actx_factory, problem, nsteps, dt, scales, order,
     [
         get_decaying_trig(1, 1.)
     ])
+@pytest.mark.octave
 def test_diffusion_compare_to_nodal_dg(actx_factory, problem, order,
             print_err=False):
     """Compares diffusion operator to Hesthaven/Warburton Nodal-DG code."""


### PR DESCRIPTION
This is to help https://github.com/inducer/meshmode/pull/114 avoid having to (somewhat pointlessly) run Octave tests.