### PR TITLE
Revert production-testing-env.sh after inadvertently changing it.

### DIFF
--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -15,7 +15,7 @@ set -x
 # patched by the incoming development. The following vars control the
 # production environment:
 #
-export PRODUCTION_BRANCH="y1-production-testing"   # The base production branch to be installed by emirge
+# export PRODUCTION_BRANCH=""   # The base production branch to be installed by emirge
 # export PRODUCTION_CHANGE_FORK=""  # The fork/home of production changes (if any)
 # export PRODUCTION_CHANGE_BRANCH=""  # Branch from which to pull prod changes (if any)
 #


### PR DESCRIPTION
A merge twisted this file - but it's ok for main. It would be nice if the default behavior (even for branches) was to test against the current y1-production.  This change makes it so.