### PR TITLE
Update to emirge fork support

### DIFF
--- a/.ci-support/production-install.sh
+++ b/.ci-support/production-install.sh
@@ -55,7 +55,7 @@ git config user.name "CI Runner"
 
 # Merge in the current developement if !main
 if [ -n "$DEVELOPMENT_BRANCH" ]; then
-    if [ -z "$DEVELOPMENT_FORK"]; then
+    if [ -z "$DEVELOPMENT_FORK" ]; then
         DEVELOPMENT_FORK="illinois-ceesd"
     fi
     git remote add changes https://github.com/${DEVELOPMENT_FORK}/mirgecom

--- a/.ci-support/production-install.sh
+++ b/.ci-support/production-install.sh
@@ -23,11 +23,11 @@
 set -x
 
 # defaults and automatics
+HOME_FORK="illinois-ceesd"
+DEVELOPMENT_FORK="$HOME_FORK"
 DEVELOPMENT_BRANCH="$GITHUB_HEAD_REF"  # this will be empty for main
-DEVELOPMENT_FORK="illinois-ceesd"
+PRODUCTION_FORK="${HOME_FORK}"
 PRODUCTION_BRANCH="y1-production"
-PRODUCTION_CHANGE_FORK=""
-PRODUCTION_CHANGE_BRANCH=""
 PRODUCTION_ENV_FILE="$1"
 if [ -n "$DEVELOPMENT_BRANCH" ]; then
     if [ -e "$PRODUCTION_ENV_FILE" ]; then
@@ -43,30 +43,15 @@ echo "PRODUCTION_ENV_FILE=$PRODUCTION_ENV_FILE"
 echo "DEVELOPMENT_FORK=$DEVELOPMENT_FORK"
 echo "DEVELOPMENT_BRANCH=$DEVELOPMENT_BRANCH"
 echo "PRODUCTION_BRANCH=$PRODUCTION_BRANCH"
-echo "PRODUCTION_CHANGE_FORK=$PRODUCTION_CHANGE_FORK"
-echo "PRODUCTION_CHANGE_BRANCH=$PRODUCTION_CHANGE_BRANCH"
+echo "PRODUCTION_FORK=$PRODUCTION_FORK"
 
 # Install the production branch with emirge
-./install.sh --branch=${PRODUCTION_BRANCH}
+./install.sh --fork=${PRODUCTION_FORK} --branch=${PRODUCTION_BRANCH}
 cd mirgecom
 
 # This junk is needed to be able to execute git commands properly
 git config user.email "ci-runner@ci.machine.com"
 git config user.name "CI Runner"
-
-# Make any requested changes to production
-if [ -n "${PRODUCTION_CHANGE_BRANCH}" ]; then
-    if [ -z "${PRODUCTION_CHANGE_FORK}"]; then
-        PRODUCTION_CHANGE_FORK="illinois-ceesd"
-    fi
-    git remote add production_change https://github.com/${PRODUCTION_CHANGE_FORK}/mirgecom
-    git fetch production_change
-    git checkout production_change/${PRODUCTION_CHANGE_BRANCH}
-    git checkout ${PRODUCTION_BRANCH}
-    git merge production_change/${PRODUCTION_CHANGE_BRANCH} --no-edit
-else
-    echo "No updates to production branch (${PRODUCTION_BRANCH})"
-fi
 
 # Merge in the current developement if !main
 if [ -n "$DEVELOPMENT_BRANCH" ]; then

--- a/.ci-support/production-install.sh
+++ b/.ci-support/production-install.sh
@@ -49,6 +49,7 @@ echo "PRODUCTION_BRANCH=$PRODUCTION_BRANCH"
 
 # Install the production branch with emirge
 ./install.sh --fork=${DEVELOPMENT_FORK} --branch=${DEVELOPMENT_BRANCH}
+source config/activate_env.sh
 cd mirgecom
 
 # This junk is needed to be able to execute git commands properly
@@ -59,3 +60,4 @@ git config user.name "CI Runner"
 git remote add production https://github.com/${PRODUCTION_FORK}/mirgecom
 git fetch production
 git merge production/${PRODUCTION_BRANCH} --no-edit
+pip install -r requirements.txt

--- a/.ci-support/production-install.sh
+++ b/.ci-support/production-install.sh
@@ -7,19 +7,19 @@
 #
 # The proposed changes to test may be in a fork, or a local branch. For
 # forks, the environment config files should set:
-
-# DEVELOPMENT_FORK = The fork from which the changes are coming (if any)
+#
+# DEVELOPMENT_FORK = The development fork (default=illinois-ceesd)
 #
 # The production capability to test against may be specified outright, or
 # patched by the incoming development. The following vars control the
 # production environment:
 #
-# PRODUCTION_BRANCH = The base production branch to be installed by emirge
-# PRODUCTION_CHANGE_FORK = The fork/home of production changes (if any)
-# PRODUCTION_CHANGE_BRANCH = Branch from which to pull prod changes (if any)
+# PRODUCTION_BRANCH = The production branch (default=y1-production)
+# PRODUCTION_FORK = The production fork (default=illinois-ceesd)
 #
 # If the environment file does not exist, the current development is
-# tested against `mirgecom@y1-production`. 
+# tested against `mirgecom@y1-production`.
+#
 set -x
 
 if [ -n "$DEVELOPMENT_BRANCH" ]; then

--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -16,8 +16,7 @@ set -x
 # production environment:
 #
 # export PRODUCTION_BRANCH=""   # The base production branch to be installed by emirge
-# export PRODUCTION_CHANGE_FORK=""  # The fork/home of production changes (if any)
-# export PRODUCTION_CHANGE_BRANCH=""  # Branch from which to pull prod changes (if any)
+# export PRODUCTION_FORK=""  # The fork/home of production changes (if any)
 #
 # The production driver repo is specified by the following vars:
 #


### PR DESCRIPTION
This change set uses emirge fork support to deeply simplify the production testing - which is now *much* closer to @matthiasdiener's preference:

1. install user's development (automatic, specify fork if needed)
2. merge the production environment (fork and branch customizable)
3. install production requirements.txt
4. run the user's production driver (fork and branch customizable)

If running on main, all user customizations are ignored. The defaults are
those which main uses. (illinois-ceesd, y1-production, nozzle)