### PR TITLE
Bump tolerances in test_lazy for P^0 geometry

### DIFF
--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -188,7 +188,7 @@ def test_lazy_op_diffusion(op_test_data, order):
         u = actx.np.cos(np.pi*nodes[0])
         return alpha, u
 
-    tol = 1e-12
+    tol = 1e-11
     isclose = partial(
         _isclose, discr, rel_tol=tol, abs_tol=tol, return_operands=True)
 
@@ -218,7 +218,7 @@ def _get_pulse():
         BTAG_ALL: AdiabaticSlipBoundary()
     }
 
-    return eos, init, boundaries, 1e-12
+    return eos, init, boundaries, 3e-12
 
 
 def _get_scalar_lump():
@@ -236,7 +236,7 @@ def _get_scalar_lump():
         BTAG_ALL: PrescribedInviscidBoundary(fluid_solution_func=init)
     }
 
-    return eos, init, boundaries, 1e-12
+    return eos, init, boundaries, 5e-12
 
 
 @pytest.mark.parametrize("order", [1, 2, 3])


### PR DESCRIPTION
This is for the benefit of https://github.com/inducer/grudge/pull/161, which starts using P^0 (that is, constant) geometry terms for affinely mapped simplices whenever possible, for a major cost reduction and additional transform opportunities. (Doing so requires broadcasting semantics, which are only properly implemented for lazy eval, so this only benefits lazy for the moment.)

I'm not super worried about these tolerance bumps; if anything, I'd expect the P^0 geometry to be *more* accurate (but quite possibly a bit different from our prior all-curvi approach).