### PR TITLE
Add Y1 production test to CI

### DIFF
--- a/.ci-support/production-driver-setup.sh
+++ b/.ci-support/production-driver-setup.sh
@@ -1,0 +1,14 @@
+set -x
+PRODUCTION_DRIVER_NAME="drivers_y1-nozzle"
+PRODUCTION_DRIVER_CHANGE_OWNER="illinois-ceesd"
+PRODUCTION_DRIVER_CHANGE_BRANCH=""
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ ${PRODUCTION_DRIVER_CHANGE_BRANCH} != "" ]; then
+    git remote add driver_change https://github.com/${PRODUCTION_DRIVER_CHANGE_OWNER}/${PRODUCTION_DRIVER_NAME}
+    git fetch driver_change
+    git checkout driver_change/${PRODUCTION_DRIVER_CHANGE_BRANCH}
+    git checkout ${CURRENT_BRANCH}
+    git merge driver_change/${PRODUCTION_DRIVER_CHANGE_BRANCH} --no-edit
+else
+    echo "No updates to production driver branch (${CURRENT_BRANCH})"
+fi

--- a/.ci-support/production-driver-setup.sh
+++ b/.ci-support/production-driver-setup.sh
@@ -1,9 +1,9 @@
 set -x
 PRODUCTION_DRIVER_NAME="drivers_y1-nozzle"
 PRODUCTION_DRIVER_CHANGE_OWNER="illinois-ceesd"
-PRODUCTION_DRIVER_CHANGE_BRANCH=""
+PRODUCTION_DRIVER_CHANGE_BRANCH="update-y1-callbacks"
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ ${PRODUCTION_DRIVER_CHANGE_BRANCH} != "" ]; then
+if [ -n "${PRODUCTION_DRIVER_CHANGE_BRANCH}" ]; then
     git remote add driver_change https://github.com/${PRODUCTION_DRIVER_CHANGE_OWNER}/${PRODUCTION_DRIVER_NAME}
     git fetch driver_change
     git checkout driver_change/${PRODUCTION_DRIVER_CHANGE_BRANCH}

--- a/.ci-support/production-driver-setup.sh
+++ b/.ci-support/production-driver-setup.sh
@@ -1,4 +1,7 @@
+#!/bin/bash
+
 set -x
+
 PRODUCTION_DRIVER_NAME="drivers_y1-nozzle"
 PRODUCTION_DRIVER_CHANGE_OWNER="illinois-ceesd"
 PRODUCTION_DRIVER_CHANGE_BRANCH="update-y1-callbacks"

--- a/.ci-support/production-setup.sh
+++ b/.ci-support/production-setup.sh
@@ -1,4 +1,7 @@
+#!/bin/bash
+
 set -x
+
 PRODUCTION_CHANGE_OWNER="illinois-ceesd"
 PRODUCTION_CHANGE_BRANCH=""
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/.ci-support/production-setup.sh
+++ b/.ci-support/production-setup.sh
@@ -2,7 +2,7 @@ set -x
 PRODUCTION_CHANGE_OWNER="illinois-ceesd"
 PRODUCTION_CHANGE_BRANCH=""
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ ${PRODUCTION_CHANGE_BRANCH} != "" ]; then
+if [ -n "${PRODUCTION_CHANGE_BRANCH}" ]; then
     git remote add production_change https://github.com/${PRODUCTION_CHANGE_OWNER}/mirgecom
     git fetch production_change
     git checkout production_change/${PRODUCTION_CHANGE_BRANCH}

--- a/.ci-support/production-setup.sh
+++ b/.ci-support/production-setup.sh
@@ -1,0 +1,13 @@
+set -x
+PRODUCTION_CHANGE_OWNER="illinois-ceesd"
+PRODUCTION_CHANGE_BRANCH=""
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ ${PRODUCTION_CHANGE_BRANCH} != "" ]; then
+    git remote add production_change https://github.com/${PRODUCTION_CHANGE_OWNER}/mirgecom
+    git fetch production_change
+    git checkout production_change/${PRODUCTION_CHANGE_BRANCH}
+    git checkout ${CURRENT_BRANCH}
+    git merge production_change/${PRODUCTION_CHANGE_BRANCH} --no-edit
+else
+    echo "No updates to production branch (${CURRENT_BRANCH})"
+fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,7 +178,7 @@ jobs:
             git config user.email "stupid@dumb.com"
             git config user.name "CI Runner"
             git checkout -b production-test
