### PR TITLE
Update and tweak callbacks and health checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,7 @@ jobs:
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 
+            sudo apt-get update
             sudo apt-get install texlive-latex-extra latexmk
             conda install sphinx graphviz
             pip install sphinx-math-dollar sphinx-copybutton furo
@@ -141,7 +142,7 @@ jobs:
         - uses: actions/checkout@v2
         - name: Install emirge
           run: |
-            [[ $(uname) == Linux ]] && sudo apt-get install -y openmpi-bin libopenmpi-dev
+            [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
             [[ $(uname) == Darwin ]] && brew update && brew install mpich
             cd ..
             git clone https://github.com/illinois-ceesd/emirge

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -258,12 +258,12 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                     logger.info("Fluid solution failed health check.")
                 logger.info(message)   # do this on all ranks
 
-        if do_viz or errors > 0:
+        if do_viz or errored:
             from mirgecom.simutil import sim_visualization
             sim_visualization(discr, io_fields, visualizer, vizname=casename,
                               step=step, t=t, overwrite=True)
 
-        if errors > 0:
+        if errored:
             a = 1/0
             print(f"{a=}")
 

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -80,6 +80,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 5
+    nhealth = 1
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -221,15 +222,56 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                 + eos.get_species_source_terms(state))
 
     def my_checkpoint(step, t, dt, state):
-        reaction_rates = eos.get_production_rates(state)
-        viz_fields = [("reaction_rates", reaction_rates)]
-        print(f"{viz_fields=}")
+        from mirgecom.simutil import check_step
+        do_status = check_step(step=step, interval=nstatus)
+        do_viz = check_step(step=step, interval=nviz)
+        do_health = check_step(step=step, interval=nhealth)
 
-    (current_step, current_t, current_state) = \
+        if do_status or do_viz or do_health:
+            dv = eos.dependent_vars(state)
+            reaction_rates = eos.get_production_rates(state)
+            io_fields = [
+                ("cv", state),
+                ("dv", dv),
+                ("reaction_rates", reaction_rates)
+            ]
+
+        if do_status:  # This is bad, logging already completely replaces this
+            from mirgecom.io import make_status_message
+            status_msg = make_status_message(discr=discr, t=t, step=step, dt=dt,
+                                             cfl=current_cfl, dependent_vars=dv)
+            if rank == 0:
+                logger.info(status_msg)
+
+        errors = 0
+        if do_health:
+            from mirgecom.simutil import check_naninf_local, check_range_local
+            if check_naninf_local(discr, "vol", dv.pressure) \
+               or check_range_local(discr, "vol", dv.pressure):
+                errors = 1
+                message = "Invalid pressure data found.\n"
+            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
+            if errors > 0:
+                if rank == 0:
+                    logger.info("Fluid solution failed health check.")
+                logger.info(message)   # do this on all ranks
+
+        if do_viz or errors > 0:
+            from mirgecom.simutil import sim_visualization
+            sim_visualization(discr, io_fields, visualizer, vizname=casename,
+                              step=step, t=t, overwrite=True)
+
+        if errors > 0:
+            a = 1/0
+            print(f"{a=}")
+
+        return state
+
+    current_step, current_t, current_state = \
         advance_state(rhs=my_rhs, timestepper=timestepper,
-                      checkpoint=my_checkpoint,
+                      pre_step_callback=my_checkpoint,
                       get_timestep=get_timestep, state=current_state,
-                      t=current_t, t_final=t_final)
+                      t=current_t, t_final=t_final, eos=eos, dim=dim)
 
     if not check_step(current_step, nviz):  # If final step not an output step
         if rank == 0:

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -264,8 +264,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               step=step, t=t, overwrite=True)
 
         if errored:
-            a = 1/0
-            print(f"{a=}")
+            raise RuntimeError("Error detected by user checkpoint, exiting.")
 
         return state
 

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -39,7 +39,6 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_checkpoint,
     generate_and_distribute_mesh
 )
 from mirgecom.io import make_init_message
@@ -126,21 +125,17 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                            t_final=t_final, constant_cfl=constant_cfl)
 
     def my_rhs(t, state):
-        return euler_operator(discr, q=state, t=t,
+        return euler_operator(discr, cv=state, t=t,
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        sim_checkpoint(discr, visualizer, eos, q=state,
-                       exact_soln=initializer, vizname=casename, step=step,
-                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                       exittol=exittol, constant_cfl=constant_cfl)
-        return state
+        print(f"{step=}")
 
-    current_step, current_t, current_state = \
+    (current_step, current_t, current_state) = \
         advance_state(rhs=my_rhs, timestepper=timestepper,
-                      pre_step_callback=my_checkpoint,
+                      checkpoint=my_checkpoint,
                       get_timestep=get_timestep, state=current_state,
-                      t=current_t, t_final=t_final, eos=eos, dim=dim)
+                      t=current_t, t_final=t_final)
 
     #    if current_t != checkpoint_t:
     if rank == 0:

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -146,7 +146,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                            t_final=t_final, constant_cfl=constant_cfl)
 
     def my_rhs(t, state):
-        return euler_operator(discr, q=state, t=t,
+        return euler_operator(discr, cv=state, t=t,
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -178,30 +178,29 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             if rank == 0:
                 logger.info(status_msg)
 
-        errors = 0
+        errored = False
         if do_health:
             from mirgecom.simutil import check_naninf_local, check_range_local
             if check_naninf_local(discr, "vol", dv.pressure) \
                or check_range_local(discr, "vol", dv.pressure):
-                errors = 1
+                errored = True
                 message = "Invalid pressure data found.\n"
-            if np.max(component_errors) > exittol:
-                errors = errors + 1
-                message += "Solution errors exceed tolerance.\n"
-            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
-            if errors > 0:
+            if max(component_errors) > exittol:
+                errored = True
+                message += "Solution diverged from exact_mix.\n"
+            errored = discr.mpi_communicator.allreduce(errored, op=MPI.LOR)
+            if errored:
                 if rank == 0:
                     logger.info("Fluid solution failed health check.")
                 logger.info(message)   # do this on all ranks
 
-        if do_viz or errors > 0:
+        if do_viz or errored:
             from mirgecom.simutil import sim_visualization
             sim_visualization(discr, io_fields, visualizer, vizname=casename,
                               step=step, t=t, overwrite=True)
 
-        if errors > 0:
-            a = 1/0
-            print(f"{a=}")
+        if errored:
+            raise RuntimeError("Error detected by user checkpoint, exiting.")
 
         return state
 

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -40,7 +40,6 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_checkpoint,
     generate_and_distribute_mesh
 )
 from mirgecom.io import make_init_message
@@ -71,8 +70,6 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     dim = 2
     nel_1d = 16
     order = 1
-    exittol = 2e-2
-    exittol = 100.0
     t_final = 0.1
     current_cfl = 1.0
     vel = np.zeros(shape=(dim,))
@@ -127,7 +124,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     uniform_state = initializer(nodes)
     acoustic_pulse = AcousticPulse(dim=dim, amplitude=1.0, width=.1,
                                    center=orig)
-    current_state = acoustic_pulse(x_vec=nodes, q=uniform_state, eos=eos)
+    current_state = acoustic_pulse(x_vec=nodes, cv=uniform_state, eos=eos)
 
     visualizer = make_visualizer(discr)
 
@@ -148,14 +145,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                            t_final=t_final, constant_cfl=constant_cfl)
 
     def my_rhs(t, state):
