### PR TITLE
Add PyOpenCLProfilingArrayContext.clone

### DIFF
--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -103,6 +103,10 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
 
         cl.array.ARRAY_KERNEL_EXEC_HOOK = self.array_kernel_exec_hook
 
+    def clone(self):
+        """Return a semantically equivalent but distinct version of *self*."""
+        return type(self)(self.queue, self.allocator, self.logmgr)
+
     def __del__(self):
         """Release resources and undo monkey patching."""
         del self.profile_events[:]


### PR DESCRIPTION
This is in preparation for https://github.com/inducer/arraycontext/pull/22. Without this, the examples CI at https://github.com/inducer/meshmode/pull/218 fails.