### PR TITLE
remove gmsh from conda

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -16,6 +16,5 @@ dependencies:
 - pyopencl
 - pymetis
 - python=3.8
-- gmsh
 - pip
 - pytest


### PR DESCRIPTION
background: the gmsh package doesn't exist for power9, so installs on Lassen fail at the moment. If we need the package for CI in the future, it should probably be installed in the CI scripts.