### PR TITLE
cantera: make sure not to pull in MPI

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -19,4 +19,4 @@ dependencies:
 - pip
 - pytest
 - cantera
-- h5py * nompi_ *  # Make sure cantera does not pull in MPI through h5py
+- h5py * nompi_*  # Make sure cantera does not pull in MPI through h5py

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -19,3 +19,4 @@ dependencies:
 - pip
 - pytest
 - cantera
+- h5py * nompi_ *  # Make sure cantera does not pull in MPI through h5py


### PR DESCRIPTION
Fixes the logpyle issues seen on Lassen etc. 🤷 

cantera depends on h5py, which depends on hdf5 (and therefore MPI). Force the non-MPI version of h5py to be installed.