### PR TITLE
Convert results to bool in `check_range_local` and `check_naninf_local`

### DIFF
--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -270,7 +270,7 @@ def allsync(local_values, comm=None, op=None):
 def check_range_local(discr, dd, field, min_value, max_value):
     """Check for any negative values."""
     actx = field.array_context
-    return (
+    return bool(  # Convert to bool because np.bool_ is not a Number
         actx.to_numpy(op.nodal_min_loc(discr, dd, field)) < min_value
         or actx.to_numpy(op.nodal_max_loc(discr, dd, field)) > max_value
     )
@@ -280,7 +280,8 @@ def check_naninf_local(discr, dd, field):
     """Check for any NANs or Infs in the field."""
     actx = field.array_context
     s = actx.to_numpy(op.nodal_sum_loc(discr, dd, field))
-    return not np.isfinite(s)
+    return bool(  # Convert to bool because np.bool_ is not a Number
+        not np.isfinite(s))
 
 
 def compare_fluid_solutions(discr, red_state, blue_state):


### PR DESCRIPTION
So, apparently `isinstance(..., Number)` returns `False` for numpy's boolean type `np.bool_`. This is causing issues in at least one of the examples in `y1-production` where the result of one of these functions is passed into `global_reduce` (which subsequently checks if the input is a `Number`).

We could alternatively change `global_reduce` to check for this, but we already use `isinstance(..., Number)` all over the place, so changing these two return values instead seemed possibly safer?

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
