### PR TITLE
Add callback hooks to the simulation stepper

### DIFF
--- a/doc/support/tools.rst
+++ b/doc/support/tools.rst
@@ -1,6 +1,6 @@
 Random Pile'o'Tools
 ===================
 
+.. automodule:: mirgecom.exceptions
 .. automodule:: mirgecom.simutil
-
 .. automodule:: mirgecom.utils

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -242,9 +242,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final)
     except ExactSolutionMismatch as ex:
         error_state = True
         current_step = ex.step

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -41,11 +41,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     check_step,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.fluid import split_conserved
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
@@ -238,7 +238,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
         viz_fields = [("reaction_rates", reaction_rates)]
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -249,7 +249,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz,
                               viz_fields=viz_fields)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -243,7 +243,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -41,11 +41,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -137,7 +137,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -152,7 +152,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -140,7 +140,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -39,12 +39,12 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
+    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
+    sim_cfd_healthcheck,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import MirgecomException
-from mirgecom.fluid import split_conserved
+from mirgecom.exceptions import StepperCrashError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -84,6 +84,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
+    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -133,28 +134,37 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        return sim_checkpoint(discr, visualizer, eos, q=state,
-                              exact_soln=initializer, vizname=casename, step=step,
-                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
+        try:
+            # Check the health of the simulation
+            sim_cfd_healthcheck(discr, eos, q=state,
+                                ncheck=ncheck, step=step, t=t)
+            # Perform checkpointing
+            sim_checkpoint(discr, eos, q=state,
+                           exact_soln=initializer,
+                           step=step, t=t, dt=dt,
+                           nstatus=nstatus, exittol=exittol,
+                           constant_cfl=constant_cfl)
+            # Visualize
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=nviz)
+        except StepperCrashError as err:
+            # Log crash error message
+            if rank == 0:
+                logger.info(str(err))
+                logger.info("Visualizing crashed state ...")
+            # Write out crashed field
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=1)
+            raise err
+        return state
 
-    def my_simhealthcheck(state, step, t, dt):
-        cv = split_conserved(discr.dim, state)
-        return sim_healthcheck(discr, eos, q=state,
-                               conserved_vars=cv,
-                               step=step, t=t)
-
-    try:
-        (current_step, current_t, current_state) = \
-            advance_state(rhs=my_rhs, timestepper=timestepper,
-                          pre_step_callback=my_checkpoint,
-                          post_step_callback=my_simhealthcheck,
-                          get_timestep=get_timestep, state=current_state,
-                          t=current_t, t_final=t_final)
-    except MirgecomException as ex:
-        current_step = ex.step
-        current_t = ex.t
-        current_state = ex.state
+    current_step, current_t, current_state = \
+        advance_state(rhs=my_rhs, timestepper=timestepper,
+                      pre_step_callback=my_checkpoint,
+                      get_timestep=get_timestep, state=current_state,
+                      t=current_t, t_final=t_final, eos=eos, dim=dim)
 
     #    if current_t != checkpoint_t:
     if rank == 0:
@@ -162,9 +172,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     my_checkpoint(current_step, t=current_t,
                   dt=(current_t - checkpoint_t),
                   state=current_state)
-
-    if current_t - t_final < 0:
-        raise ValueError("Simulation exited abnormally")
 
 
 if __name__ == "__main__":

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -40,9 +40,11 @@ from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    generate_and_distribute_mesh,
-    ExactSolutionMismatch
+    sim_healthcheck,
+    generate_and_distribute_mesh
 )
+from mirgecom.exceptions import MirgecomException
+from mirgecom.fluid import split_conserved
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -136,13 +138,18 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,
                               exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
+    def my_simhealthcheck(state, step, t, dt):
+        cv = split_conserved(discr.dim, state)
+        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
                           pre_step_callback=my_checkpoint,
+                          post_step_callback=my_simhealthcheck,
                           get_timestep=get_timestep, state=current_state,
                           t=current_t, t_final=t_final)
-    except ExactSolutionMismatch as ex:
+    except MirgecomException as ex:
         current_step = ex.step
         current_t = ex.t
         current_state = ex.state

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -41,7 +41,8 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    sim_cfd_healthcheck,
+    cfd_healthcheck,
+    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
 from mirgecom.exceptions import StepperCrashError
@@ -136,27 +137,30 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            sim_cfd_healthcheck(discr, eos, q=state,
-                                ncheck=ncheck, step=step, t=t)
+            cfd_healthcheck(discr, eos, state,
+                            step=step, t=t, freq=ncheck)
             # Perform checkpointing
-            sim_checkpoint(discr, eos, q=state,
-                           exact_soln=initializer,
-                           step=step, t=t, dt=dt,
-                           nstatus=nstatus, exittol=exittol,
+            sim_checkpoint(discr, eos, state,
+                           step=step, t=t, dt=dt, freq=nstatus,
                            constant_cfl=constant_cfl)
+            # Compare with analytic result
+            compare_with_analytic_solution(discr, eos, state,
+                                           exact_soln=initializer,
+                                           step=step, t=t, freq=nstatus,
+                                           exittol=exittol)
             # Visualize
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=nviz)
+                              step=step, t=t, freq=nviz)
         except StepperCrashError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))
                 logger.info("Visualizing crashed state ...")
             # Write out crashed field
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=1)
+                              step=step, t=t, freq=1)
             raise err
         return state
 

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -139,9 +139,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final)
     except ExactSolutionMismatch as ex:
         current_step = ex.step
         current_t = ex.t

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -39,13 +39,9 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
-    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -85,7 +81,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
-    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -135,33 +130,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        try:
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, state,
-                            step=step, t=t, freq=ncheck)
-            # Perform checkpointing
-            sim_checkpoint(discr, eos, state,
-                           step=step, t=t, dt=dt, freq=nstatus,
-                           constant_cfl=constant_cfl)
-            # Compare with analytic result
-            compare_with_analytic_solution(discr, eos, state,
-                                           exact_soln=initializer,
-                                           step=step, t=t, freq=nstatus,
-                                           exittol=exittol)
-            # Visualize
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=nviz)
-        except SynchronizedError as err:
-            # Log crash error message
-            if rank == 0:
-                logger.info(str(err))
-                logger.info("Visualizing crashed state ...")
-            # Write out crashed field
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=1)
-            raise err
+        sim_checkpoint(discr, visualizer, eos, q=state,
+                       exact_soln=initializer, vizname=casename, step=step,
+                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -162,9 +162,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final)
     except ExactSolutionMismatch as ex:
         error_state = 1
         current_step = ex.step

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -41,7 +41,8 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    sim_cfd_healthcheck,
+    cfd_healthcheck,
+    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
 from mirgecom.exceptions import StepperCrashError
@@ -156,27 +157,30 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            sim_cfd_healthcheck(discr, eos, q=state,
-                                ncheck=ncheck, step=step, t=t)
+            cfd_healthcheck(discr, eos, state,
+                            step=step, t=t, freq=ncheck)
             # Perform checkpointing
-            sim_checkpoint(discr, eos, q=state,
-                           exact_soln=initializer,
-                           step=step, t=t, dt=dt,
-                           nstatus=nstatus, exittol=exittol,
+            sim_checkpoint(discr, eos, state,
+                           step=step, t=t, dt=dt, freq=nstatus,
                            constant_cfl=constant_cfl)
+            # Compare with analytic result
+            compare_with_analytic_solution(discr, eos, state,
+                                           exact_soln=initializer,
+                                           step=step, t=t, freq=nstatus,
+                                           exittol=exittol)
             # Visualize
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=nviz)
+                              step=step, t=t, freq=nviz)
         except StepperCrashError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))
                 logger.info("Visualizing crashed state ...")
             # Write out crashed field
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=1)
+                              step=step, t=t, freq=1)
             raise err
         return state
 

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -40,9 +40,11 @@ from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    generate_and_distribute_mesh,
-    ExactSolutionMismatch
+    sim_healthcheck,
+    generate_and_distribute_mesh
 )
+from mirgecom.exceptions import MirgecomException
+from mirgecom.fluid import split_conserved
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -159,13 +161,18 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,
                               exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
