### PR TITLE
Tweaks to error handling in #370

### DIFF
--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -187,12 +187,12 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        sim_checkpoint(discr, visualizer, eos, q=state,
-                       exact_soln=initializer, step=step,
-                       t=t, dt=dt, nstatus=nstatus, healthcheck_callback=healthcheck,
-                       nviz=nviz, vis_callback=write_vis,
-                       exittol=exittol, constant_cfl=constant_cfl)
-        return state
+        return sim_checkpoint(discr, visualizer, eos, q=state,
+                              exact_soln=initializer, step=step,
+                              t=t, dt=dt, nstatus=nstatus,
+                              healthcheck_callback=healthcheck,
+                              nviz=nviz, vis_callback=write_vis,
+                              exittol=exittol, constant_cfl=constant_cfl)
 
     def handle_exception(step, t, state, exception):
         if rank == 0:

--- a/mirgecom/exceptions.py
+++ b/mirgecom/exceptions.py
@@ -29,17 +29,23 @@ THE SOFTWARE.
 """
 
 
-class SynchronizedError(Exception):
-    """Exception base class which must be globally synchronized.
-
-    .. attribute:: message
-
-        A :class:`str` describing the message for the global exception.
-    """
+class SimulationHealthError(Exception):
+    """Exception class for an unphysical simulation."""
 
     def __init__(self, message):
         super().__init__(message)
 
 
-class SimulationHealthError(SynchronizedError):
-    """Exception class for an unphysical simulation."""
+class SynchronizedException(Exception):
+    """Exception class wrapping an exception which has been globally synchronized.
+
+    .. attribute:: exception
+
+        The wrapped exception.
+    """
+
+    def __init__(self, exception):
+        super().__init__(
+            f"({exception.__class__.__module__}.{exception.__class__.__name__}) "
+            + exception.__str__())
+        self.exception = exception

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -217,6 +217,8 @@ def sim_checkpoint(discr, visualizer, eos, q, exact_soln=None,
     if check_step(step=step, interval=nviz) and vis_callback is not None:
         vis_callback(step, t, q)
 
+    return q, False
+
 
 def sim_healthcheck(discr, eos, state, step=0, t=0):
     """Check the global health of the fluids state.

--- a/mirgecom/steppers.py
+++ b/mirgecom/steppers.py
@@ -101,14 +101,18 @@ def _advance_state_stepper_func(rhs, timestepper, get_timestep,
                 raise SynchronizedException(RuntimeError(f"Invalid timestep {dt}."))
 
             if pre_step_callback is not None:
-                state = pre_step_callback(state=state, step=istep, t=t, dt=dt)
+                state, stop = pre_step_callback(state=state, step=istep, t=t, dt=dt)
+                if stop:
+                    break
 
             state = timestepper(state=state, t=t, dt=dt, rhs=rhs)
 
             t += dt
 
             if post_step_callback is not None:
-                state = post_step_callback(state=state, step=istep, t=t, dt=dt)
+                state, stop = post_step_callback(state=state, step=istep, t=t, dt=dt)
+                if stop:
+                    break
 
             istep += 1
 
@@ -212,9 +216,11 @@ def _advance_state_leap(rhs, timestepper, get_timestep,
                 raise SynchronizedException(RuntimeError(f"Invalid timestep {dt}."))
 
             if pre_step_callback is not None:
-                state = pre_step_callback(state=state,
-                                          step=istep,
-                                          t=t, dt=dt)
+                state, stop = pre_step_callback(state=state,
+                                                step=istep,
+                                                t=t, dt=dt)
+                if stop:
+                    break
 
             # Leap interface here is *a bit* different.
             for event in stepper_cls.run(t_end=t+dt):
@@ -223,9 +229,11 @@ def _advance_state_leap(rhs, timestepper, get_timestep,
                     t += dt
 
                     if post_step_callback is not None:
-                        state = post_step_callback(state=state,
-                                                   step=istep,
-                                                   t=t, dt=dt)
+                        state, stop = post_step_callback(state=state,
+                                                         step=istep,
+                                                         t=t, dt=dt)
+                        if stop:
+                            break
 
                     istep += 1
 


### PR DESCRIPTION
This PR tweaks the error handling setup in #370 in the following ways:

1. Converts `SynchronizedError` from a base class to a type that wraps another exception. `SynchronizedException` now indicates to the handling code that the contained exception has been synchronized across MPI ranks.
2. Adds some helper code for synchronizing exceptions (`bcast_from_lowest_rank`).
3. Moves the `try`/`except` from `sim_checkpoint` into `advance_state`.
4. Adds an `exception_callback` to `advance_state`. This function can either re-raise the exception after handling, or it can return a `state, stop` tuple causing stepping to either resume or halt according to what the user decides.

In the process I also added a couple of callbacks to `sim_checkpoint` (`healthcheck_callback` and `vis_callback`).

(Note: I only changed `vortex-mpi` for now, so the CI will probably fail.)

Thoughts @thomasgibson, @MTCam?