### PR TITLE
Add tests for lazily-compiled operators

### DIFF
--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -73,14 +73,15 @@ def op_test_data(ctx_factory):
     return eager_actx, lazy_actx, get_discr
 
 
-def _rel_linf_error(discr, x, y):
+def _rel_linf_error(discr, actual, expected):
     from mirgecom.fluid import ConservedVars
-    if isinstance(x, ConservedVars):
-        return _rel_linf_error(discr, x.join(), y)
-    if isinstance(y, ConservedVars):
-        return _rel_linf_error(discr, x, y.join())
+    if isinstance(actual, ConservedVars):
+        return _rel_linf_error(discr, actual.join(), expected)
+    if isinstance(expected, ConservedVars):
+        return _rel_linf_error(discr, actual, expected.join())
     return np.max(obj_array_vectorize_n_args(
-        lambda a, b: discr.norm(a - b, np.inf) / discr.norm(b, np.inf), x, y))
+        lambda a, b: discr.norm(a - b, np.inf) / discr.norm(b, np.inf),
+        actual, expected))
 
 
 # FIXME: Re-enable and fix up if/when standalone gradient operator exists

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -209,7 +209,7 @@ def test_lazy_op_euler(op_test_data, order):
         nodes = thaw(discr.nodes(), actx)
         from mirgecom.initializers import MulticomponentLump
         init = MulticomponentLump(
-            dim=2, velocity=np.ones(2), spec_y0s=np.ones(3),
+            dim=2, nspecies=3, velocity=np.ones(2), spec_y0s=np.ones(3),
             spec_amplitudes=np.ones(3))
         state = init(nodes)
         return state,

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -1,0 +1,188 @@
+__copyright__ = """Copyright (C) 2021 University of Illinois Board of Trustees"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+import pyopencl as cl
+import pyopencl.tools as cl_tools
+import pyopencl.array as cla  # noqa
+import pyopencl.clmath as clmath  # noqa
+from meshmode.array_context import (  # noqa
+    PyOpenCLArrayContext,
+    PytatoPyOpenCLArrayContext
+)
+
+from meshmode.array_context import (  # noqa
+    pytest_generate_tests_for_pyopencl_array_context
+    as pytest_generate_tests)
+
+import pytest  # noqa
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def _op_test_fixture(cl_ctx):
+    queue = cl.CommandQueue(cl_ctx)
+    actx = PytatoPyOpenCLArrayContext(
+        queue,
+        allocator=cl_tools.MemoryPool(cl_tools.ImmediateAllocator(queue)))
+
+    n = 4
+
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    mesh = generate_regular_rect_mesh(
+        a=(-0.5,)*2,
+        b=(0.5,)*2,
+        nelements_per_axis=(n,)*2,
+        boundary_tag_to_face={
+            "x": ["-x", "+x"],
+            "y": ["-y", "+y"]
+        })
+
+    from grudge.eager import EagerDGDiscretization
+    discr = EagerDGDiscretization(actx, mesh, order=2)
+
+    return actx, discr
+
+
+# FIXME: Re-enable and fix up if/when standalone gradient operator exists
+# def test_lazy_op_gradient(ctx_factory):
+#     cl_ctx = ctx_factory()
+#     actx, discr = _op_test_fixture(cl_ctx)
+#
+#     from grudge.dof_desc import DTAG_BOUNDARY, DISCR_TAG_BASE
+#     from mirgecom.diffusion import (
+#         _gradient_operator,
+#         DirichletDiffusionBoundary,
+#         NeumannDiffusionBoundary)
+#
+#     boundaries = {
+#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0.),
+#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0.)
+#     }
+#
+#     def op(alpha, u):
+#         return _gradient_operator(
+#             discr, DISCR_TAG_BASE, alpha, boundaries, u)
+
+#     compiled_op = actx.compile(op)
+#     alpha = discr.zeros(actx) + 1
+#     u = discr.zeros(actx)
+#     compiled_op(alpha, u)
+
+
+# FIXME: Re-enable and fix up if/when standalone divergence operator exists
+# def test_lazy_op_divergence(ctx_factory):
+#     cl_ctx = ctx_factory()
+#     actx, discr = _op_test_fixture(cl_ctx)
+#
+#     from grudge.dof_desc import DTAG_BOUNDARY, DISCR_TAG_BASE
+#     from mirgecom.diffusion import (
+#         _divergence_alpha_operator,
+#         DirichletDiffusionBoundary,
+#         NeumannDiffusionBoundary)
+#
+#     boundaries = {
+#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0.),
+#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0.)
+#     }
+#
+#     def op(alpha, u):
+#         return _divergence_alpha_operator(
+#             discr, DISCR_TAG_BASE, alpha, boundaries, u)
+
+#     compiled_op = actx.compile(op)
+#     alpha = discr.zeros(actx) + 1
+#     u = make_obj_array([discr.zeros(actx) for _ in range(2)])
+#     compiled_op(alpha, u)
+
+
+def test_lazy_op_diffusion(ctx_factory):
+    cl_ctx = ctx_factory()
+    actx, discr = _op_test_fixture(cl_ctx)
+
+    from grudge.dof_desc import DTAG_BOUNDARY, DISCR_TAG_BASE
+    from mirgecom.diffusion import (
+        diffusion_operator,
+        DirichletDiffusionBoundary,
+        NeumannDiffusionBoundary)
+
+    boundaries = {
+        DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0.),
+        DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0.)
+    }
+
+    def op(alpha, u):
+        return diffusion_operator(
+            discr, DISCR_TAG_BASE, alpha, boundaries, u)
+
+    compiled_op = actx.compile(op)
+
+    alpha = discr.zeros(actx) + 1
+    u = discr.zeros(actx)
+
+    eager_result = op(alpha, u)
+    lazy_result = compiled_op(alpha, u)
+    assert discr.norm(lazy_result - eager_result, np.inf) < 1e-15
+
+
+def test_lazy_op_euler(ctx_factory):
+    cl_ctx = ctx_factory()
+    actx, discr = _op_test_fixture(cl_ctx)
+
+    from grudge.dof_desc import DTAG_BOUNDARY
+    from mirgecom.fluid import make_conserved
+    from mirgecom.eos import IdealSingleGas
+    from mirgecom.boundary import AdiabaticSlipBoundary
+    from mirgecom.euler import euler_operator
+
+    eos = IdealSingleGas()
+
+    boundaries = {
+        DTAG_BOUNDARY("x"): AdiabaticSlipBoundary(),
+        DTAG_BOUNDARY("y"): AdiabaticSlipBoundary()
+    }
+
+    def op(cv):
+        return euler_operator(discr, eos, boundaries, cv)
+
+    compiled_op = actx.compile(op)
+
+    cv = make_conserved(
+        dim=2,
+        mass=discr.zeros(actx) + 1,
+        energy=discr.zeros(actx) + 1,
+        momentum=discr.zeros(actx) + np.array([1, 2]),
+        species_mass=discr.zeros(actx) + np.array([0.5, 0.25, 0.25]))
+
+    eager_result = op(cv)
+    lazy_result = compiled_op(cv)
+    assert discr.norm((lazy_result - eager_result).join(), np.inf) < 1e-15
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 import numpy as np
 from functools import partial
-from pytools.obj_array import make_obj_array
+from pytools.obj_array import make_obj_array, obj_array_vectorize_n_args
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 import pyopencl.array as cla  # noqa
@@ -79,7 +79,8 @@ def _rel_linf_error(discr, x, y):
         return _rel_linf_error(discr, x.join(), y)
     if isinstance(y, ConservedVars):
         return _rel_linf_error(discr, x, y.join())
-    return discr.norm(x - y, np.inf) / discr.norm(y, np.inf)
+    return np.max(obj_array_vectorize_n_args(
+        lambda a, b: discr.norm(a - b, np.inf) / discr.norm(b, np.inf), x, y))
 
 
 # FIXME: Re-enable and fix up if/when standalone gradient operator exists

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -87,8 +87,8 @@ def _rel_linf_error(discr, x, y):
 #         NeumannDiffusionBoundary)
 #
 #     boundaries = {
-#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0.),
-#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0.)
+#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0),
+#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0)
 #     }
 #
 #     def op(alpha, u):
@@ -113,8 +113,8 @@ def _rel_linf_error(discr, x, y):
 #         NeumannDiffusionBoundary)
 #
 #     boundaries = {
-#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0.),
-#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0.)
+#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0),
+#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0)
 #     }
 #
 #     def op(alpha, u):
@@ -139,8 +139,8 @@ def test_lazy_op_diffusion(ctx_factory):
         NeumannDiffusionBoundary)
 
     boundaries = {
-        DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0.),
-        DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0.)
+        DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0),
+        DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0)
     }
 
     def op(alpha, u):


### PR DESCRIPTION
Only diffusion/Euler for now. Production version with NS/AV [here](https://github.com/majosm/mirgecom/blob/lazy-operator-tests-ns-av/test/test_lazy.py).