+    def my_simhealthcheck(state, step, t, dt):
+        cv = split_conserved(discr.dim, state)
+        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
                           pre_step_callback=my_checkpoint,
+                          post_step_callback=my_simhealthcheck,
                           get_timestep=get_timestep, state=current_state,
                           t=current_t, t_final=t_final)
-    except ExactSolutionMismatch as ex:
+    except MirgecomException as ex:
         error_state = 1
         current_step = ex.step
         current_t = ex.t

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -163,7 +163,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -39,12 +39,12 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
+    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
+    sim_cfd_healthcheck,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import MirgecomException
-from mirgecom.fluid import split_conserved
+from mirgecom.exceptions import StepperCrashError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -81,6 +81,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
+    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -91,7 +92,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
         timestepper = rk4_step
     box_ll = -5.0
     box_ur = 5.0
-    error_state = 0
 
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
@@ -154,31 +154,37 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        global checkpoint_t
-        checkpoint_t = t
-        return sim_checkpoint(discr, visualizer, eos, q=state,
-                              exact_soln=initializer, vizname=casename, step=step,
-                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
+        try:
+            # Check the health of the simulation
+            sim_cfd_healthcheck(discr, eos, q=state,
+                                ncheck=ncheck, step=step, t=t)
+            # Perform checkpointing
+            sim_checkpoint(discr, eos, q=state,
+                           exact_soln=initializer,
+                           step=step, t=t, dt=dt,
+                           nstatus=nstatus, exittol=exittol,
+                           constant_cfl=constant_cfl)
+            # Visualize
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=nviz)
+        except StepperCrashError as err:
+            # Log crash error message
+            if rank == 0:
+                logger.info(str(err))
+                logger.info("Visualizing crashed state ...")
+            # Write out crashed field
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=1)
+            raise err
+        return state
 
-    def my_simhealthcheck(state, step, t, dt):
-        cv = split_conserved(discr.dim, state)
-        return sim_healthcheck(discr, eos, q=state,
-                               conserved_vars=cv,
-                               step=step, t=t)
-
-    try:
-        (current_step, current_t, current_state) = \
-            advance_state(rhs=my_rhs, timestepper=timestepper,
-                          pre_step_callback=my_checkpoint,
-                          post_step_callback=my_simhealthcheck,
-                          get_timestep=get_timestep, state=current_state,
-                          t=current_t, t_final=t_final)
-    except MirgecomException as ex:
-        error_state = 1
-        current_step = ex.step
-        current_t = ex.t
-        current_state = ex.state
+    current_step, current_t, current_state = \
+        advance_state(rhs=my_rhs, timestepper=timestepper,
+                      pre_step_callback=my_checkpoint,
+                      get_timestep=get_timestep, state=current_state,
+                      t=current_t, t_final=t_final, eos=eos, dim=dim)
 
     if current_t != checkpoint_t:  # This check because !overwrite
         if rank == 0:
@@ -186,12 +192,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
         my_checkpoint(current_step, t=current_t,
                       dt=(current_t - checkpoint_t),
                       state=current_state)
-
-    if current_t - t_final < 0:
-        error_state = 1
-
-    if error_state:
-        raise ValueError("Simulation did not complete successfully.")
 
 
 if __name__ == "__main__":

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -41,11 +41,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -157,7 +157,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -172,7 +172,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -39,13 +39,9 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
-    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -82,7 +78,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
-    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -155,33 +150,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        try:
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, state,
-                            step=step, t=t, freq=ncheck)
-            # Perform checkpointing
-            sim_checkpoint(discr, eos, state,
-                           step=step, t=t, dt=dt, freq=nstatus,
-                           constant_cfl=constant_cfl)
-            # Compare with analytic result
-            compare_with_analytic_solution(discr, eos, state,
-                                           exact_soln=initializer,
-                                           step=step, t=t, freq=nstatus,
-                                           exittol=exittol)
-            # Visualize
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=nviz)
-        except SynchronizedError as err:
-            # Log crash error message
-            if rank == 0:
-                logger.info(str(err))
-                logger.info("Visualizing crashed state ...")
-            # Write out crashed field
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=1)
-            raise err
+        sim_checkpoint(discr, visualizer, eos, q=state,
+                       exact_soln=initializer, vizname=casename, step=step,
+                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -162,9 +162,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final)
     except ExactSolutionMismatch as ex:
         current_step = ex.step
         current_t = ex.t

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -42,9 +42,10 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     generate_and_distribute_mesh,
     sim_checkpoint,
-    ExactSolutionMismatch,
+    sim_healthcheck
 )
-
+from mirgecom.exceptions import MirgecomException
+from mirgecom.fluid import split_conserved
 from mirgecom.io import make_init_message
 
 from mirgecom.integrators import rk4_step
@@ -159,13 +160,19 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,
                               exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
+    def my_simhealthcheck(state, step, t, dt):
+        cv = split_conserved(discr.dim, state)
+        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
                           pre_step_callback=my_checkpoint,
+                          post_step_callback=my_simhealthcheck,
                           get_timestep=get_timestep, state=current_state,
                           t=current_t, t_final=t_final)
-    except ExactSolutionMismatch as ex:
+
+    except MirgecomException as ex:
         current_step = ex.step
         current_t = ex.t
         current_state = ex.state

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -42,7 +42,8 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    sim_cfd_healthcheck,
+    cfd_healthcheck,
+    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
 from mirgecom.exceptions import StepperCrashError
@@ -158,27 +159,30 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            sim_cfd_healthcheck(discr, eos, q=state,
-                                ncheck=ncheck, step=step, t=t)
+            cfd_healthcheck(discr, eos, state,
+                            step=step, t=t, freq=ncheck)
             # Perform checkpointing
-            sim_checkpoint(discr, eos, q=state,
-                           exact_soln=initializer,
-                           step=step, t=t, dt=dt,
-                           nstatus=nstatus, exittol=exittol,
+            sim_checkpoint(discr, eos, state,
+                           step=step, t=t, dt=dt, freq=nstatus,
                            constant_cfl=constant_cfl)
+            # Compare with analytic result
+            compare_with_analytic_solution(discr, eos, state,
+                                           exact_soln=initializer,
+                                           step=step, t=t, freq=nstatus,
+                                           exittol=exittol)
             # Visualize
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=nviz)
+                              step=step, t=t, freq=nviz)
         except StepperCrashError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))
                 logger.info("Visualizing crashed state ...")
             # Write out crashed field
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=1)
+                              step=step, t=t, freq=1)
             raise err
         return state
 

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -162,7 +162,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -40,13 +40,9 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
-    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 
 from mirgecom.integrators import rk4_step
@@ -93,7 +89,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 10
     nviz = 10
-    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -157,33 +152,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        try:
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, state,
-                            step=step, t=t, freq=ncheck)
-            # Perform checkpointing
-            sim_checkpoint(discr, eos, state,
-                           step=step, t=t, dt=dt, freq=nstatus,
-                           constant_cfl=constant_cfl)
-            # Compare with analytic result
-            compare_with_analytic_solution(discr, eos, state,
-                                           exact_soln=initializer,
-                                           step=step, t=t, freq=nstatus,
-                                           exittol=exittol)
-            # Visualize
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=nviz)
-        except SynchronizedError as err:
-            # Log crash error message
-            if rank == 0:
-                logger.info(str(err))
-                logger.info("Visualizing crashed state ...")
-            # Write out crashed field
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=1)
-            raise err
+        sim_checkpoint(discr, visualizer, eos, q=state,
+                       exact_soln=initializer, vizname=casename, step=step,
+                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -42,11 +42,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 
 from mirgecom.integrators import rk4_step
@@ -159,7 +159,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -174,7 +174,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -149,9 +149,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final)
     except ExactSolutionMismatch as ex:
         current_step = ex.step
         current_t = ex.t

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -42,7 +42,8 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    sim_cfd_healthcheck,
+    cfd_healthcheck,
+    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
 from mirgecom.exceptions import StepperCrashError
@@ -146,27 +147,30 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            sim_cfd_healthcheck(discr, eos, q=state,
-                                ncheck=ncheck, step=step, t=t)
+            cfd_healthcheck(discr, eos, state,
+                            step=step, t=t, freq=ncheck)
             # Perform checkpointing
