### PR TITLE
Rearrange the boundary calls to match upcoming Navier-Stokes boundaries.

### DIFF
--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -38,6 +38,7 @@ from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 # from mirgecom.eos import IdealSingleGas
 from grudge.symbolic.primitives import TracePair
 from mirgecom.fluid import split_conserved, join_conserved
+from mirgecom.inviscid import inviscid_facial_flux
 
 
 class PrescribedBoundary:
@@ -70,6 +71,11 @@ class PrescribedBoundary:
         int_soln = discr.project("vol", btag, q)
         return TracePair(btag, interior=int_soln, exterior=ext_soln)
 
+    def get_inviscid_flux(self, discr, btag, q, eos, **kwargs):
+        """Get the inviscid flux across the boundary faces."""
+        bnd_tpair = self.boundary_pair(discr, q, btag, eos=eos, **kwargs)
+        return inviscid_facial_flux(discr, eos=eos, q_tpair=bnd_tpair)
+
 
 class DummyBoundary:
     """Boundary condition that assigns boundary-adjacent soln as the boundary solution.
@@ -81,6 +87,11 @@ class DummyBoundary:
         """Get the interior and exterior solution on the boundary."""
         dir_soln = discr.project("vol", btag, q)
         return TracePair(btag, interior=dir_soln, exterior=dir_soln)
+
+    def get_inviscid_flux(self, discr, btag, q, eos, **kwargs):
+        """Get the inviscid flux across the boundary faces."""
+        bnd_tpair = self.boundary_pair(discr, q, btag, eos=eos, **kwargs)
+        return inviscid_facial_flux(discr, eos=eos, q_tpair=bnd_tpair)
 
 
 class AdiabaticSlipBoundary:
@@ -139,3 +150,8 @@ class AdiabaticSlipBoundary:
                                     species_mass=int_cv.species_mass)
 
         return TracePair(btag, interior=int_soln, exterior=bndry_soln)
+
+    def get_inviscid_flux(self, discr, btag, q, eos, **kwargs):
+        """Get the inviscid flux across the boundary faces."""
+        bnd_tpair = self.boundary_pair(discr, q, btag, eos=eos, **kwargs)
+        return inviscid_facial_flux(discr, eos=eos, q_tpair=bnd_tpair)

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -116,7 +116,7 @@ def euler_operator(discr, eos, boundaries, q, t=0.0):
 
     # Domain boundaries
     domain_boundary_flux = sum(
-        boundaries[btag].get_inviscid_flux(discr, btag, eos=eos, q=q)
+        boundaries[btag].inviscid_boundary_flux(discr, btag, eos=eos, q=q)
         for btag in boundaries
     )
 

--- a/mirgecom/initializers.py
+++ b/mirgecom/initializers.py
@@ -130,7 +130,7 @@ class Vortex2D:
         self._center = np.array(center)
         self._velocity = np.array(velocity)
 
-    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas()):
+    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas(), **kwargs):
         """
         Create the isentropic vortex solution at time *t* at locations *x_vec*.
 
@@ -223,7 +223,7 @@ class SodShock1D:
         if self._xdir >= self._dim:
             self._xdir = self._dim - 1
 
-    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas()):
+    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas(), **kwargs):
         """
         Create the 1D Sod's shock solution at locations *x_vec*.
 
@@ -328,7 +328,7 @@ class Lump:
         self._rho0 = rho0
         self._rhoamp = rhoamp
 
-    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas()):
+    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas(), **kwargs):
         """
         Create the lump-of-mass solution at time *t* and locations *x_vec*.
 
@@ -498,7 +498,7 @@ class MulticomponentLump:
         self._spec_centers = spec_centers
         self._spec_amplitudes = spec_amplitudes
 
-    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas()):
+    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas(), **kwargs):
         """
         Create a multi-component lump solution at time *t* and locations *x_vec*.
 
@@ -629,7 +629,7 @@ class AcousticPulse:
         self._width = width
         self._dim = dim
 
-    def __call__(self, x_vec, q, eos=IdealSingleGas()):
+    def __call__(self, x_vec, q, eos=IdealSingleGas(), **kwargs):
         """
         Create the acoustic pulse at locations *x_vec*.
 
@@ -712,7 +712,7 @@ class Uniform:
         self._e = e
         self._dim = dim
 
-    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas()):
+    def __call__(self, x_vec, *, t=0, eos=IdealSingleGas(), **kwargs):
         """
         Create a uniform flow solution at locations *x_vec*.
 
@@ -804,7 +804,7 @@ class MixtureInitializer:
         self._temperature = temperature
         self._massfracs = massfractions
 
-    def __call__(self, x_vec, eos, *, t=0.0):
+    def __call__(self, x_vec, eos, *, t=0.0, **kwargs):
         """
         Create the mixture state at locations *x_vec* (t is ignored).
 

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -163,9 +163,9 @@ def test_slipwall_flux(actx_factory, dim, order):
                 acv = split_conserved(dim, avg_state)
                 err_max = max(err_max, bnd_norm(np.dot(acv.momentum, nhat)))
 
-                from mirgecom.euler import _facial_flux
-                bnd_flux = split_conserved(dim, _facial_flux(discr, eos,
-                                                             bnd_pair, local=True))
+                from mirgecom.euler import inviscid_facial_flux
+                bnd_flux = split_conserved(dim, inviscid_facial_flux(
+                    discr, eos, bnd_pair, local=True))
                 err_max = max(err_max, bnd_norm(bnd_flux.mass),
                               bnd_norm(bnd_flux.energy))
 

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -344,9 +344,9 @@ def test_facial_flux(actx_factory, nspecies, order, dim):
             dim, mass=mass_input, energy=energy_input, momentum=mom_input,
             species_mass=species_mass_input)
 
-        from mirgecom.euler import _facial_flux
+        from mirgecom.euler import inviscid_facial_flux
 
-        interior_face_flux = _facial_flux(
+        interior_face_flux = inviscid_facial_flux(
             discr, eos=IdealSingleGas(), q_tpair=interior_trace_pair(discr, fields))
 
         def inf_norm(data):
@@ -387,7 +387,7 @@ def test_facial_flux(actx_factory, nspecies, order, dim):
         dir_bc = join_conserved(dim, mass=dir_mass, energy=dir_e, momentum=dir_mom,
                                 species_mass=dir_mf)
 
-        boundary_flux = _facial_flux(
+        boundary_flux = inviscid_facial_flux(
             discr, eos=IdealSingleGas(),
             q_tpair=TracePair(BTAG_ALL, interior=dir_bval, exterior=dir_bc)
         )


### PR DESCRIPTION
This is a picked-apart refactor of boundary treatments to match development coming down from NS. The intent is to unify the fluid-specific boundary treatments between Euler, Navier-Stokes, and artificial viscosity (if used with with a fluid).