-        return euler_operator(discr, q=state, t=t,
+        return euler_operator(discr, cv=state, t=t,
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        sim_checkpoint(discr, visualizer, eos, q=state,
-                       exact_soln=initializer, vizname=casename, step=step,
-                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -168,30 +168,29 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             if rank == 0:
                 logger.info(status_msg)
 
-        errors = 0
+        errored = False
         if do_health:
             from mirgecom.simutil import check_naninf_local, check_range_local
             if check_naninf_local(discr, "vol", dv.pressure) \
                or check_range_local(discr, "vol", dv.pressure):
-                errors = 1
+                errored = True
                 message = "Invalid pressure data found.\n"
-            if np.max(component_errors) > exittol:
-                errors = errors + 1
+            if max(component_errors) > exittol:
+                errored = True
                 message += "Solution errors exceed tolerance.\n"
-            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
-            if errors > 0:
+            errored = discr.mpi_communicator.allreduce(errored, op=MPI.LOR)
+            if errored:
                 if rank == 0:
                     logger.info("Fluid solution failed health check.")
                 logger.info(message)   # do this on all ranks
 
-        if do_viz or errors > 0:
+        if do_viz or errored:
             from mirgecom.simutil import sim_visualization
             sim_visualization(discr, io_fields, visualizer, vizname=casename,
                               step=step, t=t, overwrite=True)
 
-        if errors > 0:
-            a = 1/0
-            print(f"{a=}")
+        if errored:
+            raise RuntimeError("Error detected by user checkpoint, exiting.")
 
         return state
 

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -40,7 +40,6 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_checkpoint,
     generate_and_distribute_mesh
 )
 from mirgecom.io import make_init_message
@@ -136,14 +135,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                            t_final=t_final, constant_cfl=constant_cfl)
 
     def my_rhs(t, state):
-        return euler_operator(discr, q=state, t=t,
+        return euler_operator(discr, cv=state, t=t,
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        sim_checkpoint(discr, visualizer, eos, q=state,
-                       exact_soln=initializer, vizname=casename, step=step,
-                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -74,6 +74,7 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
     constant_cfl = False
     nstatus = 1
     nviz = 1
+    nhealth = 1
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -139,6 +140,59 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
+        from mirgecom.simutil import check_step
+        do_status = check_step(step=step, interval=nstatus)
+        do_viz = check_step(step=step, interval=nviz)
+        do_health = check_step(step=step, interval=nhealth)
+
+        if do_status or do_viz or do_health:
+            from mirgecom.simutil import compare_fluid_solutions
+            dv = eos.dependent_vars(state)
+            exact_mix = initializer(x_vec=nodes, eos=eos, t=t)
+            component_errors = compare_fluid_solutions(discr, state, exact_mix)
+            resid = state - exact_mix
+            io_fields = [
+                ("cv", state),
+                ("dv", dv),
+                ("exact_mix", exact_mix),
+                ("resid", resid)
+            ]
+
+        if do_status:  # This is bad, logging already completely replaces this
+            from mirgecom.io import make_status_message
+            status_msg = make_status_message(discr=discr, t=t, step=step, dt=dt,
+                                             cfl=current_cfl, dependent_vars=dv)
+            status_msg += (
+                "\n------- errors="
+                + ", ".join("%.3g" % en for en in component_errors))
+            if rank == 0:
+                logger.info(status_msg)
+
+        errors = 0
+        if do_health:
+            from mirgecom.simutil import check_naninf_local, check_range_local
+            if check_naninf_local(discr, "vol", dv.pressure) \
+               or check_range_local(discr, "vol", dv.pressure):
+                errors = 1
+                message = "Invalid pressure data found.\n"
+            if np.max(component_errors) > exittol:
+                errors = errors + 1
+                message += "Solution errors exceed tolerance.\n"
+            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
+            if errors > 0:
+                if rank == 0:
+                    logger.info("Fluid solution failed health check.")
+                logger.info(message)   # do this on all ranks
+
+        if do_viz or errors > 0:
+            from mirgecom.simutil import sim_visualization
+            sim_visualization(discr, io_fields, visualizer, vizname=casename,
+                              step=step, t=t, overwrite=True)
+
+        if errors > 0:
+            a = 1/0
+            print(f"{a=}")
+
         return state
 
     current_step, current_t, current_state = \

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -158,30 +158,29 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
             if rank == 0:
                 logger.info(status_msg)
 
-        errors = 0
+        errored = False
         if do_health:
             from mirgecom.simutil import check_naninf_local, check_range_local
             if check_naninf_local(discr, "vol", dv.pressure) \
                or check_range_local(discr, "vol", dv.pressure):
-                errors = 1
+                errored = True
                 message = "Invalid pressure data found.\n"
             if np.max(component_errors) > exittol:
-                errors = errors + 1
+                errored = True
                 message += "Solution errors exceed tolerance.\n"
-            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
-            if errors > 0:
+            errored = discr.mpi_communicator.allreduce(errored, op=MPI.LOR)
+            if errored:
                 if rank == 0:
                     logger.info("Fluid solution failed health check.")
                 logger.info(message)   # do this on all ranks
 
-        if do_viz or errors > 0:
+        if do_viz or errored:
             from mirgecom.simutil import sim_visualization
             sim_visualization(discr, io_fields, visualizer, vizname=casename,
                               step=step, t=t, overwrite=True)
 
-        if errors > 0:
-            a = 1/0
-            print(f"{a=}")
+        if errored:
+            raise RuntimeError("Error detected by user checkpoint, exiting.")
 
         return state
 

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -38,7 +38,6 @@ from grudge.shortcuts import make_visualizer
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_checkpoint,
     generate_and_distribute_mesh
 )
 from mirgecom.io import make_init_message
@@ -125,14 +124,10 @@ def main(ctx_factory=cl.create_some_context, use_leap=False):
                            t_final=t_final, constant_cfl=constant_cfl)
 
     def my_rhs(t, state):
-        return euler_operator(discr, q=state, t=t,
+        return euler_operator(discr, cv=state, t=t,
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        sim_checkpoint(discr, visualizer, eos, q=state,
-                       exact_soln=initializer, vizname=casename, step=step,
-                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -40,7 +40,6 @@ from mirgecom.profiling import PyOpenCLProfilingArrayContext
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     inviscid_sim_timestep,
-    sim_checkpoint,
     generate_and_distribute_mesh
 )
 from mirgecom.io import make_init_message
@@ -172,14 +171,10 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
                            t_final=t_final, constant_cfl=constant_cfl)
 
     def my_rhs(t, state):
-        return euler_operator(discr, q=state, t=t,
+        return euler_operator(discr, cv=state, t=t,
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
-        sim_checkpoint(discr, visualizer, eos, q=state,
-                       exact_soln=initializer, vizname=casename, step=step,
-                       t=t, dt=dt, nstatus=nstatus, nviz=nviz,
-                       exittol=exittol, constant_cfl=constant_cfl)
         return state
 
     current_step, current_t, current_state = \

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -102,6 +102,7 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
     constant_cfl = False
     nstatus = 10
     nviz = 10
+    nhealth = 10
     rank = 0
     checkpoint_t = current_t
     current_step = 0
@@ -175,14 +176,63 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
                               boundaries=boundaries, eos=eos)
 
     def my_checkpoint(step, t, dt, state):
+        from mirgecom.simutil import check_step
+        do_status = check_step(step=step, interval=nstatus)
+        do_viz = check_step(step=step, interval=nviz)
+        do_health = check_step(step=step, interval=nhealth)
+
+        if do_status or do_viz or do_health:
+            from mirgecom.simutil import compare_fluid_solutions
+            dv = eos.dependent_vars(state)
+            vortex_exact = initializer(x_vec=nodes, eos=eos, t=t)
+            component_errors = compare_fluid_solutions(discr, state, vortex_exact)
+            resid = state - vortex_exact
+            io_fields = [
+                ("cv", state),
+                ("dv", dv),
+                ("vortex_exact", vortex_exact),
+                ("resid", resid)
+            ]
+
+        if do_status:
+            status_msg = (
+                "\n------- errors="
+                + ", ".join("%.3g" % en for en in component_errors))
+            if rank == 0:
+                logger.info(status_msg)
+
+        errors = 0
+        if do_health:
+            from mirgecom.simutil import check_naninf_local, check_range_local
+            if check_naninf_local(discr, "vol", dv.pressure) \
+               or check_range_local(discr, "vol", dv.pressure):
+                errors = 1
+                message = "Invalid pressure data found.\n"
+            if np.max(component_errors) > exittol:
+                errors = errors + 1
+                message += "Solution errors exceed tolerance.\n"
+            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
+            if errors > 0:
+                if rank == 0:
+                    logger.info("Fluid solution failed health check.")
+                logger.info(message)   # do this on all ranks
+
+        if do_viz or errors > 0:
+            from mirgecom.simutil import sim_visualization
+            sim_visualization(discr, io_fields, visualizer, vizname=casename,
+                              step=step, t=t, overwrite=True)
+
+        if errors > 0:
+            a = 1/0
+            print(f"{a=}")
+
         return state
 
     current_step, current_t, current_state = \
         advance_state(rhs=my_rhs, timestepper=timestepper,
                       pre_step_callback=my_checkpoint,
                       get_timestep=get_timestep, state=current_state,
-                      t=current_t, t_final=t_final,
-                      logmgr=logmgr, eos=eos, dim=dim)
+                      t=current_t, t_final=t_final, eos=eos, dim=dim)
 
     if rank == 0:
         logger.info("Checkpointing final state ...")

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -201,30 +201,29 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
             if rank == 0:
                 logger.info(status_msg)
 
-        errors = 0
+        errored = False
         if do_health:
             from mirgecom.simutil import check_naninf_local, check_range_local
             if check_naninf_local(discr, "vol", dv.pressure) \
                or check_range_local(discr, "vol", dv.pressure):
-                errors = 1
+                errored = True
                 message = "Invalid pressure data found.\n"
             if np.max(component_errors) > exittol:
-                errors = errors + 1
+                errored = True
                 message += "Solution errors exceed tolerance.\n"
-            errors = discr.mpi_communicator.allreduce(errors, op=MPI.SUM)
-            if errors > 0:
+            errored = discr.mpi_communicator.allreduce(errored, op=MPI.LOR)
+            if errored:
                 if rank == 0:
                     logger.info("Fluid solution failed health check.")
                 logger.info(message)   # do this on all ranks
 
-        if do_viz or errors > 0:
+        if do_viz or errored:
             from mirgecom.simutil import sim_visualization
             sim_visualization(discr, io_fields, visualizer, vizname=casename,
                               step=step, t=t, overwrite=True)
 
-        if errors > 0:
-            a = 1/0
-            print(f"{a=}")
+        if errored:
+            raise RuntimeError("Error detected by user checkpoint, exiting.")
 
         return state
 

--- a/mirgecom/eos.py
+++ b/mirgecom/eos.py
@@ -39,7 +39,7 @@ THE SOFTWARE.
 from dataclasses import dataclass
 import numpy as np
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from mirgecom.fluid import ConservedVars, join_conserved
+from mirgecom.fluid import ConservedVars, make_conserved
 
 
 @dataclass
@@ -463,5 +463,5 @@ class PyrometheusMixture(GasEOS):
         mom_source = 0 * cv.momentum
         energy_source = 0 * cv.energy
 
-        return join_conserved(dim, rho_source, energy_source, mom_source,
+        return make_conserved(dim, rho_source, energy_source, mom_source,
                               species_sources)

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -52,8 +52,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
+import numpy as np  # noqa
 from meshmode.dof_array import thaw
+from grudge.symbolic.primitives import TracePair
 from grudge.eager import (
     interior_trace_pair,
     cross_rank_trace_pairs
@@ -70,8 +71,8 @@ from functools import partial
 from mirgecom.flux import lfr_flux
 
 
-def _facial_flux(discr, eos, q_tpair, local=False):
-    """Return the flux across a face given the solution on both sides *q_tpair*.
+def _facial_flux(discr, eos, cv_tpair, local=False):
+    """Return the flux across a face given the solution on both sides *cv_tpair*.
 
     Parameters
     ----------
@@ -79,8 +80,8 @@ def _facial_flux(discr, eos, q_tpair, local=False):
         Implementing the pressure and temperature functions for
         returning pressure and temperature as a function of the state q.
 
-    q_tpair: :class:`grudge.trace_pair.TracePair`
-        Trace pair for the face upon which flux calculation is to be performed
+    cv_tpair: :class:`grudge.trace_pair.TracePair`
+        Trace pair of :class:`ConservedVars` for the face
 
     local: bool
         Indicates whether to skip projection of fluxes to "all_faces" or not. If
@@ -88,25 +89,26 @@ def _facial_flux(discr, eos, q_tpair, local=False):
         "all_faces."  If set to *True*, the returned fluxes are not projected to
         "all_faces"; remaining instead on the boundary restriction.
     """
-    actx = q_tpair[0].int.array_context
-    dim = discr.dim
+    actx = cv_tpair.int.array_context
+    dim = cv_tpair.int.dim
 
     euler_flux = partial(inviscid_flux, discr, eos)
     lam = actx.np.maximum(
-        compute_wavespeed(dim, eos=eos, cv=split_conserved(dim, q_tpair.int)),
-        compute_wavespeed(dim, eos=eos, cv=split_conserved(dim, q_tpair.ext))
+        compute_wavespeed(dim, eos, cv_tpair.int),
+        compute_wavespeed(dim, eos, cv_tpair.ext)
     )
-    normal = thaw(actx, discr.normal(q_tpair.dd))
+    normal = thaw(actx, discr.normal(cv_tpair.dd))
 
     # todo: user-supplied flux routine
-    flux_weak = lfr_flux(q_tpair, flux_func=euler_flux, normal=normal, lam=lam)
+    flux_weak = lfr_flux(cv_tpair=cv_tpair, flux_func=euler_flux,
+                         normal=normal, lam=lam)
 
     if local is False:
-        return discr.project(q_tpair.dd, "all_faces", flux_weak)
+        return discr.project(cv_tpair.dd, "all_faces", flux_weak)
     return flux_weak
 
 
-def euler_operator(discr, eos, boundaries, q, t=0.0):
+def euler_operator(discr, eos, boundaries, cv, t=0.0):
     r"""Compute RHS of the Euler flow equations.
 
     Returns
@@ -121,12 +123,8 @@ def euler_operator(discr, eos, boundaries, q, t=0.0):
 
     Parameters
     ----------
-    q
-        State array which expects at least the canonical conserved quantities
-        (mass, energy, momentum) for the fluid at each point. For multi-component
-        fluids, the conserved quantities should include
-        (mass, energy, momentum, species_mass), where *species_mass* is a vector
-        of species masses.
+    cv: :class:`mirgecom.fluid.ConservedVars`
+        Fluid conserved state object with the conserved variables.
 
     boundaries
         Dictionary of boundary functions, one for each valid btag
@@ -144,35 +142,29 @@ def euler_operator(discr, eos, boundaries, q, t=0.0):
         Agglomerated object array of DOF arrays representing the RHS of the Euler
         flow equations.
     """
-    vol_flux = inviscid_flux(discr, eos, q)
-    dflux = discr.weak_div(vol_flux)
+    vol_weak = discr.weak_div(inviscid_flux(discr=discr, eos=eos, cv=cv).join())
 
-    interior_face_flux = _facial_flux(
-        discr, eos=eos, q_tpair=interior_trace_pair(discr, q))
+    boundary_flux = (
+        _facial_flux(discr=discr, eos=eos, cv_tpair=interior_trace_pair(discr, cv))
+        + sum(
+            _facial_flux(
+                discr, eos=eos,
+                cv_tpair=TracePair(
+                    part_pair.dd,
+                    interior=split_conserved(discr.dim, part_pair.int),
+                    exterior=split_conserved(discr.dim, part_pair.ext)))
+            for part_pair in cross_rank_trace_pairs(discr, cv.join()))
+        + sum(
+            _facial_flux(
+                discr=discr, eos=eos,
+                cv_tpair=boundaries[btag].boundary_pair(
+                    discr, eos=eos, btag=btag, t=t, cv=cv)
+            )
+            for btag in boundaries)
+    ).join()
 
-    # Domain boundaries
-    domain_boundary_flux = sum(
-        _facial_flux(
-            discr,
-            q_tpair=boundaries[btag].boundary_pair(discr,
-                                                   eos=eos,
-                                                   btag=btag,
-                                                   t=t,
-                                                   q=q),
-            eos=eos
-        )
-        for btag in boundaries
-    )
-
-    # Flux across partition boundaries
-    partition_boundary_flux = sum(
-        _facial_flux(discr, eos=eos, q_tpair=part_pair)
-        for part_pair in cross_rank_trace_pairs(discr, q)
-    )
-
-    return discr.inverse_mass(
-        dflux - discr.face_mass(interior_face_flux + domain_boundary_flux
-                                + partition_boundary_flux)
+    return split_conserved(
+        discr.dim, discr.inverse_mass(vol_weak - discr.face_mass(boundary_flux))
     )
 
 
@@ -181,7 +173,7 @@ def inviscid_operator(discr, eos, boundaries, q, t=0.0):
     from warnings import warn
     warn("Do not call inviscid_operator; it is now called euler_operator. This"
          "function will disappear August 1, 2021", DeprecationWarning, stacklevel=2)
-    return euler_operator(discr, eos, boundaries, q, t)
+    return euler_operator(discr, eos, boundaries, split_conserved(discr.dim, q), t)
 
 
 # By default, run unitless
@@ -199,12 +191,11 @@ def units_for_logging(quantity: str) -> str:
     return NAME_TO_UNITS[quantity]
 
 
-def extract_vars_for_logging(dim: int, state: np.ndarray, eos) -> dict:
+def extract_vars_for_logging(dim: int, state, eos) -> dict:
     """Extract state vars."""
-    cv = split_conserved(dim, state)
-    dv = eos.dependent_vars(cv)
+    dv = eos.dependent_vars(state)
 
     from mirgecom.utils import asdict_shallow
-    name_to_field = asdict_shallow(cv)
+    name_to_field = asdict_shallow(state)
     name_to_field.update(asdict_shallow(dv))
     return name_to_field

--- a/mirgecom/fluid.py
+++ b/mirgecom/fluid.py
@@ -6,6 +6,7 @@ State Vector Handling
 .. autoclass:: ConservedVars
 .. autofunction:: split_conserved
 .. autofunction:: join_conserved
+.. autofunction:: make_conserved
 
 Helper Functions
 ^^^^^^^^^^^^^^^^
@@ -290,11 +291,8 @@ def split_conserved(dim, q):
                          species_mass=q[2+dim:2+dim+nspec])
 
 
-def join_conserved(dim, mass, energy, momentum,
-        # empty: immutable
-        species_mass=None):
-    """Create agglomerated array from quantities for each conservation eqn."""
-    if species_mass is None:
+def _join_conserved(dim, mass, energy, momentum, species_mass=None):
+    if species_mass is None:  # empty: immutable
         species_mass = np.empty((0,), dtype=object)
 
     nspec = len(species_mass)
@@ -314,6 +312,20 @@ def join_conserved(dim, mass, energy, momentum,
     result[dim+2:] = species_mass
 
     return result
+
+
+def join_conserved(dim, mass, energy, momentum, species_mass=None):
+    """Create agglomerated array from quantities for each conservation eqn."""
+    return _join_conserved(dim, mass=mass, energy=energy,
+                           momentum=momentum, species_mass=species_mass)
+
+
+def make_conserved(dim, mass, energy, momentum, species_mass=None):
+    """Create :class:`ConservedVars` from separated conserved quantities."""
+    return split_conserved(
+        dim, _join_conserved(dim, mass=mass, energy=energy,
+                             momentum=momentum, species_mass=species_mass)
+    )
 
 
 def velocity_gradient(discr, cv, grad_cv):
@@ -363,7 +375,7 @@ def velocity_gradient(discr, cv, grad_cv):
     velocity = cv.momentum / cv.mass
     return (1/cv.mass)*make_obj_array([grad_cv.momentum[i]
                                        - velocity[i]*grad_cv.mass
-                                       for i in range(discr.dim)])
+                                       for i in range(cv.dim)])
 
 
 def species_mass_fraction_gradient(discr, cv, grad_cv):
@@ -412,7 +424,7 @@ def compute_wavespeed(dim, eos, cv: ConservedVars):
 
     where $\mathbf{v}$ is the flow velocity and c is the speed of sound in the fluid.
     """
-    actx = cv.mass.array_context
+    actx = cv.array_context
 
     v = cv.momentum / cv.mass
     return actx.np.sqrt(np.dot(v, v)) + eos.sound_speed(cv)

--- a/mirgecom/flux.py
+++ b/mirgecom/flux.py
@@ -31,7 +31,7 @@ THE SOFTWARE.
 """
 
 
-def lfr_flux(q_tpair, flux_func, normal, lam):
+def lfr_flux(cv_tpair, flux_func, normal, lam):
     r"""Compute Lax-Friedrichs/Rusanov flux after [Hesthaven_2008]_, Section 6.6.
 
     The Lax-Friedrichs/Rusanov flux is calculated as:
@@ -72,6 +72,7 @@ def lfr_flux(q_tpair, flux_func, normal, lam):
         object array of :class:`meshmode.dof_array.DOFArray` with the
         Lax-Friedrichs/Rusanov flux.
     """
-    flux_avg = 0.5*(flux_func(q_tpair.int)
-                    + flux_func(q_tpair.ext))
-    return flux_avg @ normal - 0.5*lam*(q_tpair.ext - q_tpair.int)
+    flux_avg = 0.5*(flux_func(cv_tpair.int)
+                    + flux_func(cv_tpair.ext))
+    return flux_avg @ normal - 0.5*lam*(cv_tpair.ext
+                                        - cv_tpair.int)

--- a/mirgecom/initializers.py
+++ b/mirgecom/initializers.py
@@ -41,7 +41,7 @@ import numpy as np
 from pytools.obj_array import make_obj_array
 from meshmode.dof_array import thaw
 from mirgecom.eos import IdealSingleGas
-from mirgecom.fluid import split_conserved, join_conserved
+from mirgecom.fluid import make_conserved
 
 
 def make_pulse(amp, r0, w, r):
@@ -168,7 +168,7 @@ class Vortex2D:
 
         energy = p / (gamma - 1) + mass / 2 * (u ** 2 + v ** 2)
 
-        return join_conserved(dim=2, mass=mass, energy=energy,
+        return make_conserved(dim=2, mass=mass, energy=energy,
                               momentum=momentum)
 
 
@@ -262,7 +262,7 @@ class SodShock1D:
             ]
         )
 
-        return join_conserved(dim=self._dim, mass=mass, energy=energy,
+        return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom)
 
 
@@ -370,9 +370,10 @@ class Lump:
         mom = self._velocity * mass
         energy = (self._p0 / (gamma - 1.0)) + np.dot(mom, mom) / (2.0 * mass)
 
-        return join_conserved(dim=self._dim, mass=mass, energy=energy, momentum=mom)
+        return make_conserved(dim=self._dim, mass=mass, energy=energy,
+                              momentum=mom)
 
-    def exact_rhs(self, discr, q, t=0.0):
+    def exact_rhs(self, discr, cv, t=0.0):
         """
         Create the RHS for the lump-of-mass solution at time *t*, locations *x_vec*.
 
@@ -387,7 +388,7 @@ class Lump:
         t: float
             Time at which RHS is desired
         """
-        actx = q[0].array_context
+        actx = cv.array_context
         nodes = thaw(actx, discr.nodes())
         lump_loc = self._center + t * self._velocity
         # coordinates relative to lump center
@@ -410,7 +411,7 @@ class Lump:
         energyrhs = -v2 * rdotv * mass
         momrhs = v * (-2 * mass * rdotv)
 
-        return join_conserved(dim=self._dim, mass=massrhs, energy=energyrhs,
+        return make_conserved(dim=self._dim, mass=massrhs, energy=energyrhs,
                               momentum=momrhs)
 
 
@@ -546,10 +547,10 @@ class MulticomponentLump:
             expterm = self._spec_amplitudes[i] * actx.np.exp(-r2)
             species_mass[i] = self._rho0 * (self._spec_y0s[i] + expterm)
 
-        return join_conserved(dim=self._dim, mass=mass, energy=energy,
+        return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom, species_mass=species_mass)
 
-    def exact_rhs(self, discr, q, t=0.0):
+    def exact_rhs(self, discr, cv, t=0.0):
         """
         Create a RHS for multi-component lump soln at time *t*, locations *x_vec*.
 
@@ -564,7 +565,7 @@ class MulticomponentLump:
         t: float
             Time at which RHS is desired
         """
-        actx = q[0].array_context
+        actx = cv.array_context
         nodes = thaw(actx, discr.nodes())
         loc_update = t * self._velocity
 
@@ -585,7 +586,7 @@ class MulticomponentLump:
             expterm = self._spec_amplitudes[i] * actx.np.exp(-r2)
             specrhs[i] = 2 * self._rho0 * expterm * np.dot(rel_pos, v)
 
-        return join_conserved(dim=self._dim, mass=massrhs, energy=energyrhs,
+        return make_conserved(dim=self._dim, mass=massrhs, energy=energyrhs,
                               momentum=momrhs, species_mass=specrhs)
 
 
@@ -637,7 +638,7 @@ class AcousticPulse:
         self._width = width
         self._dim = dim
 
-    def __call__(self, x_vec, q, eos=None):
+    def __call__(self, x_vec, cv, eos=None):
         """
         Create the acoustic pulse at locations *x_vec*.
 
@@ -655,11 +656,10 @@ class AcousticPulse:
         if x_vec.shape != (self._dim,):
             raise ValueError(f"Expected {self._dim}-dimensional inputs.")
 
-        cv = split_conserved(self._dim, q)
         return cv.replace(
             energy=cv.energy + make_pulse(
                 amp=self._amp, w=self._width, r0=self._center, r=x_vec)
-            ).join()
+        )
 
 
 class Uniform:
@@ -744,10 +744,10 @@ class Uniform:
         energy = (self._p / (gamma - 1.0)) + np.dot(mom, mom) / (2.0 * mass)
         species_mass = self._mass_fracs * mass
 
-        return join_conserved(dim=self._dim, mass=mass, energy=energy,
+        return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom, species_mass=species_mass)
 
-    def exact_rhs(self, discr, q, t=0.0):
+    def exact_rhs(self, discr, cv, t=0.0):
         """
         Create the RHS for the uniform solution. (Hint - it should be all zero).
 
@@ -759,7 +759,7 @@ class Uniform:
         t: float
             Time at which RHS is desired (unused)
         """
-        actx = q[0].array_context
+        actx = cv.array_context
         nodes = thaw(actx, discr.nodes())
         mass = nodes[0].copy()
         mass[:] = 1.0
@@ -768,7 +768,7 @@ class Uniform:
         momrhs = make_obj_array([0 * mass for i in range(self._dim)])
         yrhs = make_obj_array([0 * mass for i in range(self._nspecies)])
 
-        return join_conserved(dim=self._dim, mass=massrhs, energy=energyrhs,
+        return make_conserved(dim=self._dim, mass=massrhs, energy=energyrhs,
                               momentum=momrhs, species_mass=yrhs)
 
 
@@ -851,5 +851,5 @@ class MixtureInitializer:
         kinetic_energy = 0.5 * np.dot(velocity, velocity)
         energy = mass * (internal_energy + kinetic_energy)
 
-        return join_conserved(dim=self._dim, mass=mass, energy=energy,
+        return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom, species_mass=specmass)

--- a/mirgecom/inviscid.py
+++ b/mirgecom/inviscid.py
@@ -37,14 +37,11 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from mirgecom.fluid import (
-    split_conserved,
-    join_conserved
-)
+from mirgecom.fluid import make_conserved
 
 
-def inviscid_flux(discr, eos, q):
-    r"""Compute the inviscid flux vectors from flow solution *q*.
+def inviscid_flux(discr, eos, cv):
+    r"""Compute the inviscid flux vectors from fluid conserved vars *cv*.
 
     The inviscid fluxes are
     $(\rho\vec{V},(\rho{E}+p)\vec{V},\rho(\vec{V}\otimes\vec{V})
@@ -52,31 +49,24 @@ def inviscid_flux(discr, eos, q):
 
     .. note::
 
-        The fluxes are returned as a 2D object array with shape:
-        ``(num_equations, ndim)``.  Each entry in the
-        flux array is a :class:`~meshmode.dof_array.DOFArray`.  This
-        form and shape for the flux data is required by the built-in
-        state data handling mechanism in :mod:`mirgecom.fluid`. That
-        mechanism is used by at least
-        :class:`mirgecom.fluid.ConservedVars`, and
-        :func:`mirgecom.fluid.join_conserved`, and
-        :func:`mirgecom.fluid.split_conserved`.
+        The fluxes are returned as a :class:`mirgecom.fluid.ConservedVars`
+        object with a *dim-vector* for each conservation equation. See
+        :class:`mirgecom.fluid.ConservedVars` for more information about
+        how the fluxes are represented.
     """
-    dim = discr.dim
-    cv = split_conserved(dim, q)
+    dim = cv.dim
     p = eos.pressure(cv)
 
     mom = cv.momentum
 
-    return join_conserved(dim,
-            mass=mom,
-            energy=mom * (cv.energy + p) / cv.mass,
-            momentum=np.outer(mom, mom) / cv.mass + np.eye(dim)*p,
-            species_mass=(  # reshaped: (nspecies, dim)
-                (mom / cv.mass) * cv.species_mass.reshape(-1, 1)))
+    return make_conserved(
+        dim, mass=mom, energy=mom * (cv.energy + p) / cv.mass,
+        momentum=np.outer(mom, mom) / cv.mass + np.eye(dim)*p,
+        species_mass=(  # reshaped: (nspecies, dim)
+            (mom / cv.mass) * cv.species_mass.reshape(-1, 1)))
 
 
-def get_inviscid_timestep(discr, eos, cfl, q):
+def get_inviscid_timestep(discr, eos, cfl, cv):
     """Routine (will) return the (local) maximum stable inviscid timestep.
 
     Currently, it's a hack waiting for the geometric_factor helpers port
@@ -99,7 +89,7 @@ def get_inviscid_timestep(discr, eos, cfl, q):
 #    return c*dt_ngf*dt_gf/max_v
 
 
-def get_inviscid_cfl(discr, eos, dt, q):
+def get_inviscid_cfl(discr, eos, dt, cv):
     """Calculate and return CFL based on current state and timestep."""
-    wanted_dt = get_inviscid_timestep(discr, eos=eos, cfl=1.0, q=q)
+    wanted_dt = get_inviscid_timestep(discr, eos=eos, cfl=1.0, cv=cv)
     return dt / wanted_dt

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -103,6 +103,10 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
 
         cl.array.ARRAY_KERNEL_EXEC_HOOK = self.array_kernel_exec_hook
 
+    def clone(self):
+        """Return a semantically equivalent but distinct version of *self*."""
+        return type(self)(self.queue, self.allocator, self.logmgr)
+
     def __del__(self):
         """Release resources and undo monkey patching."""
         del self.profile_events[:]

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -5,12 +5,14 @@ General utilities
 
 .. autofunction:: check_step
 .. autofunction:: inviscid_sim_timestep
+.. autofunction:: sim_visualization
 
-Diagnostic callbacks
+Diagnostic utilities
 --------------------
 
-.. autofunction:: sim_visualization
-.. autofunction:: compare_with_analytic_solution
+.. autofunction:: compare_fluid_solutions
+.. autofunction:: check_naninf_local
+.. autofunction:: check_range_local
 
 Mesh utilities
 --------------
@@ -45,8 +47,6 @@ THE SOFTWARE.
 import logging
 
 import numpy as np
-# from meshmode.dof_array import thaw
-# from mirgecom.io import make_status_message
 from mirgecom.inviscid import get_inviscid_timestep  # bad smell?
 import grudge.op as op
 
@@ -128,14 +128,14 @@ def sim_visualization(discr, io_fields, visualizer, vizname,
 def check_range_local(discr, dd, field, min_value=0, max_value=np.inf):
     """Check for any negative values."""
     return (
-        op.nodal_min_local(discr, dd, field) < min_value
-        or op.nodal_max_local(discr, dd, field) > max_value
+        op.nodal_min_loc(discr, dd, field) < min_value
+        or op.nodal_max_loc(discr, dd, field) > max_value
     )
 
 
 def check_naninf_local(discr, dd, field):
     """Check for any NANs or Infs in the field."""
-    s = op.nodal_sum_local(discr, dd, field)
+    s = op.nodal_sum_loc(discr, dd, field)
     return np.isnan(s) or (s == np.inf)
 
 

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -47,10 +47,11 @@ THE SOFTWARE.
 import logging
 
 import numpy as np
-from meshmode.dof_array import thaw
-from mirgecom.io import make_status_message
+# from meshmode.dof_array import thaw
+# from mirgecom.io import make_status_message
 from mirgecom.inviscid import get_inviscid_timestep  # bad smell?
-from mirgecom.exceptions import SynchronizedError, SimulationHealthError
+from mirgecom.exceptions import SimulationHealthError
+import grudge.op as op
 
 logger = logging.getLogger(__name__)
 
@@ -88,52 +89,35 @@ def inviscid_sim_timestep(discr, state, t, dt, cfl, eos,
     return mydt
 
 
-def sim_visualization(discr, eos, state, visualizer, vizname,
-                      step=0, t=0,
-                      exact_soln=None, viz_fields=None,
-                      overwrite=False, vis_timer=None):
+def sim_visualization(discr, io_fields, visualizer, vizname,
+                      step=0, t=0, overwrite=False, vis_timer=None):
     """Visualize the simulation fields.
 
-    Write VTK output of the conserved state and and specified derived
-    quantities *viz_fields*.
+    Write VTK output for the specified fields.
 
     Parameters
     ----------
-    eos: mirgecom.eos.GasEOS
-        Implementing the pressure and temperature functions for
-        returning pressure and temperature as a function of the state.
-    state
-        State array which expects at least the conserved quantities
-        (mass, energy, momentum) for the fluid at each point. For multi-component
-        fluids, the conserved quantities should include
-        (mass, energy, momentum, species_mass), where *species_mass* is a vector
-        of species masses.
     visualizer:
         A :class:`meshmode.discretization.visualization.Visualizer`
         VTK output object.
+    io_fields:
+        List of tuples indicating the (name, data) for each field to write.
     """
     from contextlib import nullcontext
-    from mirgecom.fluid import split_conserved
     from mirgecom.io import make_rank_fname, make_par_fname
 
-    cv = split_conserved(discr.dim, state)
-    dependent_vars = eos.dependent_vars(cv)
+    # io_fields = [
+    #     ("cv", cv),
+    #     ("dv", dependent_vars)
+    # ]
+    # if exact_soln is not None:
+    #     exact_list = [
+    #         ("exact_soln", exact_soln),
+    #     ]
+    #     io_fields.extend(exact_list)
 
-    io_fields = [
-        ("cv", cv),
-        ("dv", dependent_vars)
-    ]
-    if exact_soln is not None:
-        actx = cv.mass.array_context
-        nodes = thaw(actx, discr.nodes())
-        expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
-        exact_list = [
-            ("exact_soln", expected_state),
-        ]
-        io_fields.extend(exact_list)
-
-    if viz_fields is not None:
-        io_fields.extend(viz_fields)
+    # if viz_fields is not None:
+    #     io_fields.extend(viz_fields)
 
     comm = discr.mpi_communicator
     rank = 0
@@ -157,95 +141,106 @@ def sim_visualization(discr, eos, state, visualizer, vizname,
         )
 
 
-def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
-                   step=0, t=0, dt=0, cfl=1.0, nstatus=-1, nviz=-1, exittol=1e-16,
-                   constant_cfl=False, viz_fields=None, overwrite=False,
-                   vis_timer=None):
-    """Checkpoint the simulation status.
+# def sim_checkpoint(discr, visualizer, eos, q, vizname, exact_soln=None,
+#                    step=0, t=0, dt=0, cfl=1.0, nstatus=-1, nviz=-1, exittol=1e-16,
+#                   constant_cfl=False, viz_fields=None, overwrite=False,
+#                    vis_timer=None):
+#    """Checkpoint the simulation status.
+#
+#    Checkpoints the simulation status by reporting relevant diagnostic
+#     quantities, such as pressure/temperature, and visualization.
+#
+#     Parameters
+#     ----------
+#    eos: mirgecom.eos.GasEOS
+#        Implementing the pressure and temperature functions for
+#         returning pressure and temperature as a function of the state *q*.
+#     q
+#         State array which expects at least the conserved quantities
+#         (mass, energy, momentum) for the fluid at each point. For multi-component
+#         fluids, the conserved quantities should include
+#         (mass, energy, momentum, species_mass), where *species_mass* is a vector
+#         of species masses.
+#     nstatus: int
+#         An integer denoting the step frequency for performing status checks.
+#     nviz: int
+#         An integer denoting the step frequency for writing vtk output.
+#     """
+#     exception = None
+#     comm = discr.mpi_communicator
+#     rank = 0
+#     if comm is not None:
+#         rank = comm.Get_rank()
+#
+#     try:
+#         # Status checks
+#         if check_step(step=step, interval=nstatus):
+#            from mirgecom.fluid import split_conserved
+#
+#             #        if constant_cfl is False:
+#             #            current_cfl = get_inviscid_cfl(discr=discr, q=q,
+#             #                                           eos=eos, dt=dt)
+#
+#             cv = split_conserved(discr.dim, q)
+#             dependent_vars = eos.dependent_vars(cv)
+#             msg = make_status_message(discr=discr,
+#  #                                    t=t, step=step, dt=dt, cfl=cfl,
+#                                    dependent_vars=dependent_vars)
+#             if rank == 0:
+#                 logger.info(msg)
+#
+#             # Check the health of the simulation
+#             sim_healthcheck(discr, eos, q, step=step, t=t)
+#
+#             # Compare with exact solution, if provided
+#             if exact_soln is not None:
+#                 compare_with_analytic_solution(
+#                     discr, eos, q, exact_soln,
+#                     step=step, t=t, exittol=exittol
+#                 )
+#
+#         # Visualization
+#         if check_step(step=step, interval=nviz):
+#             sim_visualization(
+#                 discr, eos, q, visualizer, vizname,
+#                step=step, t=t,
+#                 exact_soln=exact_soln, viz_fields=viz_fields,
+#                 overwrite=overwrite, vis_timer=vis_timer
+#             )
+#     except SynchronizedError as err:
+#         exception = err
+#
+#     terminate = True if exception is not None else False
+#
+#     if comm is not None:
+#         from mpi4py import MPI
+#
+#        terminate = comm.allreduce(terminate, MPI.LOR)
+#
+#     if terminate:
+#        if rank == 0:
+#            logger.info("Visualizing crashed state ...")
+#
+#         # Write out crashed field
+#         sim_visualization(discr, eos, q,
+#                           visualizer, vizname=vizname,
+#                           step=step, t=t,
+#                           viz_fields=viz_fields)
+#         raise exception
 
-    Checkpoints the simulation status by reporting relevant diagnostic
-    quantities, such as pressure/temperature, and visualization.
 
-    Parameters
-    ----------
-    eos: mirgecom.eos.GasEOS
-        Implementing the pressure and temperature functions for
-        returning pressure and temperature as a function of the state *q*.
-    q
-        State array which expects at least the conserved quantities
-        (mass, energy, momentum) for the fluid at each point. For multi-component
-        fluids, the conserved quantities should include
-        (mass, energy, momentum, species_mass), where *species_mass* is a vector
-        of species masses.
-    nstatus: int
-        An integer denoting the step frequency for performing status checks.
-    nviz: int
-        An integer denoting the step frequency for writing vtk output.
-    """
-    exception = None
-    comm = discr.mpi_communicator
-    rank = 0
-    if comm is not None:
-        rank = comm.Get_rank()
-
-    try:
-        # Status checks
-        if check_step(step=step, interval=nstatus):
-            from mirgecom.fluid import split_conserved
-
-            #        if constant_cfl is False:
-            #            current_cfl = get_inviscid_cfl(discr=discr, q=q,
-            #                                           eos=eos, dt=dt)
-
-            cv = split_conserved(discr.dim, q)
-            dependent_vars = eos.dependent_vars(cv)
-            msg = make_status_message(discr=discr,
-                                    t=t, step=step, dt=dt, cfl=cfl,
-                                    dependent_vars=dependent_vars)
-            if rank == 0:
-                logger.info(msg)
-
-            # Check the health of the simulation
-            sim_healthcheck(discr, eos, q, step=step, t=t)
-
-            # Compare with exact solution, if provided
-            if exact_soln is not None:
-                compare_with_analytic_solution(
-                    discr, eos, q, exact_soln,
-                    step=step, t=t, exittol=exittol
-                )
-
-        # Visualization
-        if check_step(step=step, interval=nviz):
-            sim_visualization(
-                discr, eos, q, visualizer, vizname,
-                step=step, t=t,
-                exact_soln=exact_soln, viz_fields=viz_fields,
-                overwrite=overwrite, vis_timer=vis_timer
-            )
-    except SynchronizedError as err:
-        exception = err
-
-    terminate = True if exception is not None else False
-
-    if comm is not None:
-        from mpi4py import MPI
-
-        terminate = comm.allreduce(terminate, MPI.LOR)
-
-    if terminate:
-        if rank == 0:
-            logger.info("Visualizing crashed state ...")
-
-        # Write out crashed field
-        sim_visualization(discr, eos, q,
-                          visualizer, vizname=vizname,
-                          step=step, t=t,
-                          viz_fields=viz_fields)
-        raise exception
+def check_negative_local(discr, dd, field):
+    """Check for any negative values."""
+    return op.nodal_min_loc(discr, dd, field) < 0
 
 
-def sim_healthcheck(discr, eos, state, step=0, t=0):
+def check_naninf_local(discr, dd, field):
+    """Check for any NANs or Infs in the field."""
+    s = op.nodal_sum_local(discr, dd, field)
+    return np.isnan(s) or (s == np.inf)
+
+
+def sim_healthcheck(discr, eos, cv):
     """Check the global health of the fluids state.
 
     Determine the health of a state by inspecting for unphyiscal
@@ -256,100 +251,77 @@ def sim_healthcheck(discr, eos, state, step=0, t=0):
     eos: mirgecom.eos.GasEOS
         Implementing the pressure and temperature functions for
         returning pressure and temperature as a function of the state.
-    state
-        State array which expects at least the conserved quantities
-        (mass, energy, momentum) for the fluid at each point. For multi-component
-        fluids, the conserved quantities should include
-        (mass, energy, momentum, species_mass), where *species_mass* is a vector
-        of species masses.
+    cv: :class:`~mirgecom.fluid.ConservedVars`
+        The fluid conserved variables
     """
-    from mirgecom.fluid import split_conserved
-    import grudge.op as op
-
     # NOTE: Derived quantities are functions of the conserved variables.
     # Therefore is it sufficient to check for unphysical values of
-    # temperature and pressure.
-    cv = split_conserved(discr.dim, state)
-    dependent_vars = eos.dependent_vars(cv)
-    pressure = dependent_vars.pressure
-    temperature = dependent_vars.temperature
-
-    # Check for NaN
-    if (np.isnan(op.nodal_sum_loc(discr, "vol", pressure))
-            or np.isnan(op.nodal_sum_loc(discr, "vol", temperature))):
-        raise SimulationHealthError(
-            message=("Simulation exited abnormally; detected a NaN.")
-        )
-
-    # Check for non-positivity
-    if (op.nodal_min_loc(discr, "vol", pressure) < 0
-            or op.nodal_min_loc(discr, "vol", temperature) < 0):
-        raise SimulationHealthError(
-            message=("Simulation exited abnormally; "
-                        "found non-positive values for pressure or temperature.")
-        )
-
-    # Check for blow-up
-    if (op.nodal_sum_loc(discr, "vol", pressure) == np.inf
-            or op.nodal_sum_loc(discr, "vol", temperature) == np.inf):
-        raise SimulationHealthError(
-            message=("Simulation exited abnormally; "
-                        "derived quantities are not finite.")
-        )
+    # pressure.  Temperature is not needed.
+    from mpi4py import MPI
+    errors = 0
+    pressure = eos.pressure(cv)
+    if check_naninf_local(discr, "vol", pressure) \
+       or check_negative_local(discr, "vol", pressure):
+        errors = 1
+        message = "Invalid data found in dependent variables."
+    if discr.mpi_communicator.allreduce(errors, op=MPI.SUM) > 0:
+        raise SimulationHealthError(message=message)
 
 
-def compare_with_analytic_solution(discr, eos, state, exact_soln,
-                                   step=0, t=0, exittol=None):
-    """Compute the infinite norm of the problem residual.
+def compare_fluid_solutions(discr, red_state, blue_state):
+    """Return inf norm of (*red_state* - *blue_state*) for each component."""
+    resid = red_state - blue_state
+    return [discr.norm(v, np.inf) for v in resid.join()]
 
-    Computes the infinite norm of the residual with respect to a specified
-    exact solution *exact_soln*. If the error is larger than *exittol*,
-    raises a :class:`mirgecom.exceptions.SimulationHealthError`.
 
-    Parameters
-    ----------
-    eos: mirgecom.eos.GasEOS
-        Implementing the pressure and temperature functions for
-        returning pressure and temperature as a function of the state.
-    state
-        State array which expects at least the conserved quantities
-        (mass, energy, momentum) for the fluid at each point. For multi-component
-        fluids, the conserved quantities should include
-        (mass, energy, momentum, species_mass), where *species_mass* is a vector
-        of species masses.
-    exact_soln:
-        A callable for the exact solution with signature:
-        ``exact_soln(x_vec, t, eos)`` where `x_vec` are the nodes,
-        `t` is time, and `eos` is a :class:`mirgecom.eos.GasEOS`.
-    """
-    if exittol is None:
-        exittol = 1e-16
+# def compare_with_analytic_solution(discr, eos, state, exact_soln,
+#                                    step=0, t=0, exittol=None):
+#     """Compute the infinite norm of the problem residual.
+#
+#     Computes the infinite norm of the residual with respect to a specified
+#     exact solution *exact_soln*. If the error is larger than *exittol*,
+#     raises a :class:`mirgecom.exceptions.SimulationHealthError`.
+#
+#     Parameters
+#     ----------
+#     eos: mirgecom.eos.GasEOS
+#         Implementing the pressure and temperature functions for
+#        returning pressure and temperature as a function of the state.
+#     state: :class:`ConservedVars`
+#         Fluid solution
+#     exact_soln:
+#         A callable for the exact solution with signature:
+#         ``exact_soln(x_vec, eos, t)`` where `x_vec` are the nodes,
+#         `t` is time, and `eos` is a :class:`mirgecom.eos.GasEOS`.
+#     """
+#     if exittol is None:
+#         exittol = 1e-16
 
-    actx = discr._setup_actx
-    nodes = thaw(actx, discr.nodes())
-    expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
-    exp_resid = state - expected_state
-    norms = [discr.norm(v, np.inf) for v in exp_resid]
+#    actx = discr._setup_actx
+#     nodes = thaw(actx, discr.nodes())
+#     expected_state = exact_soln(x_vec=nodes, t=t, eos=eos)
+#     exp_resid = state - expected_state
+#     norms = [discr.norm(v, np.inf) for v in exp_resid]
 
-    comm = discr.mpi_communicator
-    rank = 0
-    if comm is not None:
-        rank = comm.Get_rank()
+#     comm = discr.mpi_communicator
+#     rank = 0
+#     if comm is not None:
+#         rank = comm.Get_rank()
 
-    statusmesg = (
-        f"Errors: {step=} {t=}\n"
-        f"------- errors = "
-        + ", ".join("%.3g" % err_norm for err_norm in norms)
-    )
+#     statusmesg = (
+#         f"Errors: {step=} {t=}\n"
+#         f"------- errors = "
+#         + ", ".join("%.3g" % err_norm for err_norm in norms)
+#     )
 
-    if rank == 0:
-        logger.info(statusmesg)
+#     if rank == 0:
+#         logger.info(statusmesg)
 
-    if max(norms) > exittol:
-        raise SimulationHealthError(
-            message=("Simulation exited abnormally; "
-                        "solution doesn't agree with analytic result.")
-        )
+#     if max(norms) > exittol:
+#         raise SimulationHealthError(
+#             message=("Simulation exited abnormally; "
+#                         "solution doesn't agree with analytic result.")
+#        )
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -31,7 +31,6 @@ import pytest
 
 from meshmode.dof_array import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from mirgecom.fluid import split_conserved
 from mirgecom.initializers import Lump
 from mirgecom.boundary import AdiabaticSlipBoundary
 from mirgecom.eos import IdealSingleGas
@@ -69,9 +68,6 @@ def test_slipwall_identity(actx_factory, dim):
     eos = IdealSingleGas()
     orig = np.zeros(shape=(dim,))
     nhat = thaw(actx, discr.normal(BTAG_ALL))
-    #    normal_mag = actx.np.sqrt(np.dot(normal, normal))
-    #    nhat_mult = 1.0 / normal_mag
-    #    nhat = normal * make_obj_array([nhat_mult])
 
     logger.info(f"Number of {dim}d elems: {mesh.nelements}")
 
@@ -88,24 +84,23 @@ def test_slipwall_identity(actx_factory, dim):
             from functools import partial
             bnd_norm = partial(discr.norm, p=np.inf, dd=BTAG_ALL)
 
-            bnd_pair = wall.boundary_pair(discr, uniform_state, t=0.0,
-                                          btag=BTAG_ALL, eos=eos)
-            bnd_cv_int = split_conserved(dim, bnd_pair.int)
-            bnd_cv_ext = split_conserved(dim, bnd_pair.ext)
+            bnd_pair = wall.boundary_pair(discr, btag=BTAG_ALL,
+                                          eos=eos, cv=uniform_state)
 
             # check that mass and energy are preserved
-            mass_resid = bnd_cv_int.mass - bnd_cv_ext.mass
+            mass_resid = bnd_pair.int.mass - bnd_pair.ext.mass
             mass_err = bnd_norm(mass_resid)
             assert mass_err == 0.0
-            energy_resid = bnd_cv_int.energy - bnd_cv_ext.energy
+
+            energy_resid = bnd_pair.int.energy - bnd_pair.ext.energy
             energy_err = bnd_norm(energy_resid)
             assert energy_err == 0.0
 
             # check that exterior momentum term is mom_interior - 2 * mom_normal
-            mom_norm_comp = np.dot(bnd_cv_int.momentum, nhat)
+            mom_norm_comp = np.dot(bnd_pair.int.momentum, nhat)
             mom_norm = nhat * mom_norm_comp
-            expected_mom_ext = bnd_cv_int.momentum - 2.0 * mom_norm
-            mom_resid = bnd_cv_ext.momentum - expected_mom_ext
+            expected_mom_ext = bnd_pair.int.momentum - 2.0 * mom_norm
+            mom_resid = bnd_pair.ext.momentum - expected_mom_ext
             mom_err = bnd_norm(mom_resid)
 
             assert mom_err == 0.0
@@ -153,19 +148,17 @@ def test_slipwall_flux(actx_factory, dim, order):
                 from mirgecom.initializers import Uniform
                 initializer = Uniform(dim=dim, velocity=vel)
                 uniform_state = initializer(nodes)
-                bnd_pair = wall.boundary_pair(discr, uniform_state, t=0.0,
-                                              btag=BTAG_ALL, eos=eos)
+                bnd_pair = wall.boundary_pair(discr, btag=BTAG_ALL,
+                                              eos=eos, cv=uniform_state)
 
                 # Check the total velocity component normal
                 # to each surface.  It should be zero.  The
                 # numerical fluxes cannot be zero.
                 avg_state = 0.5*(bnd_pair.int + bnd_pair.ext)
-                acv = split_conserved(dim, avg_state)
-                err_max = max(err_max, bnd_norm(np.dot(acv.momentum, nhat)))
+                err_max = max(err_max, bnd_norm(np.dot(avg_state.momentum, nhat)))
 
                 from mirgecom.euler import _facial_flux
-                bnd_flux = split_conserved(dim, _facial_flux(discr, eos,
-                                                             bnd_pair, local=True))
+                bnd_flux = _facial_flux(discr, eos, cv_tpair=bnd_pair, local=True)
                 err_max = max(err_max, bnd_norm(bnd_flux.mass),
                               bnd_norm(bnd_flux.energy))
 

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -38,12 +38,16 @@ from pytools.obj_array import (
     make_obj_array,
 )
 
-from meshmode.dof_array import DOFArray, thaw
+from meshmode.dof_array import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from grudge.eager import interior_trace_pair
 from grudge.symbolic.primitives import TracePair
 from mirgecom.euler import euler_operator
-from mirgecom.fluid import split_conserved, join_conserved
+from mirgecom.fluid import (
+    split_conserved,
+    join_conserved,
+    make_conserved
+)
 from mirgecom.initializers import Vortex2D, Lump, MulticomponentLump
 from mirgecom.boundary import PrescribedBoundary, DummyBoundary
 from mirgecom.eos import IdealSingleGas
@@ -126,23 +130,16 @@ def test_inviscid_flux(actx_factory, nspecies, dim):
     for i in range(nspecies):
         expected_flux[dim+2+i] = mom * mass_fractions[i]
 
+    expected_flux = split_conserved(dim, expected_flux)
+
     # }}}
 
-    flux = inviscid_flux(discr, eos, q)
+    flux = inviscid_flux(discr, eos, cv)
     flux_resid = flux - expected_flux
 
     for i in range(numeq, dim):
         for j in range(dim):
             assert (la.norm(flux_resid[i, j].get())) == 0.0
-
-
-class MyDiscr:
-    def __init__(self, dim, nnodes):
-        self.dim = dim
-        self.nnodes = nnodes
-
-    def zeros(self, actx, dtype=np.float64):
-        return DOFArray(actx, (actx.zeros((1, self.nnodes), dtype=dtype),))
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
@@ -165,6 +162,18 @@ def test_inviscid_flux_components(actx_factory, dim):
 
     p0 = 1.0
 
+    nel_1d = 4
+
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    mesh = generate_regular_rect_mesh(
+        a=(-0.5,) * dim, b=(0.5,) * dim, nelements_per_axis=(nel_1d,) * dim
+    )
+
+    order = 3
+    discr = EagerDGDiscretization(actx, mesh, order=order)
+    eos = IdealSingleGas()
+
+    logger.info(f"Number of {dim}d elems: {mesh.nelements}")
     # === this next block tests 1,2,3 dimensions,
     # with single and multiple nodes/states. The
     # purpose of this block is to ensure that when
@@ -172,37 +181,24 @@ def test_inviscid_flux_components(actx_factory, dim):
     # the expected values (and p0 within tolerance)
     # === with V = 0, fixed P = p0
     tolerance = 1e-15
-    for ntestnodes in [1, 10]:
-        discr = MyDiscr(dim, ntestnodes)
-        mass = discr.zeros(actx)
-        mass_values = np.empty((1, ntestnodes), dtype=np.float64)
-        mass_values[0] = np.linspace(1., ntestnodes, ntestnodes, dtype=np.float64)
-        mass[0].set(mass_values)
-        mom = make_obj_array([discr.zeros(actx) for _ in range(dim)])
-        p = discr.zeros(actx) + p0
-        energy = p / 0.4 + 0.5 * np.dot(mom, mom) / mass
-        q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
-        cv = split_conserved(dim, q)
-        p = eos.pressure(cv)
-        flux = inviscid_flux(discr, eos, q)
+    nodes = thaw(actx, discr.nodes())
+    mass = discr.zeros(actx) + np.dot(nodes, nodes) + 1.0
+    mom = make_obj_array([discr.zeros(actx) for _ in range(dim)])
+    p_exact = discr.zeros(actx) + p0
+    energy = p_exact / 0.4 + 0.5 * np.dot(mom, mom) / mass
+    cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
+    p = eos.pressure(cv)
+    flux = inviscid_flux(discr, eos, cv)
+    assert discr.norm(p - p_exact, np.inf) < tolerance
+    logger.info(f"{dim}d flux = {flux}")
 
-        logger.info(f"{dim}d flux = {flux}")
+    # for velocity zero, these components should be == zero
+    assert discr.norm(flux.mass, 2) == 0.0
+    assert discr.norm(flux.energy, 2) == 0.0
 
-        # for velocity zero, these components should be == zero
-        for i in range(2):
-            for j in range(dim):
-                assert (flux[i, j][0].get() == 0.0).all()
-
-        # The momentum diagonal should be p
-        # Off-diagonal should be identically 0
-        for i in range(dim):
-            for j in range(dim):
-                print(f"(i,j) = ({i},{j})")
-                if i != j:
-                    assert (flux[2 + i, j][0].get() == 0.0).all()
-                else:
-                    assert (flux[2 + i, j] == p)[0].get().all()
-                    assert (np.abs(flux[2 + i, j][0].get() - p0) < tolerance).all()
+    # The momentum diagonal should be p
+    # Off-diagonal should be identically 0
+    assert discr.norm(flux.momentum - p0*np.identity(dim), np.inf) < tolerance
 
 
 @pytest.mark.parametrize(("dim", "livedim"), [
@@ -225,75 +221,42 @@ def test_inviscid_mom_flux_components(actx_factory, dim, livedim):
 
     p0 = 1.0
 
+    nel_1d = 4
+
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    mesh = generate_regular_rect_mesh(
+        a=(-0.5,) * dim, b=(0.5,) * dim, nelements_per_axis=(nel_1d,) * dim
+    )
+
+    order = 3
+    discr = EagerDGDiscretization(actx, mesh, order=order)
+    nodes = thaw(actx, discr.nodes())
+
     tolerance = 1e-15
     for livedim in range(dim):
-        for ntestnodes in [1, 10]:
-            discr = MyDiscr(dim, ntestnodes)
-            mass = discr.zeros(actx)
-            mass_values = np.empty((1, ntestnodes), dtype=np.float64)
-            mass_values[0] = np.linspace(1., ntestnodes, ntestnodes,
-                        dtype=np.float64)
-            mass[0].set(mass_values)
-            mom = make_obj_array([discr.zeros(actx) for _ in range(dim)])
-            mom[livedim] = mass
-            p = discr.zeros(actx) + p0
-            energy = (
-                p / (eos.gamma() - 1.0)
-                + 0.5 * np.dot(mom, mom) / mass
-            )
-            q = join_conserved(dim, mass=mass, energy=energy, momentum=mom)
-            cv = split_conserved(dim, q)
-            p = eos.pressure(cv)
+        mass = discr.zeros(actx) + 1.0 + np.dot(nodes, nodes)
+        mom = make_obj_array([discr.zeros(actx) for _ in range(dim)])
+        mom[livedim] = mass
+        p_exact = discr.zeros(actx) + p0
+        energy = (
+            p_exact / (eos.gamma() - 1.0)
+            + 0.5 * np.dot(mom, mom) / mass
+        )
+        cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
+        p = eos.pressure(cv)
+        assert discr.norm(p - p_exact, np.inf) < tolerance
+        flux = inviscid_flux(discr, eos, cv)
+        logger.info(f"{dim}d flux = {flux}")
+        vel_exact = mom / mass
 
-            flux = inviscid_flux(discr, eos, q)
+        # first two components should be nonzero in livedim only
+        assert discr.norm(flux.mass - mom, np.inf) == 0
+        eflux_exact = (energy + p_exact)*vel_exact
+        assert discr.norm(flux.energy - eflux_exact, np.inf) == 0
 
-            logger.info(f"{dim}d flux = {flux}")
-
-            # first two components should be nonzero in livedim only
-            expected_flux = mom
-            logger.info("Testing continuity")
-            for i in range(dim):
-                assert la.norm((flux[0, i] - expected_flux[i])[0].get()) == 0.0
-                if i != livedim:
-                    assert la.norm(flux[0, i][0].get()) == 0.0
-                else:
-                    assert la.norm(flux[0, i][0].get()) > 0.0
-
-            logger.info("Testing energy")
-            expected_flux = mom * (energy + p) / mass
-            for i in range(dim):
-                assert la.norm((flux[1, i] - expected_flux[i])[0].get()) == 0.0
-                if i != livedim:
-                    assert la.norm(flux[1, i][0].get()) == 0.0
-                else:
-                    assert la.norm(flux[1, i][0].get()) > 0.0
-
-            logger.info("Testing momentum")
-            xpmomflux = make_obj_array(
-                [
-                    (mom[i] * mom[j] / mass + (p if i == j else 0))
-                    for i in range(dim)
-                    for j in range(dim)
-                ]
-            )
-
-            for i in range(dim):
-                expected_flux = xpmomflux[i * dim: (i + 1) * dim]
-                for j in range(dim):
-                    assert la.norm((flux[2+i, j] - expected_flux[j])[0].get()) == 0
-                    if i == j:
-                        if i == livedim:
-                            assert (
-                                la.norm(flux[2+i, j][0].get())
-                                > 0.0
-                            )
-                        else:
-                            # just for sanity - make sure the flux recovered the
-                            # prescribed value of p0 (within fp tol)
-                            assert (np.abs(flux[2 + i, j][0].get() - p0)
-                                < tolerance).all()
-                    else:
-                        assert la.norm(flux[2+i, j][0].get()) == 0.0
+        logger.info("Testing momentum")
+        xpmomflux = mass*np.outer(vel_exact, vel_exact) + p_exact*np.identity(dim)
+        assert discr.norm(flux.momentum - xpmomflux, np.inf) < tolerance
 
 
 @pytest.mark.parametrize("nspecies", [0, 10])
@@ -340,14 +303,15 @@ def test_facial_flux(actx_factory, nspecies, order, dim):
         )
         species_mass_input = mass_input * mass_frac_input
 
-        fields = join_conserved(
+        cv = make_conserved(
             dim, mass=mass_input, energy=energy_input, momentum=mom_input,
             species_mass=species_mass_input)
 
         from mirgecom.euler import _facial_flux
 
+        # Check the boundary facial fluxes as called on an interior boundary
         interior_face_flux = _facial_flux(
-            discr, eos=IdealSingleGas(), q_tpair=interior_trace_pair(discr, fields))
+            discr, eos=IdealSingleGas(), cv_tpair=interior_trace_pair(discr, cv))
 
         def inf_norm(data):
             if len(data) > 0:
@@ -355,10 +319,10 @@ def test_facial_flux(actx_factory, nspecies, order, dim):
             else:
                 return 0.0
 
-        iff_split = split_conserved(dim, interior_face_flux)
-        assert inf_norm(iff_split.mass) < tolerance
-        assert inf_norm(iff_split.energy) < tolerance
-        assert inf_norm(iff_split.species_mass) < tolerance
+        # iff_split = split_conserved(dim, interior_face_flux)
+        assert inf_norm(interior_face_flux.mass) < tolerance
+        assert inf_norm(interior_face_flux.energy) < tolerance
+        assert inf_norm(interior_face_flux.species_mass) < tolerance
 
         # The expected pressure is 1.0 (by design). And the flux diagonal is
         # [rhov_x*v_x + p] (etc) since we have zero velocities it's just p.
@@ -371,40 +335,37 @@ def test_facial_flux(actx_factory, nspecies, order, dim):
         # (Explanation courtesy of Mike Campbell,
         # https://github.com/illinois-ceesd/mirgecom/pull/44#discussion_r463304292)
 
-        # generate the exact answer: just p0*nhat for the given boundary
         nhat = thaw(actx, discr.normal("int_faces"))
         mom_flux_exact = discr.project("int_faces", "all_faces", p0*nhat)
-
-        momerr = inf_norm(iff_split.momentum - mom_flux_exact)
+        print(f"{mom_flux_exact=}")
+        print(f"{interior_face_flux.momentum=}")
+        momerr = inf_norm(interior_face_flux.momentum - mom_flux_exact)
         assert momerr < tolerance
-
         eoc_rec0.add_data_point(1.0 / nel_1d, momerr)
 
-        # Check the boundary facial fluxes as called on a boundary
+        # Check the boundary facial fluxes as called on a domain boundary
         dir_mass = discr.project("vol", BTAG_ALL, mass_input)
         dir_e = discr.project("vol", BTAG_ALL, energy_input)
         dir_mom = discr.project("vol", BTAG_ALL, mom_input)
         dir_mf = discr.project("vol", BTAG_ALL, species_mass_input)
-        dir_bval = join_conserved(dim, mass=dir_mass, energy=dir_e, momentum=dir_mom,
-                                  species_mass=dir_mf)
-        dir_bc = join_conserved(dim, mass=dir_mass, energy=dir_e, momentum=dir_mom,
-                                species_mass=dir_mf)
+
+        dir_bval = make_conserved(dim, mass=dir_mass, energy=dir_e,
+                                  momentum=dir_mom, species_mass=dir_mf)
+        dir_bc = make_conserved(dim, mass=dir_mass, energy=dir_e,
+                                momentum=dir_mom, species_mass=dir_mf)
 
         boundary_flux = _facial_flux(
             discr, eos=IdealSingleGas(),
-            q_tpair=TracePair(BTAG_ALL, interior=dir_bval, exterior=dir_bc)
+            cv_tpair=TracePair(BTAG_ALL, interior=dir_bval, exterior=dir_bc)
         )
 
-        bf_split = split_conserved(dim, boundary_flux)
-        assert inf_norm(bf_split.mass) < tolerance
-        assert inf_norm(bf_split.energy) < tolerance
-        assert inf_norm(bf_split.species_mass) < tolerance
+        assert inf_norm(boundary_flux.mass) < tolerance
+        assert inf_norm(boundary_flux.energy) < tolerance
+        assert inf_norm(boundary_flux.species_mass) < tolerance
 
-        # generate the exact answer: just p0*nhat for the given boundary
         nhat = thaw(actx, discr.normal(BTAG_ALL))
         mom_flux_exact = discr.project(BTAG_ALL, "all_faces", p0*nhat)
-
-        momerr = inf_norm(bf_split.momentum - mom_flux_exact)
+        momerr = inf_norm(boundary_flux.momentum - mom_flux_exact)
         assert momerr < tolerance
 
         eoc_rec1.add_data_point(1.0 / nel_1d, momerr)
@@ -463,31 +424,31 @@ def test_uniform_rhs(actx_factory, nspecies, dim, order):
             [ones / ((i + 1) * 10) for i in range(nspecies)]
         )
         species_mass_input = mass_input * mass_frac_input
+        num_equations = dim + 2 + len(species_mass_input)
 
-        fields = join_conserved(
+        cv = make_conserved(
             dim, mass=mass_input, energy=energy_input, momentum=mom_input,
             species_mass=species_mass_input)
 
-        expected_rhs = make_obj_array(
-            [discr.zeros(actx) for i in range(len(fields))]
+        expected_rhs = split_conserved(
+            dim, make_obj_array([discr.zeros(actx)
+                                 for i in range(num_equations)])
         )
 
         boundaries = {BTAG_ALL: DummyBoundary()}
         inviscid_rhs = euler_operator(discr, eos=IdealSingleGas(),
-                                      boundaries=boundaries, q=fields, t=0.0)
+                                      boundaries=boundaries, cv=cv, t=0.0)
         rhs_resid = inviscid_rhs - expected_rhs
 
-        resid_split = split_conserved(dim, rhs_resid)
-        rho_resid = resid_split.mass
-        rhoe_resid = resid_split.energy
-        mom_resid = resid_split.momentum
-        rhoy_resid = resid_split.species_mass
+        rho_resid = rhs_resid.mass
+        rhoe_resid = rhs_resid.energy
+        mom_resid = rhs_resid.momentum
+        rhoy_resid = rhs_resid.species_mass
 
-        rhs_split = split_conserved(dim, inviscid_rhs)
-        rho_rhs = rhs_split.mass
-        rhoe_rhs = rhs_split.energy
-        rhov_rhs = rhs_split.momentum
-        rhoy_rhs = rhs_split.species_mass
+        rho_rhs = inviscid_rhs.mass
+        rhoe_rhs = inviscid_rhs.energy
+        rhov_rhs = inviscid_rhs.momentum
+        rhoy_rhs = inviscid_rhs.species_mass
 
         logger.info(
             f"rho_rhs  = {rho_rhs}\n"
@@ -510,20 +471,19 @@ def test_uniform_rhs(actx_factory, nspecies, dim, order):
         for i in range(len(mom_input)):
             mom_input[i] = discr.zeros(actx) + (-1.0) ** i
 
-        fields = join_conserved(
+        cv = make_conserved(
             dim, mass=mass_input, energy=energy_input, momentum=mom_input,
             species_mass=species_mass_input)
 
         boundaries = {BTAG_ALL: DummyBoundary()}
         inviscid_rhs = euler_operator(discr, eos=IdealSingleGas(),
-                                      boundaries=boundaries, q=fields, t=0.0)
+                                      boundaries=boundaries, cv=cv, t=0.0)
         rhs_resid = inviscid_rhs - expected_rhs
 
-        resid_split = split_conserved(dim, rhs_resid)
-        rho_resid = resid_split.mass
-        rhoe_resid = resid_split.energy
-        mom_resid = resid_split.momentum
-        rhoy_resid = resid_split.species_mass
+        rho_resid = rhs_resid.mass
+        rhoe_resid = rhs_resid.energy
+        mom_resid = rhs_resid.momentum
+        rhoy_resid = rhs_resid.species_mass
 
         assert discr.norm(rho_resid, np.inf) < tolerance
         assert discr.norm(rhoe_resid, np.inf) < tolerance
@@ -586,9 +546,9 @@ def test_vortex_rhs(actx_factory, order):
 
         inviscid_rhs = euler_operator(
             discr, eos=IdealSingleGas(), boundaries=boundaries,
-            q=vortex_soln, t=0.0)
+            cv=vortex_soln, t=0.0)
 
-        err_max = discr.norm(inviscid_rhs, np.inf)
+        err_max = discr.norm(inviscid_rhs.join(), np.inf)
         eoc_rec.add_data_point(1.0 / nel_1d, err_max)
 
     logger.info(
@@ -639,10 +599,10 @@ def test_lump_rhs(actx_factory, dim, order):
         lump_soln = lump(nodes)
         boundaries = {BTAG_ALL: PrescribedBoundary(lump)}
         inviscid_rhs = euler_operator(
-            discr, eos=IdealSingleGas(), boundaries=boundaries, q=lump_soln, t=0.0)
-        expected_rhs = lump.exact_rhs(discr, lump_soln, 0)
+            discr, eos=IdealSingleGas(), boundaries=boundaries, cv=lump_soln, t=0.0)
+        expected_rhs = lump.exact_rhs(discr, cv=lump_soln, t=0)
 
-        err_max = discr.norm(inviscid_rhs-expected_rhs, np.inf)
+        err_max = discr.norm((inviscid_rhs-expected_rhs).join(), np.inf)
         if err_max > maxxerr:
             maxxerr = err_max
 
@@ -707,11 +667,11 @@ def test_multilump_rhs(actx_factory, dim, order, v0):
         boundaries = {BTAG_ALL: PrescribedBoundary(lump)}
 
         inviscid_rhs = euler_operator(
-            discr, eos=IdealSingleGas(), boundaries=boundaries, q=lump_soln, t=0.0)
-        expected_rhs = lump.exact_rhs(discr, lump_soln, 0)
+            discr, eos=IdealSingleGas(), boundaries=boundaries, cv=lump_soln, t=0.0)
+        expected_rhs = lump.exact_rhs(discr, cv=lump_soln, t=0)
         print(f"inviscid_rhs = {inviscid_rhs}")
         print(f"expected_rhs = {expected_rhs}")
-        err_max = discr.norm(inviscid_rhs-expected_rhs, np.inf)
+        err_max = discr.norm((inviscid_rhs-expected_rhs).join(), np.inf)
         if err_max > maxxerr:
             maxxerr = err_max
 
@@ -759,8 +719,8 @@ def _euler_flow_stepper(actx, parameters):
 
     discr = EagerDGDiscretization(actx, mesh, order=order)
     nodes = thaw(actx, discr.nodes())
-    fields = initializer(nodes)
-    sdt = get_inviscid_timestep(discr, eos=eos, cfl=cfl, q=fields)
+    cv = initializer(nodes)
+    sdt = get_inviscid_timestep(discr, eos=eos, cfl=cfl, cv=cv)
 
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
@@ -773,13 +733,12 @@ def _euler_flow_stepper(actx, parameters):
         f"EOS:             {eosname}"
     )
 
-    vis = make_visualizer(discr, order + 3 if dim == 2 else order)
+    vis = make_visualizer(discr, order)
 
-    def write_soln(write_status=True):
-        cv = split_conserved(dim, fields)
-        dv = eos.dependent_vars(cv)
+    def write_soln(state, write_status=True):
+        dv = eos.dependent_vars(cv=state)
         expected_result = initializer(nodes, t=t)
-        result_resid = fields - expected_result
+        result_resid = (state - expected_result).join()
         maxerr = [np.max(np.abs(result_resid[i].get())) for i in range(dim + 2)]
         mindv = [np.min(dvfld.get()) for dvfld in dv]
         maxdv = [np.max(dvfld.get()) for dvfld in dv]
@@ -794,7 +753,7 @@ def _euler_flow_stepper(actx, parameters):
             )
             logger.info(statusmsg)
 
-        io_fields = ["cv", split_conserved(dim, fields)]
+        io_fields = ["cv", state]
         io_fields += eos.split_fields(dim, dv)
         io_fields.append(("exact_soln", expected_result))
         io_fields.append(("residual", result_resid))
@@ -805,7 +764,7 @@ def _euler_flow_stepper(actx, parameters):
         return maxerr
 
     def rhs(t, q):
-        return euler_operator(discr, eos=eos, boundaries=boundaries, q=q, t=t)
+        return euler_operator(discr, eos=eos, boundaries=boundaries, cv=q, t=t)
 
     filter_order = 8
     eta = .5
@@ -831,23 +790,24 @@ def _euler_flow_stepper(actx, parameters):
 
         if nstepstatus > 0:
             if istep % nstepstatus == 0:
-                write_soln()
+                write_soln(state=cv)
 
-        fields = rk4_step(fields, t, dt, rhs)
-        fields = filter_modally(discr, "vol", cutoff,
-                                frfunc, fields)
+        cv = rk4_step(cv, t, dt, rhs)
+        cv = split_conserved(
+            dim, filter_modally(discr, "vol", cutoff, frfunc, cv.join())
+        )
 
         t += dt
         istep += 1
 
-        sdt = get_inviscid_timestep(discr, eos=eos, cfl=cfl, q=fields)
+        sdt = get_inviscid_timestep(discr, eos=eos, cfl=cfl, cv=cv)
 
     if nstepstatus > 0:
         logger.info("Writing final dump.")
-        maxerr = max(write_soln(False))
+        maxerr = max(write_soln(cv, False))
     else:
         expected_result = initializer(nodes, t=t)
-        maxerr = discr.norm(fields - expected_result, np.inf)
+        maxerr = discr.norm((cv - expected_result).join(), np.inf)
 
     logger.info(f"Max Error: {maxerr}")
     if maxerr > exittol:

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -186,7 +186,7 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
     # the filter unharmed.
     from mirgecom.initializers import Uniform
     initr = Uniform(dim=dim)
-    uniform_soln = initr(t=0, x_vec=nodes)
+    uniform_soln = initr(t=0, x_vec=nodes).join()
 
     from mirgecom.filter import filter_modally
     filtered_soln = filter_modally(discr, "vol", cutoff,

--- a/test/test_simutil.py
+++ b/test/test_simutil.py
@@ -59,15 +59,17 @@ def test_basic_cfd_healthcheck(actx_factory):
 
     # Let's make a very bad state (negative mass)
     mass = -1*ones
-    energy = zeros + 2.5
     velocity = 2 * nodes
     mom = mass * velocity
+    energy = zeros + .5*np.dot(mom, mom)/mass
 
     eos = IdealSingleGas()
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
+    pressure = eos.pressure(cv)
 
     from mirgecom.simutil import check_range_local
     assert check_range_local(discr, "vol", mass)
+    assert check_range_local(discr, "vol", pressure, min_value=1e-6)
 
     # Let's make another very bad state (nans)
     mass = 1*ones


### PR DESCRIPTION
Here is a set of changes that I think accomplishes most the stuff we've been talking about.

- Updates callback changes to work with current main (including CV array containers)
- Eliminates `sim_checkpoint` in favor of fully customizable `my_checkpoint`
- Allows full customization of status messages, viz fields, and health checking
- Implements minimally collective health-check (only one collective comm to sync)
- Optionally dumps viz at health fail (automatically collective)
- Correctly places control over what to do with errors in the hands of the user/driver

Since this also merges current main, the changeset is pretty large.  You can get a good idea of what is done by having a look at the example drivers. #381 shows the diff against main.
