### PR TITLE
Fix doctest update

### DIFF
--- a/doc/support/arrays.rst
+++ b/doc/support/arrays.rst
@@ -70,7 +70,7 @@ the following:
    >>> dcoll.nodes() * 5
    Traceback (most recent call last):
     ...
-   ValueError: PyOpenCL array has no queue; call .with_queue() to add one in order to be able to perform operations
+   ValueError: array containers with frozen arrays cannot be operated upon
 
 Fortunately, recovering from this is straightforward:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E127,E128,E123,E226,E241,W503
+ignore = E127,E128,E123,E226,E241,W503,N818
 exclude = .*,\#*
 max-line-length=85
 


### PR DESCRIPTION
cc @matthiasdiener @majosm @thomasgibson for disabling flake8's N818: "All exception classes must end in `Error`". I'm not a fan, but I figured I'd put it up for debate.