### PR TITLE
Tweak symbolic `div` and `grad`

### DIFF
--- a/mirgecom/symbolic.py
+++ b/mirgecom/symbolic.py
@@ -31,7 +31,7 @@ THE SOFTWARE.
 
 import numpy as np
 import numpy.linalg as la # noqa
-# from pytools.obj_array import flat_obj_array
+from pytools.obj_array import make_obj_array
 import pymbolic as pmbl
 import pymbolic.primitives as prim
 import pymbolic.mapper.evaluator as ev
@@ -58,16 +58,13 @@ def div(vector_func):
     """Return the symbolic divergence of *vector_func*."""
     dim = len(vector_func)
     coords = prim.make_sym_vector("x", dim)
-    div = 0
-    for i in range(dim):
-        div += diff(coords[i])(vector_func[i])
-    return div
+    return sum([diff(coords[i])(vector_func[i]) for i in range(dim)])
 
 
 def grad(dim, func):
     """Return the symbolic *dim*-dimensional gradient of *func*."""
     coords = prim.make_sym_vector("x", dim)
-    return [diff(coords[i])(func) for i in range(dim)]
+    return make_obj_array([diff(coords[i])(func) for i in range(dim)])
 
 
 class EvaluationMapper(ev.EvaluationMapper):

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -152,7 +152,7 @@ def get_decaying_trig_truncated_domain(dim, alpha):
             return sym.EvaluationMapper({"x": nodes, "t": t})(expr)
 
         exact_u = sym_eval(sym_u)
-        exact_grad_u = make_obj_array(sym_eval(sym.grad(dim, sym_u)))
+        exact_grad_u = sym_eval(sym.grad(dim, sym_u))
 
         boundaries = {}
 
@@ -219,7 +219,7 @@ def get_static_trig_var_diff(dim):
 def sym_diffusion(dim, sym_alpha, sym_u):
     """Return a symbolic expression for the diffusion operator applied to a function.
     """
-    return sym.div([sym_alpha * grad_i for grad_i in sym.grad(dim, sym_u)])
+    return sym.div(sym_alpha * sym.grad(dim, sym_u))
 
 
 # Note: Must integrate in time for a while in order to achieve expected spatial


### PR DESCRIPTION
Simplifies the implementation of `sym.div` and makes `sym.grad` return an object array. (Is there any reason it might not be OK to return an object array here, @inducer? I couldn't figure out why I made it return a list originally.)