-            sim_checkpoint(discr, eos, q=state,
-                           exact_soln=initializer,
-                           step=step, t=t, dt=dt,
-                           nstatus=nstatus, exittol=exittol,
+            sim_checkpoint(discr, eos, state,
+                           step=step, t=t, dt=dt, freq=nstatus,
                            constant_cfl=constant_cfl)
+            # Compare with analytic result
+            compare_with_analytic_solution(discr, eos, state,
+                                           exact_soln=initializer,
+                                           step=step, t=t, freq=nstatus,
+                                           exittol=exittol)
             # Visualize
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=nviz)
+                              step=step, t=t, freq=nviz)
         except StepperCrashError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))
                 logger.info("Visualizing crashed state ...")
             # Write out crashed field
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=1)
+                              step=step, t=t, freq=1)
             raise err
         return state
 

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -150,7 +150,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -42,11 +42,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -147,7 +147,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -162,7 +162,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -41,9 +41,11 @@ from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    generate_and_distribute_mesh,
-    ExactSolutionMismatch
+    sim_healthcheck,
+    generate_and_distribute_mesh
 )
+from mirgecom.exceptions import MirgecomException
+from mirgecom.fluid import split_conserved
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -146,13 +148,19 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,
                               exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
+    def my_simhealthcheck(state, step, t, dt):
+        cv = split_conserved(discr.dim, state)
+        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
                           pre_step_callback=my_checkpoint,
+                          post_step_callback=my_simhealthcheck,
                           get_timestep=get_timestep, state=current_state,
                           t=current_t, t_final=t_final)
-    except ExactSolutionMismatch as ex:
+
+    except MirgecomException as ex:
         current_step = ex.step
         current_t = ex.t
         current_state = ex.state

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -40,12 +40,12 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
+    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
+    sim_cfd_healthcheck,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import MirgecomException
-from mirgecom.fluid import split_conserved
+from mirgecom.exceptions import StepperCrashError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -78,6 +78,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
+    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -143,29 +144,37 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        return sim_checkpoint(discr, visualizer, eos, q=state,
-                              exact_soln=initializer, vizname=casename, step=step,
-                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
+        try:
+            # Check the health of the simulation
+            sim_cfd_healthcheck(discr, eos, q=state,
+                                ncheck=ncheck, step=step, t=t)
+            # Perform checkpointing
+            sim_checkpoint(discr, eos, q=state,
+                           exact_soln=initializer,
+                           step=step, t=t, dt=dt,
+                           nstatus=nstatus, exittol=exittol,
+                           constant_cfl=constant_cfl)
+            # Visualize
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=nviz)
+        except StepperCrashError as err:
+            # Log crash error message
+            if rank == 0:
+                logger.info(str(err))
+                logger.info("Visualizing crashed state ...")
+            # Write out crashed field
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=1)
+            raise err
+        return state
 
-    def my_simhealthcheck(state, step, t, dt):
-        cv = split_conserved(discr.dim, state)
-        return sim_healthcheck(discr, eos, q=state,
-                               conserved_vars=cv,
-                               step=step, t=t)
-
-    try:
-        (current_step, current_t, current_state) = \
-            advance_state(rhs=my_rhs, timestepper=timestepper,
-                          pre_step_callback=my_checkpoint,
-                          post_step_callback=my_simhealthcheck,
-                          get_timestep=get_timestep, state=current_state,
-                          t=current_t, t_final=t_final)
-
-    except MirgecomException as ex:
-        current_step = ex.step
-        current_t = ex.t
-        current_state = ex.state
+    current_step, current_t, current_state = \
+        advance_state(rhs=my_rhs, timestepper=timestepper,
+                      pre_step_callback=my_checkpoint,
+                      get_timestep=get_timestep, state=current_state,
+                      t=current_t, t_final=t_final, eos=eos, dim=dim)
 
     #    if current_t != checkpoint_t:
     if rank == 0:
@@ -173,9 +182,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     my_checkpoint(current_step, t=current_t,
                   dt=(current_t - checkpoint_t),
                   state=current_state)
-
-    if current_t - t_final < 0:
-        raise ValueError("Simulation exited abnormally")
 
 
 if __name__ == "__main__":

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -40,13 +40,9 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
-    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -79,7 +75,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
-    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -145,33 +140,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        try:
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, state,
-                            step=step, t=t, freq=ncheck)
-            # Perform checkpointing
-            sim_checkpoint(discr, eos, state,
-                           step=step, t=t, dt=dt, freq=nstatus,
-                           constant_cfl=constant_cfl)
-            # Compare with analytic result
-            compare_with_analytic_solution(discr, eos, state,
-                                           exact_soln=initializer,
-                                           step=step, t=t, freq=nstatus,
-                                           exittol=exittol)
-            # Visualize
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=nviz)
-        except SynchronizedError as err:
-            # Log crash error message
-            if rank == 0:
-                logger.info(str(err))
-                logger.info("Visualizing crashed state ...")
-            # Write out crashed field
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=1)
-            raise err
+        sim_checkpoint(discr, visualizer, eos, q=state,
+                       exact_soln=initializer, vizname=casename, step=step,
+                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -139,7 +139,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -40,11 +40,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -136,7 +136,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -151,7 +151,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -38,13 +38,9 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
-    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -82,7 +78,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 10
     nviz = 10
-    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -134,33 +129,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        try:
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, state,
-                            step=step, t=t, freq=ncheck)
-            # Perform checkpointing
-            sim_checkpoint(discr, eos, state,
-                           step=step, t=t, dt=dt, freq=nstatus,
-                           constant_cfl=constant_cfl)
-            # Compare with analytic result
-            compare_with_analytic_solution(discr, eos, state,
-                                           exact_soln=initializer,
-                                           step=step, t=t, freq=nstatus,
-                                           exittol=exittol)
-            # Visualize
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=nviz)
-        except SynchronizedError as err:
-            # Log crash error message
-            if rank == 0:
-                logger.info(str(err))
-                logger.info("Visualizing crashed state ...")
-            # Write out crashed field
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=1)
-            raise err
+        sim_checkpoint(discr, visualizer, eos, q=state,
+                       exact_soln=initializer, vizname=casename, step=step,
+                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -38,12 +38,12 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
+    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
+    sim_cfd_healthcheck,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import MirgecomException
-from mirgecom.fluid import split_conserved
+from mirgecom.exceptions import StepperCrashError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -81,6 +81,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 10
     nviz = 10
+    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -132,29 +133,37 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        return sim_checkpoint(discr, visualizer, eos, q=state,
-                              exact_soln=initializer, vizname=casename, step=step,
-                              t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                              exittol=exittol, constant_cfl=constant_cfl, comm=comm)
+        try:
+            # Check the health of the simulation
+            sim_cfd_healthcheck(discr, eos, q=state,
+                                ncheck=ncheck, step=step, t=t)
+            # Perform checkpointing
+            sim_checkpoint(discr, eos, q=state,
+                           exact_soln=initializer,
+                           step=step, t=t, dt=dt,
+                           nstatus=nstatus, exittol=exittol,
+                           constant_cfl=constant_cfl)
+            # Visualize
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=nviz)
+        except StepperCrashError as err:
+            # Log crash error message
+            if rank == 0:
+                logger.info(str(err))
+                logger.info("Visualizing crashed state ...")
+            # Write out crashed field
+            sim_visualization(discr, state, eos,
+                              visualizer, vizname=casename,
+                              step=step, t=t, nviz=1)
+            raise err
+        return state
 
-    def my_simhealthcheck(state, step, t, dt):
-        cv = split_conserved(discr.dim, state)
-        return sim_healthcheck(discr, eos, q=state,
-                               conserved_vars=cv,
-                               step=step, t=t)
-
-    try:
-        (current_step, current_t, current_state) = \
-            advance_state(rhs=my_rhs, timestepper=timestepper,
-                          pre_step_callback=my_checkpoint,
-                          post_step_callback=my_simhealthcheck,
-                          get_timestep=get_timestep, state=current_state,
-                          t=current_t, t_final=t_final)
-
-    except MirgecomException as ex:
-        current_step = ex.step
-        current_t = ex.t
-        current_state = ex.state
+    current_step, current_t, current_state = \
+        advance_state(rhs=my_rhs, timestepper=timestepper,
+                      pre_step_callback=my_checkpoint,
+                      get_timestep=get_timestep, state=current_state,
+                      t=current_t, t_final=t_final, eos=eos, dim=dim)
 
     #    if current_t != checkpoint_t:
     if rank == 0:
