### PR TITLE
Flake8 ignore emacs temporary backup and hidden files.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 ignore = E127,E128,E123,E226,E241,W503
+exclude = .*,\#*
 max-line-length=85
 
 inline-quotes = "


### PR DESCRIPTION
flake8 finding these files are quite annoying with pre-commit hooks enabled.