### PR TITLE
Refactor `allsync`

### DIFF
--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -88,6 +88,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     rank = comm.Get_rank()
     nparts = comm.Get_size()
 
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
     logmgr = initialize_logmgr(use_logmgr,
         filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
 
@@ -271,11 +274,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
             if do_health:
                 dv = eos.dependent_vars(state)
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
-                from mirgecom.simutil import allsync
-                health_errors = allsync(
-                    my_health_check(dv=dv, state=state, exact=exact),
-                    comm, op=MPI.LOR
-                )
+                health_errors = global_reduce(
+                    my_health_check(dv=dv, state=state, exact=exact), op="lor")
                 if health_errors:
                     if rank == 0:
                         logger.info("Fluid solution failed health check.")

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -91,6 +91,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     rank = comm.Get_rank()
     nparts = comm.Get_size()
 
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
     logmgr = initialize_logmgr(use_logmgr,
         filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
 
@@ -295,9 +298,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
                 component_errors = compare_fluid_solutions(discr, state, exact)
-                from mirgecom.simutil import allsync
-                health_errors = allsync(my_health_check(dv, component_errors), comm,
-                                        op=MPI.LOR)
+                health_errors = global_reduce(
+                    my_health_check(dv, component_errors), op="lor")
                 if health_errors:
                     if rank == 0:
                         logger.info("Fluid solution failed health check.")

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -91,6 +91,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     rank = comm.Get_rank()
     num_parts = comm.Get_size()
 
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
     logmgr = initialize_logmgr(use_logmgr,
         filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
 
@@ -254,9 +257,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
             if do_health:
                 dv = eos.dependent_vars(state)
-                from mirgecom.simutil import allsync
-                health_errors = allsync(my_health_check(dv.pressure), comm,
-                                        op=MPI.LOR)
+                health_errors = global_reduce(my_health_check(dv.pressure), op="lor")
                 if health_errors:
                     if rank == 0:
                         logger.info("Fluid solution failed health check.")

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -89,6 +89,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     rank = comm.Get_rank()
     nparts = comm.Get_size()
 
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
     logmgr = initialize_logmgr(use_logmgr,
         filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
 
@@ -283,11 +286,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
                 component_errors = compare_fluid_solutions(discr, state, exact)
-                from mirgecom.simutil import allsync
-                health_errors = allsync(
-                    my_health_check(dv.pressure, component_errors),
-                    comm, op=MPI.LOR
-                )
+                health_errors = global_reduce(
+                    my_health_check(dv.pressure, component_errors), op="lor")
                 if health_errors:
                     if rank == 0:
                         logger.info("Fluid solution failed health check.")

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -88,6 +88,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     rank = comm.Get_rank()
     num_parts = comm.Get_size()
 
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
     logmgr = initialize_logmgr(use_logmgr,
         filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
 
@@ -273,11 +276,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
                 component_errors = compare_fluid_solutions(discr, state, exact)
-                from mirgecom.simutil import allsync
-                health_errors = allsync(
-                    my_health_check(dv.pressure, component_errors),
-                    comm, op=MPI.LOR
-                )
+                health_errors = global_reduce(
+                    my_health_check(dv.pressure, component_errors), op="lor")
                 if health_errors:
                     if rank == 0:
                         logger.info("Fluid solution failed health check.")

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -89,6 +89,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     rank = comm.Get_rank()
     num_parts = comm.Get_size()
 
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
     logmgr = initialize_logmgr(use_logmgr,
         filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
 
@@ -297,11 +300,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
                 component_errors = compare_fluid_solutions(discr, state, exact)
-                from mirgecom.simutil import allsync
-                health_errors = allsync(
-                    my_health_check(dv.pressure, component_errors),
-                    comm, op=MPI.LOR
-                )
+                health_errors = global_reduce(
+                    my_health_check(dv.pressure, component_errors), op="lor")
                 if health_errors:
                     if rank == 0:
                         logger.info("Fluid solution failed health check.")

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -6,7 +6,7 @@ General utilities
 .. autofunction:: check_step
 .. autofunction:: get_sim_timestep
 .. autofunction:: write_visfile
-.. autofunction:: allsync
+.. autofunction:: global_reduce
 
 Diagnostic utilities
 --------------------
@@ -47,6 +47,7 @@ THE SOFTWARE.
 import logging
 import numpy as np
 import grudge.op as op
+from numbers import Number
 
 logger = logging.getLogger(__name__)
 
@@ -175,42 +176,95 @@ def write_visfile(discr, io_fields, visualizer, vizname,
         )
 
 
-def allsync(local_values, comm=None, op=None):
-    """Perform allreduce if MPI comm is provided.
+def global_reduce(local_values, op, *, comm=None):
+    """Perform a global reduction (allreduce if MPI comm is provided).
 
-    This routine is a convenience wrapper for the MPI AllReduce operation.
-    The common use case is to synchronize error indicators across all MPI
-    ranks. If an MPI communicator is not provided, the *local_values* is
-    simply returned.  The reduction operation must be an MPI-supported
-    reduction operation and it defaults to MPI.MAX.
+    This routine is a convenience wrapper for the MPI AllReduce operation
+    that also works outside of an MPI context.
 
     .. note::
         This is a collective routine and must be called by all MPI ranks.
 
     Parameters
     ----------
-    local_values: Any
-        The (MPI-compatible) value or collection of values on which the
+    local_values: numbers.Number or numpy.ndarray
+        The (MPI-compatible) value or array of values on which the
         reduction operation is to be performed.
 
-    comm: *MPI.Comm*
+    op: str
+        Reduction operation to be performed. Must be one of "min", "max", "sum",
+        "prod", "lor", or "land".
+
+    comm:
         Optional parameter specifying the MPI communicator on which the
         reduction operation (if any) is to be performed
-
-    op: *MPI.op*
-        Reduction operation to be performed. Defaults to *MPI.MAX*.
 
     Returns
     -------
     Any ( like *local_values* )
         Returns the result of the reduction operation on *local_values*
     """
+    if comm is not None:
+        from mpi4py import MPI
+        op_to_mpi_op = {
+            "min": MPI.MIN,
+            "max": MPI.MAX,
+            "sum": MPI.SUM,
+            "prod": MPI.PROD,
+            "lor": MPI.LOR,
+            "land": MPI.LAND,
+        }
+        return comm.allreduce(local_values, op=op_to_mpi_op[op])
+    else:
+        if isinstance(local_values, Number):
+            return local_values
+        else:
+            op_to_numpy_func = {
+                "min": np.minimum,
+                "max": np.maximum,
+                "sum": np.add,
+                "prod": np.multiply,
+                "lor": np.logical_or,
+                "land": np.logical_and,
+            }
+            from functools import reduce
+            return reduce(op_to_numpy_func[op], local_values)
+
+
+def allsync(local_values, comm=None, op=None):
+    """
+    Perform allreduce if MPI comm is provided.
+
+    Deprecated. Do not use in new code.
+    """
+    from warnings import warn
+    warn("allsync is deprecated and will disappear in Q1 2022. "
+         "Use global_reduce instead.", DeprecationWarning, stacklevel=2)
+
     if comm is None:
         return local_values
+
+    from mpi4py import MPI
+
     if op is None:
-        from mpi4py import MPI
         op = MPI.MAX
-    return comm.allreduce(local_values, op=op)
+
+    if op == MPI.MIN:
+        op_string = "min"
+    elif op == MPI.MAX:
+        op_string = "max"
+    elif op == MPI.SUM:
+        op_string = "sum"
+    elif op == MPI.PROD:
+        op_string = "prod"
+    elif op == MPI.LOR:
+        op_string = "lor"
+    elif op == MPI.LAND:
+        op_string = "land"
+    else:
+        raise ValueError(f"Unrecognized MPI reduce op {op}.")
+
+    return global_reduce(local_values, op_string, comm=comm)
 
 
 def check_range_local(discr, dd, field, min_value, max_value):


### PR DESCRIPTION
Renames `allsync` to `global_reduce`, and removes MPI ops from its interface so it can be called without importing `mpi4py.MPI`. 

(Trying to make MPI an option in the examples so we can ditch the `-mpi` naming.)

Fixes part of #509.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