@@ -162,9 +171,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     my_checkpoint(current_step, t=current_t,
                   dt=(current_t - checkpoint_t),
                   state=current_state)
-
-    if current_t - t_final < 0:
-        raise ValueError("Simulation exited abnormally")
 
 
 if __name__ == "__main__":

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -39,9 +39,11 @@ from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_checkpoint,
-    generate_and_distribute_mesh,
-    ExactSolutionMismatch,
+    sim_healthcheck,
+    generate_and_distribute_mesh
 )
+from mirgecom.exceptions import MirgecomException
+from mirgecom.fluid import split_conserved
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -135,13 +137,19 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,
                               exittol=exittol, constant_cfl=constant_cfl, comm=comm)
 
+    def my_simhealthcheck(state, step, t, dt):
+        cv = split_conserved(discr.dim, state)
+        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
                           pre_step_callback=my_checkpoint,
+                          post_step_callback=my_simhealthcheck,
                           get_timestep=get_timestep, state=current_state,
                           t=current_t, t_final=t_final)
-    except ExactSolutionMismatch as ex:
+
+    except MirgecomException as ex:
         current_step = ex.step
         current_t = ex.t
         current_state = ex.state

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -138,9 +138,9 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final)
     except ExactSolutionMismatch as ex:
         current_step = ex.step
         current_t = ex.t

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -42,11 +42,11 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    cfd_healthcheck,
+    sim_healthcheck,
     compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import StepperCrashError
+from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -183,7 +183,7 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            cfd_healthcheck(discr, eos, state,
+            sim_healthcheck(discr, eos, state,
                             step=step, t=t, freq=ncheck)
             # Perform checkpointing
             sim_checkpoint(discr, eos, state,
@@ -198,7 +198,7 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
             sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
                               step=step, t=t, freq=nviz)
-        except StepperCrashError as err:
+        except SynchronizedError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -42,7 +42,8 @@ from mirgecom.simutil import (
     inviscid_sim_timestep,
     sim_visualization,
     sim_checkpoint,
-    sim_cfd_healthcheck,
+    cfd_healthcheck,
+    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
 from mirgecom.exceptions import StepperCrashError
@@ -182,29 +183,30 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
     def my_checkpoint(step, t, dt, state):
         try:
             # Check the health of the simulation
-            sim_cfd_healthcheck(discr, eos, q=state,
-                                ncheck=ncheck, step=step, t=t)
+            cfd_healthcheck(discr, eos, state,
+                            step=step, t=t, freq=ncheck)
             # Perform checkpointing
-            sim_checkpoint(discr, eos, q=state,
-                           exact_soln=initializer,
-                           step=step, t=t, dt=dt,
-                           nstatus=nstatus, exittol=exittol,
+            sim_checkpoint(discr, eos, state,
+                           step=step, t=t, dt=dt, freq=nstatus,
                            constant_cfl=constant_cfl)
+            # Compare with analytic result
+            compare_with_analytic_solution(discr, eos, state,
+                                           exact_soln=initializer,
+                                           step=step, t=t, freq=nstatus,
+                                           exittol=exittol)
             # Visualize
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=nviz,
-                              vis_timer=vis_timer)
+                              step=step, t=t, freq=nviz)
         except StepperCrashError as err:
             # Log crash error message
             if rank == 0:
                 logger.info(str(err))
                 logger.info("Visualizing crashed state ...")
             # Write out crashed field
-            sim_visualization(discr, state, eos,
+            sim_visualization(discr, eos, state,
                               visualizer, vizname=casename,
-                              step=step, t=t, nviz=1,
-                              vis_timer=vis_timer)
+                              step=step, t=t, freq=1)
             raise err
         return state
 

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -40,13 +40,9 @@ from mirgecom.profiling import PyOpenCLProfilingArrayContext
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_visualization,
     sim_checkpoint,
-    sim_healthcheck,
-    compare_with_analytic_solution,
     generate_and_distribute_mesh
 )
-from mirgecom.exceptions import SynchronizedError
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
 
@@ -107,7 +103,6 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
     constant_cfl = False
     nstatus = 10
     nviz = 10
-    ncheck = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -181,33 +176,10 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        try:
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, state,
-                            step=step, t=t, freq=ncheck)
-            # Perform checkpointing
-            sim_checkpoint(discr, eos, state,
-                           step=step, t=t, dt=dt, freq=nstatus,
-                           constant_cfl=constant_cfl)
-            # Compare with analytic result
-            compare_with_analytic_solution(discr, eos, state,
-                                           exact_soln=initializer,
-                                           step=step, t=t, freq=nstatus,
-                                           exittol=exittol)
-            # Visualize
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=nviz)
-        except SynchronizedError as err:
-            # Log crash error message
-            if rank == 0:
-                logger.info(str(err))
-                logger.info("Visualizing crashed state ...")
-            # Write out crashed field
-            sim_visualization(discr, eos, state,
-                              visualizer, vizname=casename,
-                              step=step, t=t, freq=1)
-            raise err
+        sim_checkpoint(discr, visualizer, eos, q=state,
+                       exact_soln=initializer, vizname=casename, step=step,
+                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
+                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -187,7 +187,9 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
 
     def my_simhealthcheck(state, step, t, dt):
         cv = split_conserved(discr.dim, state)
-        sim_healthcheck(discr, eos, q=state, conserved_vars=cv, step=step, t=t)
+        return sim_healthcheck(discr, eos, q=state,
+                               conserved_vars=cv,
+                               step=step, t=t)
 
     try:
         (current_step, current_t, current_state) = \

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -186,10 +186,10 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
     try:
         (current_step, current_t, current_state) = \
             advance_state(rhs=my_rhs, timestepper=timestepper,
-                checkpoint=my_checkpoint,
-                get_timestep=get_timestep, state=current_state,
-                t=current_t, t_final=t_final, logmgr=logmgr,
-                eos=eos, dim=dim)
+                          pre_step_callback=my_checkpoint,
+                          get_timestep=get_timestep, state=current_state,
+                          t=current_t, t_final=t_final, logmgr=logmgr, eos=eos,
+                          dim=dim)
     except ExactSolutionMismatch as ex:
         current_step = ex.step
         current_t = ex.t

--- a/mirgecom/exceptions.py
+++ b/mirgecom/exceptions.py
@@ -1,7 +1,6 @@
 """Provide custom exceptions for use in callback routines.
 
 .. autoexception:: MirgecomException
-.. autoexception:: ExactSolutionMismatch
 .. autoexception:: SimulationHealthError
 """
 
@@ -30,49 +29,18 @@ THE SOFTWARE.
 """
 
 
-class MirgecomException(Exception):
-    """Exception base class for mirgecom exceptions.
-
-    .. attribute:: step
-
-        A :class:`int` denoting the simulation step when the exception
-        was raised.
-
-    .. attribute:: t
-
-        A :class:`float` denoting the simulation time when the
-        exception was raised.
-
-    .. attribute:: state
-
-        The simulation state when the exception was raised.
+class StepperCrashError(Exception):
+    """Exception base class for simulation exceptions.
 
     .. attribute:: message
 
         A :class:`str` describing the message for the exception.
     """
 
-    def __init__(self, step, t, state, message):
-        """Record the simulation state on creation."""
-        self.step = step
-        self.t = t
-        self.state = state
+    def __init__(self, message):
         self.message = message
         super().__init__(self.message)
 
 
-class ExactSolutionMismatch(MirgecomException):
-    """Exception class for solution mismatch."""
-
-    def __init__(self, step, t, state):
-        super().__init__(
-            step, t, state,
-            message="Solution doesn't agree with analytic result."
-        )
-
-
-class SimulationHealthError(MirgecomException):
+class SimulationHealthError(StepperCrashError):
     """Exception class for an unphysical simulation."""
