### PR TITLE
Add the 14-stage, 4th order LSRK method of Niegemann, Diehl, and Busch (2012)

### DIFF
--- a/doc/misc.rst
+++ b/doc/misc.rst
@@ -59,3 +59,5 @@ References
     `DOI <https://doi.org/10.1016/S0021-9991(03)00206-7>`__
 .. [Poinsot_1992] Poinsot and Lele (1992), Journal of Computational Physics 101 \
    `PDF <https://doi.org/10.1016/0021-9991(92)90046-2>`__
+.. [Niegemann_2012] J. Niegemann, R. Diehl, K. Busch (2012), Journal of Computational Physics 231 \
+    `DOI: <https://doi.org/10.1016/j.jcp.2011.09.003>`__

--- a/mirgecom/butcher_tableau.py
+++ b/mirgecom/butcher_tableau.py
@@ -1,0 +1,110 @@
+"""Butcher tableau for Runge-Kutta timestepping methods.
+"""
+
+__copyright__ = """
+Copyright (C) 2020 University of Illinois Board of Trustees
+"""
+
+__author__ = """
+Center for Exascale-Enabled Scramjet Design
+University of Illinois, Urbana, IL 61801
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+
+__all__ = ("_LSRK4_A", "_LSRK4_B", "_LSRK4_C",
+           "_LSRK144_A", "_LSRK144_B", "_LSRK144_C")
+
+# Butcher table for the Kennedy-Carpenter explicit 5-stage, 4th order,
+# low-storage Runge-Kutta method
+_LSRK4_A = np.array([
+    0.,
+    -567301805773/1357537059087,
+    -2404267990393/2016746695238,
+    -3550918686646/2091501179385,
+    -1275806237668/842570457699])
+
+_LSRK4_B = np.array([
+    1432997174477/9575080441755,
+    5161836677717/13612068292357,
+    1720146321549/2090206949498,
+    3134564353537/4481467310338,
+    2277821191437/14882151754819])
+
+_LSRK4_C = np.array([
+    0.,
+    1432997174477/9575080441755,
+    2526269341429/6820363962896,
+    2006345519317/3224310063776,
+    2802321613138/2924317926251])
+
+# Butcher table for the explicit 14-stage, 4th order,
+# low-storage Runge-Kutta method of Niegemann, Diehl, and Busch (2012)
+# with an optimized stability region
+_LSRK144_A = np.array([
+    0.,
+    -0.7188012108672410,
+    -0.7785331173421570,
+    -0.0053282796654044,
+    -0.8552979934029281,
+    -3.9564138245774565,
+    -1.5780575380587385,
+    -2.0837094552574054,
+    -0.7483334182761610,
+    -0.7032861106563359,
+    0.0013917096117681,
+    -0.0932075369637460,
+    -0.9514200470875948,
+    -7.1151571693922548])
+
+_LSRK144_B = np.array([
+    0.0367762454319673,
+    0.3136296607553959,
+    0.1531848691869027,
+    0.0030097086818182,
+    0.3326293790646110,
+    0.2440251405350864,
+    0.3718879239592277,
+    0.6204126221582444,
+    0.1524043173028741,
+    0.0760894927419266,
+    0.0077604214040978,
+    0.0024647284755382,
+    0.0780348340049386,
+    5.5059777270269628])
+
+_LSRK144_C = np.array([
+    0.,
+    0.0367762454319673,
+    0.1249685262725025,
+    0.2446177702277698,
+    0.2476149531070420,
+    0.2969311120382472,
+    0.3978149645802642,
+    0.5270854589440328,
+    0.6981269994175695,
+    0.8190890835352128,
+    0.8527059887098624,
+    0.8604711817462826,
+    0.8627060376969976,
+    0.8734213127600976])

--- a/mirgecom/butcher_tableau.py
+++ b/mirgecom/butcher_tableau.py
@@ -1,5 +1,4 @@
-"""Butcher tableau for Runge-Kutta timestepping methods.
-"""
+"""Butcher tableau for Runge-Kutta timestepping methods."""
 
 __copyright__ = """
 Copyright (C) 2020 University of Illinois Board of Trustees
@@ -31,9 +30,6 @@ THE SOFTWARE.
 """
 
 import numpy as np
-
-__all__ = ("_LSRK4_A", "_LSRK4_B", "_LSRK4_C",
-           "_LSRK144_A", "_LSRK144_B", "_LSRK144_C")
 
 # Butcher table for the Kennedy-Carpenter explicit 5-stage, 4th order,
 # low-storage Runge-Kutta method

--- a/mirgecom/integrators.py
+++ b/mirgecom/integrators.py
@@ -37,7 +37,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from mirgecom.butcher_tableau import *
+import mirgecom.butcher_tableau as bt
+
 
 def rk4_step(state, t, dt, rhs):
     """Take one step using 4th order Runge-Kutta."""
@@ -58,22 +59,25 @@ def lsrk4_step(state, t, dt, rhs):
     k = p * 0.
 
     for i in range(5):
-        k = _LSRK4_A[i]*k + dt*rhs(t + _LSRK4_C[i]*dt, p)
-        p = p + _LSRK4_B[i]*k
+        k = bt._LSRK4_A[i]*k + dt*rhs(t + bt._LSRK4_C[i]*dt, p)
+        p = p + bt._LSRK4_B[i]*k
 
     return p
 
+
 def lsrk144_step(state, t, dt, rhs):
     """
