### PR TITLE
Replicate call_loopy changes from pyopencl actx base class

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             export XDG_CACHE_HOME=/tmp
-            python -m mpi4py examples/vortex-mpi.py
+            mpiexec -n 2 python -m mpi4py examples/vortex-mpi.py
 
     doc:
         name: Documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             export XDG_CACHE_HOME=/tmp
-            mpiexec -n 2 python -m mpi4py examples/vortex-mpi.py
+            examples/run_examples.sh ./examples
 
     doc:
         name: Documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             export XDG_CACHE_HOME=/tmp
-            examples/run_examples.sh ./examples
+            python -m mpi4py examples/vortex-mpi.py
 
     doc:
         name: Documentation

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,7 @@ jobs:
           run: |
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+            export XDG_CACHE_HOME=/tmp
             examples/run_examples.sh ./examples
 
     doc:

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -292,6 +292,7 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
             self.kernel_stats[t_unit][args_tuple]
             return args_tuple
         except KeyError:
+            print("CACHE MISS", t_unit.default_entrypoint.name)
             # If not, calculate and cache the stats
             ep_name = t_unit.default_entrypoint.name
             executor = t_unit.target.get_kernel_executor(t_unit, self.queue,

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -364,17 +364,30 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
 
             return args_tuple
 
-    def call_loopy(self, program, **kwargs) -> dict:
+    def call_loopy(self, t_unit, **kwargs) -> dict:
         """Execute the loopy kernel and profile it."""
-        program = self.transform_loopy_program(program)
-        assert program.default_entrypoint.options.return_dict
-        assert program.default_entrypoint.options.no_numpy
+        try:
+            t_unit = self._loopy_transform_cache[t_unit]
+        except KeyError:
+            orig_t_unit = t_unit
+            t_unit = self.transform_loopy_program(t_unit)
+            self._loopy_transform_cache[orig_t_unit] = t_unit
+            del orig_t_unit
 
-        evt, result = program(self.queue, **kwargs, allocator=self.allocator)
+        evt, result = t_unit(self.queue, **kwargs, allocator=self.allocator)
+
+        if self._wait_event_queue_length is not False:
+            prg_name = t_unit.default_entrypoint.name
+            wait_event_queue = self._kernel_name_to_wait_event_queue.setdefault(
+                prg_name, [])
+
+            wait_event_queue.append(evt)
+            if len(wait_event_queue) > self._wait_event_queue_length:
+                wait_event_queue.pop(0).wait()
 
         # Generate the stats here so we don't need to carry around the kwargs
-        args_tuple = self._cache_kernel_stats(program, kwargs)
+        args_tuple = self._cache_kernel_stats(t_unit, kwargs)
 
-        self.profile_events.append(ProfileEvent(evt, program, args_tuple))
+        self.profile_events.append(ProfileEvent(evt, t_unit, args_tuple))
 
         return result

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -292,7 +292,6 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
             self.kernel_stats[t_unit][args_tuple]
             return args_tuple
         except KeyError:
-            print("CACHE MISS", t_unit.default_entrypoint.name)
             # If not, calculate and cache the stats
             ep_name = t_unit.default_entrypoint.name
             executor = t_unit.target.get_kernel_executor(t_unit, self.queue,


### PR DESCRIPTION
This fixes a large part of the CI slowness w/ profiling.