### PR TITLE
Remove importing `grudge.dof_desc` objects from `grudge.symbolic.primitives`

### DIFF
--- a/examples/heat-source-mpi.py
+++ b/examples/heat-source-mpi.py
@@ -33,7 +33,7 @@ from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from grudge.eager import EagerDGDiscretization
 from grudge import sym as grudge_sym
 from grudge.shortcuts import make_visualizer
-from grudge.symbolic.primitives import QTAG_NONE
+from grudge.dof_desc import QTAG_NONE
 from mirgecom.integrators import rk4_step
 from mirgecom.diffusion import (
     diffusion_operator,

--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -38,9 +38,9 @@ import numpy.linalg as la  # noqa
 from pytools.obj_array import make_obj_array, obj_array_vectorize_n_args
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from meshmode.dof_array import thaw
-from grudge.symbolic.primitives import DOFDesc
+from grudge.dof_desc import DOFDesc, as_dofdesc
 from grudge.eager import interior_trace_pair, cross_rank_trace_pairs
-from grudge.symbolic.primitives import TracePair, as_dofdesc
+from grudge.symbolic.primitives import TracePair
 
 
 def gradient_flux(discr, quad_tag, u_tpair):

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -32,8 +32,7 @@ from mirgecom.diffusion import (
     DirichletDiffusionBoundary,
     NeumannDiffusionBoundary)
 from meshmode.dof_array import thaw, DOFArray
-from grudge.symbolic import DTAG_BOUNDARY
-from grudge.symbolic.primitives import QTAG_NONE
+from grudge.dof_desc import DTAG_BOUNDARY, QTAG_NONE
 
 from meshmode.array_context import (  # noqa
     pytest_generate_tests_for_pyopencl_array_context


### PR DESCRIPTION
Importing objects like `QTAG_NONE`, `DOFDesc`, `as_dofdesc` and others should now be imported directly from `grudge.dof_desc` (see https://github.com/inducer/grudge/pull/75)