### PR TITLE
Add array context retriever function

### DIFF
--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -41,11 +41,12 @@ from meshmode.dof_array import thaw
 from grudge.dof_desc import DOFDesc, as_dofdesc
 from grudge.eager import interior_trace_pair, cross_rank_trace_pairs
 from grudge.symbolic.primitives import TracePair
+from mirgecom.utils import get_actx
 
 
 def gradient_flux(discr, quad_tag, u_tpair):
     r"""Compute the numerical flux for $\nabla u$."""
-    actx = u_tpair.int.array_context
+    actx = get_actx(u_tpair)
 
     dd = u_tpair.dd
     dd_quad = dd.with_qtag(quad_tag)
@@ -65,7 +66,7 @@ def gradient_flux(discr, quad_tag, u_tpair):
 
 def diffusion_flux(discr, quad_tag, alpha_tpair, grad_u_tpair):
     r"""Compute the numerical flux for $\nabla \cdot (\alpha \nabla u)$."""
-    actx = grad_u_tpair.int[0].array_context
+    actx = get_actx(grad_u_tpair)
 
     dd = grad_u_tpair.dd
     dd_quad = dd.with_qtag(quad_tag)

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -68,6 +68,7 @@ from mirgecom.inviscid import (
 )
 from functools import partial
 from mirgecom.flux import lfr_flux
+from mirgecom.utils import get_actx
 
 
 def _facial_flux(discr, eos, q_tpair, local=False):
@@ -88,7 +89,7 @@ def _facial_flux(discr, eos, q_tpair, local=False):
         "all_faces."  If set to *True*, the returned fluxes are not projected to
         "all_faces"; remaining instead on the boundary restriction.
     """
-    actx = q_tpair[0].int.array_context
+    actx = get_actx(q_tpair)
     dim = discr.dim
 
     euler_flux = partial(inviscid_flux, discr, eos)

--- a/mirgecom/utils.py
+++ b/mirgecom/utils.py
@@ -113,3 +113,35 @@ class StatisticsAccumulator:
             return None
 
         return self._min * self.scale_factor
+
+
+def get_actx(obj):
+    """
+    Retrieve an array context from an object.
+
+    Parameters
+    ----------
+    obj:
+        The object that has an associated array context. Must be either a
+        :class:`~meshmode.dof_array.DOFArray` or an object that contains one.
+        Supported containing types are:
+            1) :class:`~numpy.ndarray`
+            2) :class:`~grudge.symbolic.primitives.TracePair`.
+
+    Returns
+    -------
+    array_context:
+        The associated array context.
+    """
+    import numpy as np
+    from meshmode.dof_array import DOFArray
+    from grudge.symbolic.primitives import TracePair
+
+    if isinstance(obj, TracePair):
+        return get_actx(obj.int)
+    if isinstance(obj, np.ndarray):
+        return get_actx(obj[0])
+    elif isinstance(obj, DOFArray):
+        return obj.array_context
+    else:
+        raise ValueError("Unrecognized type; can't retrieve array context.")


### PR DESCRIPTION
Adds a universal-ish array context retrieval function to avoid having to do gymnastics like [this]( https://github.com/illinois-ceesd/mirgecom/blob/ea3dc359abbd2e8f852b4f60ff4a77dbec3e0ac2/mirgecom/artificial_viscosity.py#L126-L130).