### PR TITLE
Add backwards-compatible API for LSRK4.

### DIFF
--- a/mirgecom/integrators/__init__.py
+++ b/mirgecom/integrators/__init__.py
@@ -31,3 +31,11 @@ __doc__ = """
 .. automodule:: mirgecom.integrators.explicit_rk
 .. automodule:: mirgecom.integrators.lsrk
 """
+
+
+def lsrk4_step(state, t, dt, rhs):
+    """Call lsrk54_step with backwards-compatible interface."""
+    from warnings import warn
+    warn("Do not call lsrk4; it is now callled lsrk54_step. This function will "
+         "disappear August 1, 2021", DeprecationWarning, stacklevel=2)
+    return lsrk54_step(state, t, dt, rhs)

--- a/mirgecom/integrators/lsrk.py
+++ b/mirgecom/integrators/lsrk.py
@@ -34,6 +34,13 @@ from dataclasses import dataclass
 import numpy as np
 
 
+def lsrk4_step(state, t, dt, rhs):
+    from warnings import warn
+    warn("Do not call lsrk4; it is now callled lsrk54_step. This function will "
+         "disappear April 1, 2021", DeprecationWarning, stacklevel=2)
+    return lsrk54_step(state, t, dt, rhs)
+
+
 @dataclass(frozen=True)
 class LSRKCoefficients:
     """Dataclass which defines a given low-storage Runge-Kutta (LSRK) scheme.

--- a/mirgecom/integrators/lsrk.py
+++ b/mirgecom/integrators/lsrk.py
@@ -35,6 +35,7 @@ import numpy as np
 
 
 def lsrk4_step(state, t, dt, rhs):
+    """Call lsrk54_step with backwards-compatible interface."""
     from warnings import warn
     warn("Do not call lsrk4; it is now callled lsrk54_step. This function will "
          "disappear April 1, 2021", DeprecationWarning, stacklevel=2)

--- a/mirgecom/integrators/lsrk.py
+++ b/mirgecom/integrators/lsrk.py
@@ -34,14 +34,6 @@ from dataclasses import dataclass
 import numpy as np
 
 
-def lsrk4_step(state, t, dt, rhs):
-    """Call lsrk54_step with backwards-compatible interface."""
-    from warnings import warn
-    warn("Do not call lsrk4; it is now callled lsrk54_step. This function will "
-         "disappear April 1, 2021", DeprecationWarning, stacklevel=2)
-    return lsrk54_step(state, t, dt, rhs)
-
-
 @dataclass(frozen=True)
 class LSRKCoefficients:
     """Dataclass which defines a given low-storage Runge-Kutta (LSRK) scheme.


### PR DESCRIPTION
Function rename for LSRK4 caused outstanding drivers using it to fail.  This patch brings back a backwards-compatible interface with a warning. cc @thomasgibson @anderson2981 