### PR TITLE
Logging: Convert to post LogQuantity

### DIFF
--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -39,7 +39,8 @@ __doc__ = """
 .. autofunction:: logmgr_set_time
 """
 
-from logpyle import (LogQuantity, LogManager, MultiLogQuantity, add_run_info,
+from logpyle import (LogQuantity, PostLogQuantity, LogManager,
+    MultiPostLogQuantity, add_run_info,
     add_general_quantities, add_simulation_quantities)
 from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.discretization import Discretization
@@ -230,7 +231,7 @@ class StateConsumer:
 # {{{ Discretization-based quantities
 
 
-class DiscretizationBasedQuantity(LogQuantity, StateConsumer):
+class DiscretizationBasedQuantity(PostLogQuantity, StateConsumer):
     """Logging support for physical quantities.
 
     Possible rank aggregation operations (``op``) are: min, max, L2_norm.
@@ -288,7 +289,7 @@ class DiscretizationBasedQuantity(LogQuantity, StateConsumer):
 
 # {{{ Kernel profile quantities
 
-class KernelProfile(MultiLogQuantity):
+class KernelProfile(MultiPostLogQuantity):
     """Logging support for statistics of the OpenCL kernel profiling (num_calls, \
     time, flops, bytes_accessed, footprint).
 
@@ -336,7 +337,7 @@ class KernelProfile(MultiLogQuantity):
 
 # {{{ Memory profiling
 
-class PythonMemoryUsage(LogQuantity):
+class PythonMemoryUsage(PostLogQuantity):
     """Logging support for Python memory usage (RSS, host).
 
     Uses :mod:`psutil` to track memory usage. Virtually no overhead.
@@ -357,7 +358,7 @@ class PythonMemoryUsage(LogQuantity):
         return self.process.memory_info()[0] / 1024 / 1024
 
 
-class DeviceMemoryUsage(LogQuantity):
+class DeviceMemoryUsage(PostLogQuantity):
     """Logging support for GPU memory usage (Nvidia only currently)."""
 
     def __init__(self, name: str = None) -> None:


### PR DESCRIPTION
Should fix https://github.com/illinois-ceesd/logpyle/issues/70

When running `python -m mpi4py examples/vortex-mpi.py`:

before:
`step.max=0 | t_step.max=0.357478s | t_log.max=9.13143e-05s | min_temperature=0 | L2_norm_momentum1=0 | memory_usage_python.max=106.734MByte |`

after:
`step.max=0 | t_step.max=0.366507s | t_log.max=5.31673e-05s | min_temperature=0.00231604 | L2_norm_momentum1=9.96694 | memory_usage_python.max=130.578MByte |`