### PR TITLE
Fix restart reading of `num_parts` in examples

### DIFF
--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -134,7 +134,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_mesh = restart_data["local_mesh"]
         local_nelements = local_mesh.nelements
         global_nelements = restart_data["global_nelements"]
-        assert restart_data["nparts"] == nparts
+        assert restart_data["num_parts"] == nparts
     else:  # generate the grid from scratch
         box_ll = -5.0
         box_ur = 5.0

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -135,7 +135,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_mesh = restart_data["local_mesh"]
         local_nelements = local_mesh.nelements
         global_nelements = restart_data["global_nelements"]
-        assert restart_data["nparts"] == nparts
+        assert restart_data["num_parts"] == nparts
     else:  # generate the grid from scratch
         nel_1d = 16
         box_ll = -5.0

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -135,7 +135,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_mesh = restart_data["local_mesh"]
         local_nelements = local_mesh.nelements
         global_nelements = restart_data["global_nelements"]
-        assert restart_data["nparts"] == num_parts
+        assert restart_data["num_parts"] == num_parts
     else:  # generate the grid from scratch
         from meshmode.mesh.generation import generate_regular_rect_mesh
         box_ll = -0.5

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -133,7 +133,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_mesh = restart_data["local_mesh"]
         local_nelements = local_mesh.nelements
         global_nelements = restart_data["global_nelements"]
-        assert restart_data["nparts"] == nparts
+        assert restart_data["num_parts"] == nparts
     else:  # generate the grid from scratch
         box_ll = -5.0
         box_ur = 5.0

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -132,7 +132,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_mesh = restart_data["local_mesh"]
         local_nelements = local_mesh.nelements
         global_nelements = restart_data["global_nelements"]
-        assert restart_data["nparts"] == num_parts
+        assert restart_data["num_parts"] == num_parts
     else:  # generate the grid from scratch
         from meshmode.mesh.generation import generate_regular_rect_mesh
         nel_1d = 24

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -136,7 +136,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_mesh = restart_data["local_mesh"]
         local_nelements = local_mesh.nelements
         global_nelements = restart_data["global_nelements"]
-        assert restart_data["nparts"] == num_parts
+        assert restart_data["num_parts"] == num_parts
     else:  # generate the grid from scratch
         nel_1d = 16
         box_ll = -5.0


### PR DESCRIPTION
Fixes the restart reading to use the same name for the partition count when reading as when writing (`num_parts`).