### PR TITLE
Fix passing of time variable to boundary

### DIFF
--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -207,7 +207,7 @@ def main(ctx_factory=cl.create_some_context):
             discr, q=state, t=t, boundaries=boundaries, eos=eos
         ) + av_operator(
             discr, q=state, boundaries=boundaries,
-            boundary_kwargs={"t": t, "eos": eos}, alpha=alpha,
+            boundary_kwargs={"time": t, "eos": eos}, alpha=alpha,
             s0=s0, kappa=kappa
         )
 

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -108,7 +108,8 @@ def euler_operator(discr, eos, boundaries, q, t=0.0):
         inviscid_facial_flux(discr, eos=eos, q_tpair=interior_trace_pair(discr, q))
         + sum(inviscid_facial_flux(discr, eos=eos, q_tpair=part_tpair)
               for part_tpair in cross_rank_trace_pairs(discr, q))
-        + sum(boundaries[btag].inviscid_boundary_flux(discr, btag=btag, q=q, eos=eos)
+        + sum(boundaries[btag].inviscid_boundary_flux(discr, btag=btag, q=q, eos=eos,
+              time=t)
               for btag in boundaries)
     )
 


### PR DESCRIPTION
This fixes bugs in passing the time dependent boundary conditions to the euler_operator, and similar issues when calling the av_operator in the doublemach case