### PR TITLE
enable more lazy examples

### DIFF
--- a/examples/heat-source-mpi-lazy.py
+++ b/examples/heat-source-mpi-lazy.py
@@ -1,0 +1,1 @@
+heat-source-mpi.py

--- a/examples/lump-mpi-lazy.py
+++ b/examples/lump-mpi-lazy.py
@@ -1,0 +1,1 @@
+lump-mpi.py

--- a/examples/scalar-lump-mpi-lazy.py
+++ b/examples/scalar-lump-mpi-lazy.py
@@ -1,0 +1,1 @@
+scalar-lump-mpi.py

--- a/examples/wave-mpi-lazy.py
+++ b/examples/wave-mpi-lazy.py
@@ -1,0 +1,1 @@
+wave-mpi.py


### PR DESCRIPTION
Missing:
- sod-mpi (needs better slicing support in pytato)
- mixture-mpi (needs pyrometheus support)
- autoignition-mpi (needs pyrometheus support)