### PR TITLE
Add forward-looking dependency on arraycontext

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,6 +78,7 @@ intersphinx_mapping = {
     "https://numpy.org/doc/stable/": None,
     "https://documen.tician.de/pyopencl/": None,
     "https://documen.tician.de/modepy/": None,
+    "https://documen.tician.de/arraycontext/": None,
     "https://documen.tician.de/meshmode/": None,
     "https://documen.tician.de/grudge/": None,
     "https://documen.tician.de/pytato/": None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ psutil
 --editable git+https://github.com/inducer/dagrt.git#egg=dagrt
 --editable git+https://github.com/inducer/leap.git#egg=leap
 --editable git+https://github.com/inducer/modepy.git#egg=modepy
+--editable git+https://github.com/inducer/arraycontext.git#egg=arraycontext
 --editable git+https://github.com/inducer/meshmode.git#egg=meshmode
 --editable git+https://github.com/inducer/grudge.git#egg=grudge
 --editable git+https://github.com/inducer/pytato.git#egg=pytato

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ def main():
               "pytest>=2.3",
               "pytools>=2018.5.2",
               "modepy>=2013.3",
+              "arraycontext=2021.1",
               "meshmode>=2013.3",
               "pyopencl>=2013.1",
               "pymbolic>=2013.2",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def main():
               "pytest>=2.3",
               "pytools>=2018.5.2",
               "modepy>=2013.3",
-              "arraycontext=2021.1",
+              "arraycontext>=2021.1",
               "meshmode>=2013.3",
               "pyopencl>=2013.1",
               "pymbolic>=2013.2",


### PR DESCRIPTION
This isn't technically needed yet (`arraycontext` is nothing but an empty shell for now), but it'll help me with some [upstream PR headaches](https://github.com/inducer/meshmode/pull/181).