### PR TITLE
Test pulse, not wave

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,7 +145,7 @@ jobs:
             cd ..
             source emirge/config/activate_env.sh
             cd mirgecom/examples
-            python -m mpi4py ./wave-eager-mpi.py
+            python -m mpi4py ./pulse-mpi.py
 
     y1: 
         name: Production testing


### PR DESCRIPTION
Use pulse as a test problem instead of wave-eager-mpi, which is sort of going away anyway.