### PR TITLE
Add gitattributes preventing merge mods to production prep scripts

### DIFF
--- a/.ci-support/.gitattributes
+++ b/.ci-support/.gitattributes
@@ -1,2 +1,2 @@
 production_setup.sh merge=ours
-prodution_driver_setup.sh merge=ours
+production_driver_setup.sh merge=ours

--- a/.ci-support/.gitattributes
+++ b/.ci-support/.gitattributes
@@ -1,0 +1,2 @@
+production_setup.sh merge=ours
+prodution_driver_setup.sh merge=ours

--- a/.ci-support/.gitattributes
+++ b/.ci-support/.gitattributes
@@ -1,2 +1,2 @@
-production_setup.sh merge=ours
-production_driver_setup.sh merge=ours
+production-setup.sh merge=ours
+production-driver-setup.sh merge=ours

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,14 +175,12 @@ jobs:
             cd emirge.y1
             ./install.sh --branch=y1-production
             cd mirgecom
-            env
             . ../../mirgecom/.ci-support/production-setup.sh
 
         - name: Run Y1 production test
           run: |
             cd ..
             source emirge.y1/config/activate_env.sh
-            env
             git clone https://github.com/illinois-ceesd/drivers_y1-nozzle y1-production-driver
             cd y1-production-driver
             . ../mirgecom/.ci-support/production-driver-setup.sh


### PR DESCRIPTION
Keeps merges from changing the production tests. Unrelated: removes CI environment inspection.