-            . ../../mirgecom/mirgecom/.ci-support/production-setup.sh
+            . ../../mirgecom/.ci-support/production-setup.sh
             git remote add changes https://github.com/${GITHUB_REPOSITORY_OWNER}/mirgecom
             git fetch changes
             git checkout changes/${GITHUB_HEAD_REF}
@@ -193,6 +193,6 @@ jobs:
             cd y1-production-driver
             git config user.email "stupid@dumb.com"
             git config user.name "CI Runner"
-            . ../mirgecom/mirgecom/.ci-support/production-driver-setup.sh
+            . ../mirgecom/.ci-support/production-driver-setup.sh
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,16 +171,18 @@ jobs:
             [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
             [[ $(uname) == Darwin ]] && brew update && brew install mpich
             cd ..
+            git config user.email "stupid@dumb.com"
+            git config user.name "CI Runner"
             git clone https://github.com/illinois-ceesd/emirge emirge.y1
             cd emirge.y1
             ./install.sh --branch=y1-production
             cd mirgecom
+            git checkout -b production-test
+            . ../../mirgecom/mirgecom/.ci-support/production-setup.sh
             git remote add changes https://github.com/${GITHUB_REPOSITORY_OWNER}/mirgecom
             git fetch changes
             git checkout changes/${GITHUB_HEAD_REF}
-            git checkout y1-production
-            git config user.email "stupid@dumb.com"
-            git config user.name "CI Runner"
+            git checkout production-test
             git merge changes/${GITHUB_HEAD_REF} --no-edit
 
         - name: Run Y1 production test
@@ -188,5 +190,7 @@ jobs:
             cd ..
             source emirge.y1/config/activate_env.sh
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
+            cd y1-production-driver
+            . ../mirgecom/mirgecom/.ci-support/production-driver-setup.sh
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,15 +162,15 @@ jobs:
             cd ../../
             git clone https://github.com/illinois-ceesd/emirge emirge.y1
             cd emirge.y1
-            ./install.sh --branch=${GITHUB_REF##*/}
+            ./install.sh --branch=y1-production
             source config/activate_env.sh
             cd mirgecom
-            git remote add ceesd https://illinois-ceesd/mirgecom
-            git fetch ceesd
-            git checkout ceesd/y1-production
-            pip install -r requirements.txt
+            env
+            echo "GITHUB_REF: ${GITHUB_REF}"
+            echo "Testing Branch: ${GITHUB_REF##*/}"
             git checkout ${GITHUB_REF##*/}
-            git merge y1-production
+            git checkout y1-production
+            git merge ${GITHUB_REF##*/}
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
             echo "Testing Branch: ${GITHUB_HEAD_REF}"
             git checkout ${GITHUB_HEAD_REF}
             git checkout y1-production
-            git merge ${GITHUB_HEAD_REF}
+            git merge ${GITHUB_HEAD_REF} --no-edit
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,11 +166,11 @@ jobs:
             source config/activate_env.sh
             cd mirgecom
             env
-            echo "GITHUB_REF: ${GITHUB_REF}"
-            echo "Testing Branch: ${GITHUB_REF##*/}"
-            git checkout ${GITHUB_REF##*/}
+            echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
+            echo "Testing Branch: ${GITHUB_HEAD_REF}"
+            git checkout ${GITHUB_HEAD_REF}
             git checkout y1-production
-            git merge ${GITHUB_REF##*/}
+            git merge ${GITHUB_HEAD_REF}
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,13 +156,27 @@ jobs:
             source emirge/config/activate_env.sh
             cd mirgecom/examples
             python -m mpi4py ./wave-eager-mpi.py
- 
+
+    y1: 
+        name: Y1 production testing
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-latest, macos-latest]
+
+        steps:
+        - uses: actions/checkout@v2
+        - name: Install emirge
+          run: |
+            [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
+            [[ $(uname) == Darwin ]] && brew update && brew install mpich
+            cd ..
+            git clone https://github.com/illinois-ceesd/emirge
+            cd emirge
+            ./install.sh --branch=y1-production
+
         - name: Run Y1 production test
           run: |
-            cd ../../
-            git clone https://github.com/illinois-ceesd/emirge emirge.y1
-            cd emirge.y1
-            ./install.sh --branch=y1-production
             source config/activate_env.sh
             cd mirgecom
             env
@@ -170,6 +184,8 @@ jobs:
             echo "Testing Branch: ${GITHUB_HEAD_REF}"
             git checkout ${GITHUB_HEAD_REF}
             git checkout y1-production
+            git config user.email "stupid@dumb.com"
+            git config user.name "CI Runner"
             git merge ${GITHUB_HEAD_REF} --no-edit
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver/smoke_test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,7 +160,6 @@ jobs:
         - name: Run Y1 production test
           run: |
             cd ../../
-            conda deactivate
             git clone https://github.com/illinois-ceesd/emirge emirge.y1
             cd emirge.y1
             ./install.sh --branch=${GITHUB_REF##*/}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,26 +166,27 @@ jobs:
 
         steps:
         - uses: actions/checkout@v2
-        - name: Install emirge
+        - name: Prepare Y1 environment
           run: |
             [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
             [[ $(uname) == Darwin ]] && brew update && brew install mpich
             cd ..
-            git clone https://github.com/illinois-ceesd/emirge
-            cd emirge
+            git clone https://github.com/illinois-ceesd/emirge emirge.y1
+            cd emirge.y1
             ./install.sh --branch=y1-production
-
-        - name: Run Y1 production test
-          run: |
-            env
-            cd ..
-            source emirge/config/activate_env.sh
-            cd emirge/mirgecom
-            git checkout ${GITHUB_HEAD_REF}
+            cd mirgecom
+            git remote add changes https://github.com/${GITHUB_REPOSITORY_OWNER}/mirgecom
+            git fetch changes
+            git checkout changes/${GITHUB_HEAD_REF}
             git checkout y1-production
             git config user.email "stupid@dumb.com"
             git config user.name "CI Runner"
-            git merge ${GITHUB_HEAD_REF} --no-edit
+            git merge changes/${GITHUB_HEAD_REF} --no-edit
+
+        - name: Run Y1 production test
+          run: |
+            cd ..
+            source emirge.y1/config/activate_env.sh
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,12 +171,12 @@ jobs:
             [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
             [[ $(uname) == Darwin ]] && brew update && brew install mpich
             cd ..
-            git config user.email "stupid@dumb.com"
-            git config user.name "CI Runner"
             git clone https://github.com/illinois-ceesd/emirge emirge.y1
             cd emirge.y1
             ./install.sh --branch=y1-production
             cd mirgecom
+            git config user.email "stupid@dumb.com"
+            git config user.name "CI Runner"
             git checkout -b production-test
             . ../../mirgecom/mirgecom/.ci-support/production-setup.sh
             git remote add changes https://github.com/${GITHUB_REPOSITORY_OWNER}/mirgecom
@@ -191,6 +191,8 @@ jobs:
             source emirge.y1/config/activate_env.sh
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver
+            git config user.email "stupid@dumb.com"
+            git config user.name "CI Runner"
             . ../mirgecom/mirgecom/.ci-support/production-driver-setup.sh
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,11 +159,19 @@ jobs:
  
         - name: Run Y1 production test
           run: |
-            cd ..
-            # source emirge/config/activate_env.sh
-            git checkout -b current_branch
-            git checkout y1-production
-            git merge current_branch
+            cd ../../
+            conda deactivate
+            git clone https://github.com/illinois-ceesd/emirge emirge.y1
+            cd emirge.y1
+            ./install.sh --branch=${GITHUB_REF##*/}
+            source config/activate_env.sh
+            cd mirgecom
+            git remote add ceesd https://illinois-ceesd/mirgecom
+            git fetch ceesd
+            git checkout ceesd/y1-production
+            pip install -r requirements.txt
+            git checkout ${GITHUB_REF##*/}
+            git merge y1-production
             git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver/smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,10 +189,10 @@ jobs:
           run: |
             cd ..
             source emirge.y1/config/activate_env.sh
-            git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
+            git clone https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver
             git config user.email "stupid@dumb.com"
             git config user.name "CI Runner"
             . ../mirgecom/.ci-support/production-driver-setup.sh
-            cd y1-production-driver/smoke_test
+            cd smoke_test
             python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,3 +156,14 @@ jobs:
             source emirge/config/activate_env.sh
             cd mirgecom/examples
             python -m mpi4py ./wave-eager-mpi.py
+ 
+        - name: Run Y1 production test
+          run: |
+            cd ..
+            # source emirge/config/activate_env.sh
+            git checkout -b current_branch
+            git checkout y1-production
+            git merge current_branch
+            git clone -b update-y1-callbacks https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
+            cd y1-production-driver/smoke_test
+            python -m mpi4py ./nozzle.py -i run_params.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,11 +177,10 @@ jobs:
 
         - name: Run Y1 production test
           run: |
-            source config/activate_env.sh
-            cd mirgecom
             env
-            echo "GITHUB_HEAD_REF: ${GITHUB_HEAD_REF}"
-            echo "Testing Branch: ${GITHUB_HEAD_REF}"
+            cd ..
+            source emirge/config/activate_env.sh
+            cd emirge/mirgecom
             git checkout ${GITHUB_HEAD_REF}
             git checkout y1-production
             git config user.email "stupid@dumb.com"


### PR DESCRIPTION
This adds a production case checker to the CI, to test changes to main against our production problem.

- Uses emirge to install the default `y1-production`
- Uses .ci-support/production-setup.sh to apply any changes to `y1-production` that could be required to support the current change-set
- Merges the current change-set to `y1-production`
- Checks out the default production driver (nozzle)
- Uses .ci-support/production-driver-setup.sh to apply any changes to the production driver required to support the current change-set
- Runs @anderson2981's production driver test (smoke_test)

Let's say you have a change to make to main, by default this CI will check that if `y1-production` merges the "new main" (i.e. main with your changes applied) will result in a running production problem.  If not:

- For example your change set does not cleanly merge to `y1-production`:
  - Pull `y1-production` - make the necessary changes and push a branch/fork/PR with your proposed changes to `y1-production` to bring it up-to-date with your change-set.
  - Set up .ci-support/production-setup.sh to apply your changes by changing:
    - PRODUCTION_CHANGE_OWNER="illinois-ceesd" (or your user name if using a fork)
    - PRODUCTION_CHANGE_BRANCH="propose-y1-production-change"  (i.e. your branch name)
  - Push to kick off CI.  CI will apply your changes to y1-production before attempting to merge the current change-set.
- For example the default production driver does not work with your version of `y1-production`
  - Pull the default production driver (we're using nozzle: illinois-ceesd/drivers_y1-nozzle) and push a branch/fork/PR with your proposed changes to bring the driver up-to-date with your changed version of `y1-production`.
  - Set up .ci-support/production-driver-setup.sh to apply your changes by changing:
    - PRODUCTION_DRIVER_CHANGE_OWNER="illinois-ceesd" (or your user name if using a fork)
    - PRODUCTION_DRIVER_CHANGE_BRANCH="proposed-driver-changes" (i.e. your branch name)
  - Push to kick off CI.  CI will apply your proposed driver changes before attempting to run the driver.
 
This is currently being tested with my proposed changes to a production driver to bring it into working condition with the current mirgecom@{main,y1-production}.  Local changes (i.e. those living inside illinois-ceesd) and forks should work.