### PR TITLE
Extend make conserved to handle joined quantities, sharpen the docs.

### DIFF
--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -61,7 +61,7 @@ from grudge.eager import (
 )
 from mirgecom.fluid import (
     compute_wavespeed,
-    split_conserved,
+    make_conserved
 )
 
 from mirgecom.inviscid import (
@@ -151,8 +151,10 @@ def euler_operator(discr, eos, boundaries, cv, t=0.0):
                 discr, eos=eos,
                 cv_tpair=TracePair(
                     part_pair.dd,
-                    interior=split_conserved(discr.dim, part_pair.int),
-                    exterior=split_conserved(discr.dim, part_pair.ext)))
+                    interior=make_conserved(discr.dim,
+                                            scalar_quantities=part_pair.int),
+                    exterior=make_conserved(discr.dim,
+                                            scalar_quantities=part_pair.ext)))
             for part_pair in cross_rank_trace_pairs(discr, cv.join()))
         + sum(
             _facial_flux(
@@ -163,8 +165,10 @@ def euler_operator(discr, eos, boundaries, cv, t=0.0):
             for btag in boundaries)
     ).join()
 
-    return split_conserved(
-        discr.dim, discr.inverse_mass(vol_weak - discr.face_mass(boundary_flux))
+    return make_conserved(
+        discr.dim,
+        scalar_quantities=discr.inverse_mass(vol_weak
+                                             - discr.face_mass(boundary_flux))
     )
 
 
@@ -173,7 +177,8 @@ def inviscid_operator(discr, eos, boundaries, q, t=0.0):
     from warnings import warn
     warn("Do not call inviscid_operator; it is now called euler_operator. This"
          "function will disappear August 1, 2021", DeprecationWarning, stacklevel=2)
-    return euler_operator(discr, eos, boundaries, split_conserved(discr.dim, q), t)
+    return euler_operator(discr, eos, boundaries,
+                          make_conserved(discr.dim, scalar_quantities=q), t)
 
 
 # By default, run unitless


### PR DESCRIPTION
Now that CV is the main object in the fluid components of *MIRGE-Com*, we can reshape the CV creation tools to be a bit more convenient and transparent at the call site. 

Users typically make CV from these data:

* Split arrays for scalar quantities (e.g. dof_array for each of mass, energy, momentum, etc)
* Split arrays for vector quantities (e.g. array of dof_array for mass, etc)
* Joined arrays for scalar components of Q[Neq] (i.e. with Q[0]=mass, Q[1]=energy, etc)
* Joined arrays for vector components of flux or gradients

Right now, *MIRGE-Com* handles the first two cases (split quantities) properly with `make_conserved`. This change set extends `make_conserved` to the other two cases.  Currently the other two cases are handled by:

```python
# Joined scalar array q
cv = split_conserved(dim, q)
# Joined flux arrays f
flux = split_conserved(dim, q=f)
```

The proposed change (which is currently used by Navier-Stokes, and y1-production) would replace the above with:

```python
# Joined scalar array q
cv = make_conserved(dim, scalar_quantities=q)
# Joined flux arrays f
flux = make_conserved(dim, vector_quantities=f)
```

Although this does not reduce the amount of user-facing code, I believe it makes it more clear that this returns a CV object, and that it is taking a scalar quantity, or vector quantity as an argument.  Internally, our infrastructure is smart enough to figure it out - so the back-end handling is identical, but as a user and reader of the code, I like this better.