-
-    def __init__(self, step, t, state, message):
-        super().__init__(step, t, state, message)

--- a/mirgecom/exceptions.py
+++ b/mirgecom/exceptions.py
@@ -1,0 +1,78 @@
+"""Provide custom exceptions for use in callback routines.
+
+.. autoexception:: MirgecomException
+.. autoexception:: ExactSolutionMismatch
+.. autoexception:: SimulationHealthError
+"""
+
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+
+class MirgecomException(Exception):
+    """Exception base class for mirgecom exceptions.
+
+    .. attribute:: step
+
+        A :class:`int` denoting the simulation step when the exception
+        was raised.
+
+    .. attribute:: t
+
+        A :class:`float` denoting the simulation time when the
+        exception was raised.
+
+    .. attribute:: state
+
+        The simulation state when the exception was raised.
+
+    .. attribute:: message
+
+        A :class:`str` describing the message for the exception.
+    """
+
+    def __init__(self, step, t, state, message):
+        """Record the simulation state on creation."""
+        self.step = step
+        self.t = t
+        self.state = state
+        self.message = message
+        super().__init__(self.message)
+
+
+class ExactSolutionMismatch(MirgecomException):
+    """Exception class for solution mismatch."""
+
+    def __init__(self, step, t, state):
+        super().__init__(
+            step, t, state,
+            message="Solution doesn't agree with analytic result."
+        )
+
+
+class SimulationHealthError(MirgecomException):
+    """Exception class for an unphysical simulation."""
+
+    def __init__(self, step, t, state, message):
+        super().__init__(step, t, state, message)

--- a/mirgecom/exceptions.py
+++ b/mirgecom/exceptions.py
@@ -1,6 +1,6 @@
 """Provide custom exceptions for use in callback routines.
 
-.. autoexception:: StepperCrashError
+.. autoexception:: SynchronizedError
 .. autoexception:: SimulationHealthError
 """
 
@@ -29,17 +29,17 @@ THE SOFTWARE.
 """
 
 
-class StepperCrashError(Exception):
-    """Exception base class for simulation exceptions.
+class SynchronizedError(Exception):
+    """Exception base class which must be globally synchronized.
 
     .. attribute:: message
 
-        A :class:`str` describing the message for the exception.
+        A :class:`str` describing the message for the global exception.
     """
 
     def __init__(self, message):
         super().__init__(message)
 
 
-class SimulationHealthError(StepperCrashError):
+class SimulationHealthError(SynchronizedError):
     """Exception class for an unphysical simulation."""

--- a/mirgecom/exceptions.py
+++ b/mirgecom/exceptions.py
@@ -1,6 +1,6 @@
 """Provide custom exceptions for use in callback routines.
 
-.. autoexception:: MirgecomException
+.. autoexception:: StepperCrashError
 .. autoexception:: SimulationHealthError
 """
 
@@ -38,8 +38,7 @@ class StepperCrashError(Exception):
     """
 
     def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class SimulationHealthError(StepperCrashError):

--- a/mirgecom/fluid.py
+++ b/mirgecom/fluid.py
@@ -42,8 +42,17 @@ import numpy as np  # noqa
 from pytools.obj_array import make_obj_array
 from meshmode.dof_array import DOFArray  # noqa
 from dataclasses import dataclass
+from arraycontext import (
+    dataclass_array_container,
+    with_container_arithmetic,
+)
 
 
+@with_container_arithmetic(bcast_obj_array=False,
+                           bcast_container_types=(DOFArray, np.ndarray),
+                           matmul=True,
+                           rel_comparison=True)
+@dataclass_array_container
 @dataclass(frozen=True)
 class ConservedVars:
     r"""Store and resolve quantities according to the fluid conservation equations.
@@ -218,6 +227,11 @@ class ConservedVars:
     energy: DOFArray
     momentum: np.ndarray
     species_mass: np.ndarray = np.empty((0,), dtype=object)  # empty = immutable
+
+    @property
+    def array_context(self):
+        """Return an array context for the :class:`ConservedVars` object."""
+        return self.mass.array_context
 
     @property
     def dim(self):

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -149,8 +149,7 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
 
 
 def sim_healthcheck(discr, eos, q, conserved_vars, step=0, t=0):
-    """Checks the health of the simulation by checking for unphysical values.
-    """
+    """Check the health of the simulation by checking for unphysical values."""
     import grudge.op as op
 
     # NOTE: Derived quantities are functions of the conserved variables.

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -177,9 +177,9 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
         fluids, the conserved quantities should include
         (mass, energy, momentum, species_mass), where *species_mass* is a vector
         of species masses.
-    freq: nstatus
+    nstatus: int
         An integer denoting the step frequency for performing status checks.
-    freq: nviz
+    nviz: int
         An integer denoting the step frequency for writing vtk output.
     """
     exception = None
@@ -228,20 +228,15 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
 
     terminate = True if exception is not None else False
 
-    if comm is None:
-        if terminate:
-            raise exception
-        return
+    if comm is not None:
+        from mpi4py import MPI
 
-    from mpi4py import MPI
-
-    terminate = comm.allreduce(terminate, MPI.LOR)
+        terminate = comm.allreduce(terminate, MPI.LOR)
 
     if terminate:
-        # Log crash error message
         if rank == 0:
-            logger.info(str(exception))
             logger.info("Visualizing crashed state ...")
+
         # Write out crashed field
         sim_visualization(discr, eos, q,
                           visualizer, vizname=vizname,

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -11,7 +11,7 @@ Diagnostic callbacks
 
 .. autofunction:: sim_visualization
 .. autofunction:: sim_checkpoint
-.. autofunction:: cfd_healthcheck
+.. autofunction:: sim_healthcheck
 .. autofunction:: compare_with_analytic_solution
 
 Mesh utilities
@@ -204,7 +204,7 @@ def sim_checkpoint(discr, eos, state, step=0, t=0, dt=0,
             logger.info(msg)
 
 
-def cfd_healthcheck(discr, eos, state, step=0, t=0, freq=-1):
+def sim_healthcheck(discr, eos, state, step=0, t=0, freq=-1):
     """Check the global health of the fluids state.
 
     Determine the health of a state by inspecting for unphyiscal

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -83,7 +83,7 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
     do_viz = check_step(step=step, interval=nviz)
     do_status = check_step(step=step, interval=nstatus)
     if do_viz is False and do_status is False:
-        return 0
+        return q
 
     from mirgecom.fluid import split_conserved
     cv = split_conserved(discr.dim, q)
@@ -147,6 +147,8 @@ def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
     if maxerr > exittol:
         raise ExactSolutionMismatch(step, t=t, state=q)
 
+    return q
+
 
 def sim_healthcheck(discr, eos, q, conserved_vars, step=0, t=0):
     """Check the health of the simulation by checking for unphysical values."""
@@ -180,6 +182,8 @@ def sim_healthcheck(discr, eos, q, conserved_vars, step=0, t=0):
             step, t=t, state=q,
             message="Infinity-norm of derived quantities is not finite."
         )
