### PR TITLE
Add logpyle to development packages.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ numpy
 pytest
 pyvisfile
 pymetis
-logpyle
 importlib-resources
 psutil
 
@@ -18,6 +17,7 @@ psutil
 --editable git+https://github.com/inducer/meshmode.git#egg=meshmode
 --editable git+https://github.com/inducer/grudge.git#egg=grudge
 --editable git+https://github.com/inducer/pytato.git#egg=pytato
+--editable git+https://github.com/inducer/logpyle.git#egg=logpyle
 
 # Toy Fortran parser for Loopy
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ psutil
 --editable git+https://github.com/inducer/meshmode.git#egg=meshmode
 --editable git+https://github.com/inducer/grudge.git#egg=grudge
 --editable git+https://github.com/inducer/pytato.git#egg=pytato
---editable git+https://github.com/inducer/logpyle.git#egg=logpyle
+--editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle
 
 # Toy Fortran parser for Loopy
 #


### PR DESCRIPTION
Add _logpyle_ to development packages so that we can pick up current performance logging features when we perform automated build-and-test (e.g. enabling https://github.com/illinois-ceesd/timing/issues/1 in https://github.com/illinois-ceesd/timing/pull/2)