### PR TITLE
Add arbitrary user quantities to logging

### DIFF
--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -185,7 +185,8 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
         viz_flds = [("cfl", current_cfl)]
         from grudge.op import nodal_max
         max_cfl = nodal_max(discr, "vol", current_cfl)
-        my_log_quantity.set_quantity(max_cfl)
+        logmgr.set_quantity_value("cfl", max_cfl)
+        # my_log_quantity.set_quantity(max_cfl)
         return sim_checkpoint(discr, visualizer, eos, cv=state, viz_fields=viz_flds,
                               exact_soln=initializer, vizname=casename, step=step,
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -137,13 +137,12 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
 
     vis_timer = None
 
-    my_log_quantity = LogUserQuantity(name="cfl", value=current_cfl)
     if logmgr:
         logmgr_add_device_name(logmgr, queue)
         logmgr_add_device_memory_usage(logmgr, queue)
         logmgr_add_many_discretization_quantities(logmgr, discr, dim,
                              extract_vars_for_logging, units_for_logging)
-        logmgr.add_quantity(my_log_quantity)
+        logmgr.add_quantity(LogUserQuantity(name="cfl", value=current_cfl))
         logmgr.add_watches(["step.max", "t_step.max", "t_log.max",
                             "min_temperature", "L2_norm_momentum1", "cfl.max"])
 
@@ -186,7 +185,6 @@ def main(ctx_factory=cl.create_some_context, use_profiling=False, use_logmgr=Fal
         from grudge.op import nodal_max
         max_cfl = nodal_max(discr, "vol", current_cfl)
         logmgr.set_quantity_value("cfl", max_cfl)
-        # my_log_quantity.set_quantity(max_cfl)
         return sim_checkpoint(discr, visualizer, eos, cv=state, viz_fields=viz_flds,
                               exact_soln=initializer, vizname=casename, step=step,
                               t=t, dt=dt, nstatus=nstatus, nviz=nviz,

--- a/mirgecom/inviscid.py
+++ b/mirgecom/inviscid.py
@@ -66,30 +66,50 @@ def inviscid_flux(discr, eos, cv):
             (mom / cv.mass) * cv.species_mass.reshape(-1, 1)))
 
 
-def get_inviscid_timestep(discr, eos, cfl, cv):
-    """Routine (will) return the (local) maximum stable inviscid timestep.
+def get_inviscid_timestep(discr, eos, cv):
+    """Routine returns the node-local maximum stable dt for inviscid fluid.
 
-    Currently, it's a hack waiting for the geometric_factor helpers port
-    from grudge.
+    The maximum stable timestep is computed from the acoustic wavespeed.
+
+    Parameters
+    ----------
+    discr: grudge.eager.EagerDGDiscretization
+        the discretization to use
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state q.
+    cv: :class:`~mirgecom.fluid.ConservedVars`
+        Fluid soluition
+    Returns
+    -------
+    class:`~meshmode.dof_array.DOFArray`
+        The maximum stable timestep at each node.
     """
-    dim = discr.dim
-    mesh = discr.mesh
-    order = max([grp.order for grp in discr.discr_from_dd("vol").groups])
-    nelements = mesh.nelements
-    nel_1d = nelements ** (1.0 / (1.0 * dim))
-
-    # This roughly reproduces the timestep AK used in wave toy
-    dt = (1.0 - 0.25 * (dim - 1)) / (nel_1d * order ** 2)
-    return cfl * dt
-
-#    dt_ngf = dt_non_geometric_factor(discr.mesh)
-#    dt_gf  = dt_geometric_factor(discr.mesh)
-#    wavespeeds = compute_wavespeed(w,eos=eos)
-#    max_v = clmath.max(wavespeeds)
-#    return c*dt_ngf*dt_gf/max_v
+    from grudge.dt_utils import characteristic_lengthscales
+    from mirgecom.fluid import compute_wavespeed
+    return (
+        characteristic_lengthscales(cv.array_context, discr)
+        / compute_wavespeed(discr, eos, cv)
+    )
 
 
 def get_inviscid_cfl(discr, eos, dt, cv):
-    """Calculate and return CFL based on current state and timestep."""
-    wanted_dt = get_inviscid_timestep(discr, eos=eos, cfl=1.0, cv=cv)
-    return dt / wanted_dt
+    """Calculate and return node-local CFL based on current state and timestep.
+
+    Parameters
+    ----------
+    discr: :class:`grudge.eager.EagerDGDiscretization`
+        the discretization to use
+    eos: mirgecom.eos.GasEOS
+        Implementing the pressure and temperature functions for
+        returning pressure and temperature as a function of the state q.
+    dt: float or :class:`~meshmode.dof_array.DOFArray`
+        A constant scalar dt or node-local dt
+    cv: :class:`~mirgecom.fluid.ConservedVars`
+        Fluid solution
+    Returns
+    -------
+    :class:`meshmode.dof_array.DOFArray`
+        The CFL at each node.
+    """
+    return dt / get_inviscid_timestep(discr, eos=eos, cv=cv)

--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -310,6 +310,25 @@ class LogCFL(LogQuantity, StateConsumer, DtConsumer):
         return get_inviscid_cfl(self.discr, eos=self.eos, dt=self.dt, cv=self.state)
 
 
+class LogUserQuantity(LogQuantity):
+    """Logging support for arbitrary user quantities."""
+
+    def __init__(self, name="user_quantity", value=None, user_function=None) -> None:
+        LogQuantity.__init__(self, name, "1")
+        self._value = value
+        self._uf = user_function
+
+    def set_quantity(self, value) -> None:
+        """Set the user quantity to be used in calculating the logged value."""
+        self._value = value
+
+    def __call__(self) -> float:
+        """Return the value of cfl."""
+        if self._uf:
+            return self._uf(self._value)
+        return self._value
+
+
 # {{{ Kernel profile quantities
 
 class KernelProfile(MultiLogQuantity):

--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -315,18 +315,14 @@ class LogUserQuantity(LogQuantity):
 
     def __init__(self, name="user_quantity", value=None, user_function=None) -> None:
         LogQuantity.__init__(self, name, "1")
-        self._value = value
+        self._quantity_value = value
         self._uf = user_function
 
-    def set_quantity(self, value) -> None:
-        """Set the user quantity to be used in calculating the logged value."""
-        self._value = value
-
     def __call__(self) -> float:
-        """Return the value of cfl."""
+        """Return the actual logged quantity."""
         if self._uf:
-            return self._uf(self._value)
-        return self._value
+            return self._uf(self._quantity_value)
+        return self._quantity_value
 
 
 # {{{ Kernel profile quantities

--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -40,6 +40,7 @@ __doc__ = """
 .. autofunction:: logmgr_set_time
 """
 
+from typing import Any
 from logpyle import (DtConsumer, LogQuantity, LogManager, MultiLogQuantity,
     add_run_info, add_general_quantities, add_simulation_quantities)
 from meshmode.array_context import PyOpenCLArrayContext
@@ -323,6 +324,10 @@ class LogUserQuantity(LogQuantity):
         if self._uf:
             return self._uf(self._quantity_value)
         return self._quantity_value
+
+    def set_quantity_value(self, value: Any) -> None:
+        """Set the value of the logged quantity."""
+        self._quantity_value = value
 
 
 # {{{ Kernel profile quantities

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -67,8 +67,8 @@ def inviscid_sim_timestep(discr, state, t, dt, cfl, eos,
     """Return the maximum stable dt."""
     mydt = dt
     if constant_cfl is True:
-        mydt = get_inviscid_timestep(discr=discr, cv=state,
-                                     cfl=cfl, eos=eos)
+        mydt = cfl * get_inviscid_timestep(discr=discr, cv=state,
+                                           eos=eos)
     if (t + mydt) > t_final:
         mydt = t_final - t
     return mydt

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ psutil
 --editable git+https://github.com/inducer/grudge.git#egg=grudge
 --editable git+https://github.com/inducer/pytato.git#egg=pytato
 --editable git+https://github.com/ecisneros8/pyrometheus.git#egg=pyrometheus
---editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle
+--editable git+https://github.com/MTCam/logpyle.git@user-quantities#egg=logpyle

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -720,7 +720,7 @@ def _euler_flow_stepper(actx, parameters):
     discr = EagerDGDiscretization(actx, mesh, order=order)
     nodes = thaw(actx, discr.nodes())
     cv = initializer(nodes)
-    sdt = get_inviscid_timestep(discr, eos=eos, cfl=cfl, cv=cv)
+    sdt = cfl * get_inviscid_timestep(discr, eos=eos, cv=cv)
 
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
@@ -800,7 +800,7 @@ def _euler_flow_stepper(actx, parameters):
         t += dt
         istep += 1
 
-        sdt = get_inviscid_timestep(discr, eos=eos, cfl=cfl, cv=cv)
+        sdt = cfl * get_inviscid_timestep(discr, eos=eos, cv=cv)
 
     if nstepstatus > 0:
         logger.info("Writing final dump.")


### PR DESCRIPTION
Follows onto #390, and adds an interface for arbitrary user quantities.  Demonstrating use with CFL. In this one, the use is free to use the CFL field and visualize it, and the logger does not redundantly calculate it.

fixes #389