-    Take one step using Carpenter-Kennedy low storage 14-stage, 4th order
-    Runge-Kutta method of Niegemann, Diehl, and Busch (2012).
+    Take one step using the low storage 14-stage 4th order Runge-Kutta method.
+
+    LSRK coefficients are summarized in Table 3 of Niegemann, Diehl, and
+    Busch (2012): https://doi.org/10.1016/j.jcp.2011.09.003.
     """
     p = state
     k = p * 0.
 
     for i in range(14):
-        k = _LSRK144_A[i]*k + dt*rhs(t + _LSRK144_C[i]*dt, p)
-        p = p + _LSRK144_B[i]*k
+        k = bt._LSRK144_A[i]*k + dt*rhs(t + bt._LSRK144_C[i]*dt, p)
+        p = p + bt._LSRK144_B[i]*k
 
     return p
 

--- a/mirgecom/integrators.py
+++ b/mirgecom/integrators.py
@@ -4,6 +4,7 @@ Time integrators
 ^^^^^^^^^^^^^^^^
 .. autofunction:: rk4_step
 .. autofunction:: lsrk4_step
+.. autofunction:: lsrk144_step
 .. autofunction:: euler_step
 """
 
@@ -36,29 +37,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
-
-_LSRK4_A = np.array([
-    0.,
-    -567301805773/1357537059087,
-    -2404267990393/2016746695238,
-    -3550918686646/2091501179385,
-    -1275806237668/842570457699])
-
-_LSRK4_B = np.array([
-    1432997174477/9575080441755,
-    5161836677717/13612068292357,
-    1720146321549/2090206949498,
-    3134564353537/4481467310338,
-    2277821191437/14882151754819])
-
-_LSRK4_C = np.array([
-    0.,
-    1432997174477/9575080441755,
-    2526269341429/6820363962896,
-    2006345519317/3224310063776,
-    2802321613138/2924317926251])
-
+from mirgecom.butcher_tableau import *
 
 def rk4_step(state, t, dt, rhs):
     """Take one step using 4th order Runge-Kutta."""
@@ -81,6 +60,20 @@ def lsrk4_step(state, t, dt, rhs):
     for i in range(5):
         k = _LSRK4_A[i]*k + dt*rhs(t + _LSRK4_C[i]*dt, p)
         p = p + _LSRK4_B[i]*k
+
+    return p
+
+def lsrk144_step(state, t, dt, rhs):
+    """
+    Take one step using Carpenter-Kennedy low storage 14-stage, 4th order
+    Runge-Kutta method of Niegemann, Diehl, and Busch (2012).
+    """
+    p = state
+    k = p * 0.
+
+    for i in range(14):
+        k = _LSRK144_A[i]*k + dt*rhs(t + _LSRK144_C[i]*dt, p)
+        p = p + _LSRK144_B[i]*k
 
     return p
 

--- a/mirgecom/integrators.py
+++ b/mirgecom/integrators.py
@@ -69,8 +69,7 @@ def lsrk144_step(state, t, dt, rhs):
     """
     Take one step using the low storage 14-stage 4th order Runge-Kutta method.
 
-    LSRK coefficients are summarized in Table 3 of Niegemann, Diehl, and
-    Busch (2012): https://doi.org/10.1016/j.jcp.2011.09.003.
+    LSRK coefficients are summarized in [Niegemann_2012]_, Table 3.
     """
     p = state
     k = p * 0.

--- a/test/test_time_integrators.py
+++ b/test/test_time_integrators.py
@@ -28,7 +28,7 @@ import numpy as np
 import logging
 import pytest
 
-from mirgecom.integrators import rk4_step, lsrk4_step, euler_step
+from mirgecom.integrators import rk4_step, lsrk4_step, lsrk144_step, euler_step
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize(("integrator", "method_order"),
                          [(rk4_step, 4),
                           (lsrk4_step, 4),
+                          (lsrk144_step, 4),
                           (euler_step, 1)])
 def test_integration_order(integrator, method_order):
     """Test that time integrators have correct order."""


### PR DESCRIPTION
Howdy!

I've just installed mirgecom and noticed ya'll have the LSRK 5-stage, 4th order method by Kennedy and Carpenter, so I thought I'd add another LSRK method. The method I have added is a 14-stage, 4th order method summarized in the following paper (Table 3): https://www.sciencedirect.com/science/article/pii/S0021999111005213?via%3Dihub

It possesses an optimized stability region for advection-dominated flows, and is capable of taking much larger time-steps than the RK4 or LSRK4 methods. I've seen nice results in terms of time-to-solution using this 14-stage method in other DG codes I have experimented with, and I thought I would add this to mirgecom too. This hopefully can help speed up the time-to-solution for people running tests and simulations.

As a quick example, I ran the `examples/wave-eager.py` example in 2D, and the 14-stage method can take a larger timestep (6 times larger) than the 5-stage 4th order method. I also rearranged some of the code a bit to perhaps make it a bit neater/organized!