+
+    return q
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -180,7 +180,7 @@ def sim_checkpoint(discr, eos, q, exact_soln=None,
 
 
 def sim_cfd_healthcheck(discr, eos, q, ncheck=-1, step=0, t=0):
-    """Check the global health of the fluids state *q.
+    """Check the global health of the fluids state *q*.
 
     Determine the health of a state by inspecting for unphyiscal
     values of pressure and temperature.
@@ -198,10 +198,6 @@ def sim_cfd_healthcheck(discr, eos, q, ncheck=-1, step=0, t=0):
         of species masses.
     ncheck: int
         An integer denoting the frequency interval.
-
-    Returns
-    -------
-    None
     """
     from mirgecom.fluid import split_conserved
     import grudge.op as op

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -1,10 +1,22 @@
 """Provide some utilities for building simulation applications.
 
+General utilities
+-----------------
+
 .. autofunction:: check_step
 .. autofunction:: inviscid_sim_timestep
+
+Diagnostic callbacks
+--------------------
+
 .. autofunction:: sim_visualization
 .. autofunction:: sim_checkpoint
-.. autofunction:: sim_cfd_healthcheck
+.. autofunction:: cfd_healthcheck
+.. autofunction:: compare_with_analytic_solution
+
+Mesh utilities
+--------------
+
 .. autofunction:: generate_and_distribute_mesh
 """
 
@@ -76,8 +88,8 @@ def inviscid_sim_timestep(discr, state, t, dt, cfl, eos,
     return mydt
 
 
-def sim_visualization(discr, state, eos, visualizer, vizname,
-                      step=0, t=0, nviz=-1,
+def sim_visualization(discr, eos, state, visualizer, vizname,
+                      step=0, t=0, freq=-1,
                       exact_soln=None, viz_fields=None,
                       overwrite=False, vis_timer=None):
     """Visualize the simulation fields.
@@ -87,72 +99,70 @@ def sim_visualization(discr, state, eos, visualizer, vizname,
 
     Parameters
     ----------
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state.
     state
         State array which expects at least the conserved quantities
         (mass, energy, momentum) for the fluid at each point. For multi-component
         fluids, the conserved quantities should include
         (mass, energy, momentum, species_mass), where *species_mass* is a vector
         of species masses.
-    eos: mirgecom.eos.GasEOS
-        Implementing the pressure and temperature functions for
-        returning pressure and temperature as a function of the state q.
     visualizer:
         A :class:`meshmode.discretization.visualization.Visualizer`
         VTK output object.
-    nviz: int
-        An integer denoting the frequency interval.
+    freq: int
+        An integer denoting the step frequency.
     """
-    from contextlib import nullcontext
-    from mirgecom.fluid import split_conserved
-    from mirgecom.io import make_rank_fname, make_par_fname
+    if check_step(step=step, interval=freq):
 
-    if not check_step(step=step, interval=nviz):
-        return
+        from contextlib import nullcontext
+        from mirgecom.fluid import split_conserved
+        from mirgecom.io import make_rank_fname, make_par_fname
 
-    cv = split_conserved(discr.dim, state)
-    dependent_vars = eos.dependent_vars(cv)
+        cv = split_conserved(discr.dim, state)
+        dependent_vars = eos.dependent_vars(cv)
 
-    io_fields = [
-        ("cv", cv),
-        ("dv", dependent_vars)
-    ]
-    if exact_soln is not None:
-        actx = cv.mass.array_context
-        nodes = thaw(actx, discr.nodes())
-        expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
-        exact_list = [
-            ("exact_soln", expected_state),
+        io_fields = [
+            ("cv", cv),
+            ("dv", dependent_vars)
         ]
-        io_fields.extend(exact_list)
+        if exact_soln is not None:
+            actx = cv.mass.array_context
+            nodes = thaw(actx, discr.nodes())
+            expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
+            exact_list = [
+                ("exact_soln", expected_state),
+            ]
+            io_fields.extend(exact_list)
 
-    if viz_fields is not None:
-        io_fields.extend(viz_fields)
+        if viz_fields is not None:
+            io_fields.extend(viz_fields)
 
-    comm = discr.mpi_communicator
-    rank = 0
-    if comm is not None:
-        rank = comm.Get_rank()
+        comm = discr.mpi_communicator
+        rank = 0
+        if comm is not None:
+            rank = comm.Get_rank()
 
-    rank_fn = make_rank_fname(basename=vizname, rank=rank, step=step, t=t)
+        rank_fn = make_rank_fname(basename=vizname, rank=rank, step=step, t=t)
 
-    if vis_timer:
-        ctm = vis_timer.start_sub_timer()
-    else:
-        ctm = nullcontext()
+        if vis_timer:
+            ctm = vis_timer.start_sub_timer()
+        else:
+            ctm = nullcontext()
 
-    with ctm:
-        visualizer.write_parallel_vtk_file(
-            comm, rank_fn, io_fields,
-            overwrite=overwrite,
-            par_manifest_filename=make_par_fname(
-                basename=vizname, step=step, t=t
+        with ctm:
+            visualizer.write_parallel_vtk_file(
+                comm, rank_fn, io_fields,
+                overwrite=overwrite,
+                par_manifest_filename=make_par_fname(
+                    basename=vizname, step=step, t=t
+                )
             )
-        )
 
 
-def sim_checkpoint(discr, eos, q, exact_soln=None,
-                   step=0, t=0, dt=0, cfl=1.0, nstatus=-1, exittol=1e-16,
-                   constant_cfl=False):
+def sim_checkpoint(discr, eos, state, step=0, t=0, dt=0,
+                   cfl=1.0, freq=-1, constant_cfl=False):
     """Checkpoint the simulation status.
 
     Checkpoints the simulation status by reporting relevant diagnostic
@@ -160,66 +170,42 @@ def sim_checkpoint(discr, eos, q, exact_soln=None,
 
     Parameters
     ----------
-    q
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state.
+    state
         State array which expects at least the conserved quantities
         (mass, energy, momentum) for the fluid at each point. For multi-component
         fluids, the conserved quantities should include
         (mass, energy, momentum, species_mass), where *species_mass* is a vector
         of species masses.
-    eos: mirgecom.eos.GasEOS
-        Implementing the pressure and temperature functions for
-        returning pressure and temperature as a function of the state q.
-    nstatus: int
-        An integer denoting the frequency interval.
+    freq: int
+        An integer denoting the step frequency.
     """
-    from mirgecom.fluid import split_conserved
+    if check_step(step=step, interval=freq):
 
-    do_status = check_step(step=step, interval=nstatus)
-    if do_status is False:
-        return
+        from mirgecom.fluid import split_conserved
 
-    cv = split_conserved(discr.dim, q)
-    dependent_vars = eos.dependent_vars(cv)
-
-    maxerr = 0.0
-    if exact_soln is not None:
-        actx = cv.mass.array_context
-        nodes = thaw(actx, discr.nodes())
-        expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
-        exp_resid = q - expected_state
-        err_norms = [discr.norm(v, np.inf) for v in exp_resid]
-        maxerr = max(err_norms)
-
-    comm = discr.mpi_communicator
-    rank = 0
-    if comm is not None:
-        rank = comm.Get_rank()
-
-    if do_status is True:
         #        if constant_cfl is False:
-        #            current_cfl = get_inviscid_cfl(discr=discr, q=q,
+        #            current_cfl = get_inviscid_cfl(discr=discr, q=state,
         #                                           eos=eos, dt=dt)
-        statusmesg = make_status_message(discr=discr, t=t, step=step, dt=dt,
-                                         cfl=cfl, dependent_vars=dependent_vars)
-        if exact_soln is not None:
-            statusmesg += (
-                "\n------- errors="
-                + ", ".join("%.3g" % en for en in err_norms))
 
+        comm = discr.mpi_communicator
+        rank = 0
+        if comm is not None:
+            rank = comm.Get_rank()
+
+        cv = split_conserved(discr.dim, state)
+        dependent_vars = eos.dependent_vars(cv)
+        msg = make_status_message(discr=discr,
+                                  t=t, step=step, dt=dt, cfl=cfl,
+                                  dependent_vars=dependent_vars)
         if rank == 0:
-            logger.info(statusmesg)
-
-    if maxerr > exittol:
-        raise SimulationHealthError(
-            message=(
-                "Simulation exited abnormally; "
-                "solution doesn't agree with analytic result."
-            )
-        )
+            logger.info(msg)
 
 
-def sim_cfd_healthcheck(discr, eos, q, ncheck=-1, step=0, t=0):
-    """Check the global health of the fluids state *q*.
+def cfd_healthcheck(discr, eos, state, step=0, t=0, freq=-1):
+    """Check the global health of the fluids state.
 
     Determine the health of a state by inspecting for unphyiscal
     values of pressure and temperature.
@@ -228,57 +214,109 @@ def sim_cfd_healthcheck(discr, eos, q, ncheck=-1, step=0, t=0):
     ----------
     eos: mirgecom.eos.GasEOS
         Implementing the pressure and temperature functions for
-        returning pressure and temperature as a function of the state q.
-    q
+        returning pressure and temperature as a function of the state.
+    state
         State array which expects at least the conserved quantities
         (mass, energy, momentum) for the fluid at each point. For multi-component
         fluids, the conserved quantities should include
         (mass, energy, momentum, species_mass), where *species_mass* is a vector
         of species masses.
-    ncheck: int
-        An integer denoting the frequency interval.
+    freq: int
+        An integer denoting the step frequency.
     """
-    from mirgecom.fluid import split_conserved
-    import grudge.op as op
+    if check_step(step=step, interval=freq):
 
-    if not check_step(step=step, interval=ncheck):
-        return
+        from mirgecom.fluid import split_conserved
+        import grudge.op as op
 
-    cv = split_conserved(discr.dim, q)
+        # NOTE: Derived quantities are functions of the conserved variables.
+        # Therefore is it sufficient to check for unphysical values of
+        # temperature and pressure.
+        cv = split_conserved(discr.dim, state)
+        dependent_vars = eos.dependent_vars(cv)
+        pressure = dependent_vars.pressure
+        temperature = dependent_vars.temperature
 
-    # NOTE: Derived quantities are functions of the conserved variables.
-    # Therefore is it sufficient to check for unphysical values of
-    # temperature and pressure.
-    dependent_vars = eos.dependent_vars(cv)
-
-    # Check for NaN
-    if (np.isnan(op.nodal_sum_loc(discr, "vol", dependent_vars.pressure))
-            or np.isnan(op.nodal_sum_loc(discr, "vol", dependent_vars.temperature))):
-        raise SimulationHealthError(
-            message=(
-                "Simulation exited abnormally; detected a NaN."
+        # Check for NaN
+        if (np.isnan(op.nodal_sum_loc(discr, "vol", pressure))
+                or np.isnan(op.nodal_sum_loc(discr, "vol", temperature))):
+            raise SimulationHealthError(
+                message=("Simulation exited abnormally; detected a NaN.")
             )
+
+        # Check for non-positivity
+        if (op.nodal_min_loc(discr, "vol", pressure) < 0
+                or op.nodal_min_loc(discr, "vol", temperature) < 0):
+            raise SimulationHealthError(
+                message=("Simulation exited abnormally; "
+                         "found non-positive values for pressure or temperature.")
+            )
+
+        # Check for blow-up
+        if (op.nodal_sum_loc(discr, "vol", pressure) == np.inf
+                or op.nodal_sum_loc(discr, "vol", temperature) == np.inf):
+            raise SimulationHealthError(
+                message=("Simulation exited abnormally; "
+                         "derived quantities are not finite.")
+            )
+
+
+def compare_with_analytic_solution(discr, eos, state, exact_soln,
+                                   step=0, t=0, freq=-1, exittol=None):
+    """Compute the infinite norm of the problem residual.
+
+    Computes the infinite norm of the residual with respect to a specified
+    exact solution *exact_soln*. If the error is larger than *exittol*,
+    raises a :class:`mirgecom.exceptions.SimulationHealthError`.
+
+    Parameters
+    ----------
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state.
+    state
+        State array which expects at least the conserved quantities
+        (mass, energy, momentum) for the fluid at each point. For multi-component
+        fluids, the conserved quantities should include
+        (mass, energy, momentum, species_mass), where *species_mass* is a vector
+        of species masses.
+    exact_soln:
+        A callable for the exact solution with signature:
+        ``exact_soln(x_vec, t, eos)`` where `x_vec` are the nodes,
+        `t` is time, and `eos` is a :class:`mirgecom.eos.GasEOS`.
+    freq: int
+        An integer denoting the step frequency.
+    """
+    if check_step(step=step, interval=freq):
+
+        if exittol is None:
+            exittol = 1e-16
+
+        actx = discr._setup_actx
+        nodes = thaw(actx, discr.nodes())
+        expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
+        exp_resid = state - expected_state
+        norms = [discr.norm(v, np.inf) for v in exp_resid]
+
+        comm = discr.mpi_communicator
+        rank = 0
+        if comm is not None:
+            rank = comm.Get_rank()
+
+        statusmesg = (
+            f"Errors: {step=} {t=}\n"
+            f"------- errors = "
+            + ", ".join("%.3g" % err_norm for err_norm in norms)
         )
 
-    # Check for non-positivity
-    if (op.nodal_min_loc(discr, "vol", dependent_vars.pressure) < 0
-            or op.nodal_min_loc(discr, "vol", dependent_vars.temperature) < 0):
-        raise SimulationHealthError(
-            message=(
-                "Simulation exited abnormally; "
-                "found non-positive values for pressure or temperature."
-            )
-        )
+        if rank == 0:
+            logger.info(statusmesg)
 
-    # Check for blow-up
-    if (op.nodal_sum_loc(discr, "vol", dependent_vars.pressure) == np.inf
-            or op.nodal_sum_loc(discr, "vol", dependent_vars.temperature) == np.inf):
-        raise SimulationHealthError(
-            message=(
-                "Simulation exited abnormally; "
-                "derived quantities are not finite."
+        if max(norms) > exittol:
+            raise SimulationHealthError(
+                message=("Simulation exited abnormally; "
+                         "solution doesn't agree with analytic result.")
             )
-        )
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -80,7 +80,28 @@ def sim_visualization(discr, state, eos, visualizer, vizname,
                       step=0, t=0, nviz=-1,
                       exact_soln=None, viz_fields=None,
                       overwrite=False, vis_timer=None):
-    """Visualize the simulation fields."""
+    """Visualize the simulation fields.
+
+    Write VTK output of the conserved state and and specified derived
+    quantities *viz_fields*.
+
+    Parameters
+    ----------
+    state
+        State array which expects at least the conserved quantities
+        (mass, energy, momentum) for the fluid at each point. For multi-component
+        fluids, the conserved quantities should include
+        (mass, energy, momentum, species_mass), where *species_mass* is a vector
+        of species masses.
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state q.
+    visualizer:
+        A :class:`meshmode.discretization.visualization.Visualizer`
+        VTK output object.
+    nviz: int
+        An integer denoting the frequency interval.
+    """
     from contextlib import nullcontext
     from mirgecom.fluid import split_conserved
     from mirgecom.io import make_rank_fname, make_par_fname
@@ -132,7 +153,25 @@ def sim_visualization(discr, state, eos, visualizer, vizname,
 def sim_checkpoint(discr, eos, q, exact_soln=None,
                    step=0, t=0, dt=0, cfl=1.0, nstatus=-1, exittol=1e-16,
                    constant_cfl=False):
-    """Check simulation status, and restart."""
+    """Checkpoint the simulation status.
+
+    Checkpoints the simulation status by reporting relevant diagnostic
+    quantities, such as pressure/temperature.
+
+    Parameters
+    ----------
+    q
+        State array which expects at least the conserved quantities
+        (mass, energy, momentum) for the fluid at each point. For multi-component
+        fluids, the conserved quantities should include
+        (mass, energy, momentum, species_mass), where *species_mass* is a vector
+        of species masses.
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state q.
+    nstatus: int
+        An integer denoting the frequency interval.
+    """
     from mirgecom.fluid import split_conserved
 
     do_status = check_step(step=step, interval=nstatus)

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -33,14 +33,14 @@ from arraycontext import (  # noqa
     as pytest_generate_tests
 )
 
-from mirgecom.fluid import join_conserved, split_conserved
+from mirgecom.fluid import join_conserved
 from mirgecom.eos import IdealSingleGas
 
 from grudge.eager import EagerDGDiscretization
 
 
-def test_basic_healthcheck(actx_factory):
-    from mirgecom.simutil import sim_healthcheck
+def test_basic_cfd_healthcheck(actx_factory):
+    from mirgecom.simutil import sim_cfd_healthcheck
 
     actx = actx_factory()
     nel_1d = 4
@@ -66,12 +66,11 @@ def test_basic_healthcheck(actx_factory):
 
     eos = IdealSingleGas()
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
-    cv = split_conserved(dim, q)
 
     from mirgecom.exceptions import SimulationHealthError
 
     with pytest.raises(SimulationHealthError):
-        sim_healthcheck(discr, eos, q, cv)
+        sim_cfd_healthcheck(discr, eos, q, ncheck=1)
 
     # Let's make another very bad state (nans)
     mass = 1*ones
@@ -80,10 +79,9 @@ def test_basic_healthcheck(actx_factory):
     mom = mass * velocity
 
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
-    cv = split_conserved(dim, q)
 
     with pytest.raises(SimulationHealthError):
-        sim_healthcheck(discr, eos, q, cv)
+        sim_cfd_healthcheck(discr, eos, q, ncheck=1)
 
     # Let's make one last very bad state (inf)
     mass = 1*ones
@@ -92,7 +90,6 @@ def test_basic_healthcheck(actx_factory):
     mom = mass * velocity
 
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
-    cv = split_conserved(dim, q)
 
     with pytest.raises(SimulationHealthError):
-        sim_healthcheck(discr, eos, q, cv)
+        sim_cfd_healthcheck(discr, eos, q, ncheck=1)

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -40,7 +40,7 @@ from grudge.eager import EagerDGDiscretization
 
 
 def test_basic_cfd_healthcheck(actx_factory):
-    from mirgecom.simutil import sim_cfd_healthcheck
+    from mirgecom.simutil import cfd_healthcheck
 
     actx = actx_factory()
     nel_1d = 4
@@ -70,7 +70,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     from mirgecom.exceptions import SimulationHealthError
 
     with pytest.raises(SimulationHealthError):
-        sim_cfd_healthcheck(discr, eos, q, ncheck=1)
+        cfd_healthcheck(discr, eos, q, freq=1)
 
     # Let's make another very bad state (nans)
     mass = 1*ones
@@ -81,7 +81,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
 
     with pytest.raises(SimulationHealthError):
-        sim_cfd_healthcheck(discr, eos, q, ncheck=1)
+        cfd_healthcheck(discr, eos, q, freq=1)
 
     # Let's make one last very bad state (inf)
     mass = 1*ones
@@ -92,4 +92,4 @@ def test_basic_cfd_healthcheck(actx_factory):
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
 
     with pytest.raises(SimulationHealthError):
-        sim_cfd_healthcheck(discr, eos, q, ncheck=1)
+        cfd_healthcheck(discr, eos, q, freq=1)

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -79,7 +79,6 @@ def test_basic_healthcheck(actx_factory):
     velocity = np.nan * nodes
     mom = mass * velocity
 
-    eos = IdealSingleGas()
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
     cv = split_conserved(dim, q)
 
@@ -92,7 +91,6 @@ def test_basic_healthcheck(actx_factory):
     velocity = 2 * nodes
     mom = mass * velocity
 
-    eos = IdealSingleGas()
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
     cv = split_conserved(dim, q)
 

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -40,7 +40,7 @@ from grudge.eager import EagerDGDiscretization
 
 
 def test_basic_cfd_healthcheck(actx_factory):
-    from mirgecom.simutil import cfd_healthcheck
+    from mirgecom.simutil import sim_healthcheck
 
     actx = actx_factory()
     nel_1d = 4
@@ -70,7 +70,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     from mirgecom.exceptions import SimulationHealthError
 
     with pytest.raises(SimulationHealthError):
-        cfd_healthcheck(discr, eos, q, freq=1)
+        sim_healthcheck(discr, eos, q, freq=1)
 
     # Let's make another very bad state (nans)
     mass = 1*ones
@@ -81,7 +81,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
 
     with pytest.raises(SimulationHealthError):
-        cfd_healthcheck(discr, eos, q, freq=1)
+        sim_healthcheck(discr, eos, q, freq=1)
 
     # Let's make one last very bad state (inf)
     mass = 1*ones
@@ -92,7 +92,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
 
     with pytest.raises(SimulationHealthError):
-        cfd_healthcheck(discr, eos, q, freq=1)
+        sim_healthcheck(discr, eos, q, freq=1)
 
 
 def test_analytic_comparison(actx_factory):

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -1,0 +1,100 @@
+"""Test built-in callback routines."""
+
+__copyright__ = """
+Copyright (C) 2021 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+import pytest
+
+from arraycontext import (  # noqa
+    thaw,
+    pytest_generate_tests_for_pyopencl_array_context
+    as pytest_generate_tests
+)
+
+from mirgecom.fluid import join_conserved, split_conserved
+from mirgecom.eos import IdealSingleGas
+
+from grudge.eager import EagerDGDiscretization
+
+
+def test_basic_healthcheck(actx_factory):
+    from mirgecom.simutil import sim_healthcheck
+
+    actx = actx_factory()
+    nel_1d = 4
+    dim = 2
+
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+
+    mesh = generate_regular_rect_mesh(
+        a=(1.0,) * dim, b=(2.0,) * dim, nelements_per_axis=(nel_1d,) * dim
+    )
+
+    order = 3
+    discr = EagerDGDiscretization(actx, mesh, order=order)
+    nodes = thaw(discr.nodes(), actx)
+    zeros = discr.zeros(actx)
+    ones = zeros + 1.0
+
+    # Let's make a very bad state (negative mass)
+    mass = -1*ones
+    energy = zeros + 2.5
+    velocity = 2 * nodes
+    mom = mass * velocity
+
+    eos = IdealSingleGas()
+    q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
+    cv = split_conserved(dim, q)
+
+    from mirgecom.exceptions import SimulationHealthError
+
+    with pytest.raises(SimulationHealthError):
+        sim_healthcheck(discr, eos, q, cv)
+
+    # Let's make another very bad state (nans)
+    mass = 1*ones
+    energy = zeros + 2.5
+    velocity = np.nan * nodes
+    mom = mass * velocity
+
+    eos = IdealSingleGas()
+    q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
+    cv = split_conserved(dim, q)
+
+    with pytest.raises(SimulationHealthError):
+        sim_healthcheck(discr, eos, q, cv)
+
+    # Let's make one last very bad state (inf)
+    mass = 1*ones
+    energy = np.inf * ones
+    velocity = 2 * nodes
+    mom = mass * velocity
+
+    eos = IdealSingleGas()
+    q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
+    cv = split_conserved(dim, q)
+
+    with pytest.raises(SimulationHealthError):
+        sim_healthcheck(discr, eos, q, cv)

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -70,7 +70,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     from mirgecom.exceptions import SimulationHealthError
 
     with pytest.raises(SimulationHealthError):
-        sim_healthcheck(discr, eos, q, freq=1)
+        sim_healthcheck(discr, eos, q)
 
     # Let's make another very bad state (nans)
     mass = 1*ones
@@ -81,7 +81,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
 
     with pytest.raises(SimulationHealthError):
-        sim_healthcheck(discr, eos, q, freq=1)
+        sim_healthcheck(discr, eos, q)
 
     # Let's make one last very bad state (inf)
     mass = 1*ones
@@ -92,7 +92,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
 
     with pytest.raises(SimulationHealthError):
-        sim_healthcheck(discr, eos, q, freq=1)
+        sim_healthcheck(discr, eos, q)
 
 
 def test_analytic_comparison(actx_factory):
@@ -125,4 +125,4 @@ def test_analytic_comparison(actx_factory):
     from mirgecom.exceptions import SimulationHealthError
 
     with pytest.raises(SimulationHealthError):
-        compare_with_analytic_solution(discr, eos, q, Vortex2D(), freq=1)
+        compare_with_analytic_solution(discr, eos, q, Vortex2D())

--- a/test/test_time_integrators.py
+++ b/test/test_time_integrators.py
@@ -128,13 +128,13 @@ if found:
                 return dt
 
             def my_checkpoint(state, step, t, dt):
-                return 0
+                return state
 
             (step, t, state) = \
                 advance_state(rhs=rhs, timestepper=method,
-                            checkpoint=my_checkpoint,
-                            get_timestep=get_timestep, state=state,
-                            t=t, t_final=t_final, component_id="y")
+                              get_timestep=get_timestep, state=state,
+                              t=t, t_final=t_final, component_id="y",
+                              post_step_callback=my_checkpoint)
 
             error = np.abs(state - exact_soln(t)) / exact_soln(t)
             integrator_eoc.add_data_point(dt, error)


### PR DESCRIPTION
Adds pre/post-step callbacks to `advance_state`. This also removes the `checkpoint` argument since it is technically a callback. All examples have been updated.

I also threw in a health-check callback that is exercised in the examples. Will write a short unit test for it as well.

cc @MTCam @anderson2981 