### PR TITLE
profiling: fix elwise kernel exec hook

### DIFF
--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -114,6 +114,8 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
 
     def clone(self):
         """Return a semantically equivalent but distinct version of *self*."""
+        from warnings import warn
+        warn("Cloned PyOpenCLProfilingArrayContexts can not profile elementwise PyOpenCL kernels.")
         return type(self)(self.queue, self.allocator, self.logmgr)
 
     def __del__(self):

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -1,4 +1,4 @@
-"""An array context with profiling capabilities."""
+"""An array context with kernel profiling capabilities."""
 
 __copyright__ = """
 Copyright (C) 2020 University of Illinois Board of Trustees
@@ -73,7 +73,7 @@ class ProfileEvent:
 
 
 class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
-    """An array context that profiles kernel executions.
+    """An array context that profiles OpenCL kernel executions.
 
     .. automethod:: tabulate_profiling_data
     .. automethod:: call_loopy
@@ -81,6 +81,13 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
     .. automethod:: reset_profiling_data_for_kernel
 
     Inherits from :class:`arraycontext.PyOpenCLArrayContext`.
+
+    .. note::
+
+       Profiling of :mod:`pyopencl` kernels (that is, kernels that do not get
+       called through :meth:`call_loopy`) is restricted to a single instance of
+       this class. If there are multiple instances, only the first one created
+       will be able to profile these kernels.
     """
 
     def __init__(self, queue, allocator=None, logmgr: LogManager = None) -> None:
@@ -114,8 +121,6 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
         del self.profile_events[:]
         self.profile_results.clear()
         self.kernel_stats.clear()
-
-        cl.array.ARRAY_KERNEL_EXEC_HOOK = None
 
     def array_kernel_exec_hook(self, knl, queue, gs, ls, *actual_args, wait_for):
         """Extract data from the elementwise array kernel."""

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -115,7 +115,8 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
     def clone(self):
         """Return a semantically equivalent but distinct version of *self*."""
         from warnings import warn
-        warn("Cloned PyOpenCLProfilingArrayContexts can not profile elementwise PyOpenCL kernels.")
+        warn("Cloned PyOpenCLProfilingArrayContexts can not "
+             "profile elementwise PyOpenCL kernels.")
         return type(self)(self.queue, self.allocator, self.logmgr)
 
     def __del__(self):

--- a/mirgecom/profiling.py
+++ b/mirgecom/profiling.py
@@ -101,7 +101,9 @@ class PyOpenCLProfilingArrayContext(PyOpenCLArrayContext):
         self.kernel_stats = {}
         self.logmgr = logmgr
 
-        cl.array.ARRAY_KERNEL_EXEC_HOOK = self.array_kernel_exec_hook
+        # Only store the first kernel exec hook for elwise kernels
+        if cl.array.ARRAY_KERNEL_EXEC_HOOK is None:
+            cl.array.ARRAY_KERNEL_EXEC_HOOK = self.array_kernel_exec_hook
 
     def clone(self):
         """Return a semantically equivalent but distinct version of *self*."""


### PR DESCRIPTION
This restores profiling of the elwise kernels.

Grudge e.g. creates temporary (?) actx copies when building face connections that will point the exec hook to an actx that isn't used throughout the actual execution.