### PR TITLE
Inviscid boundary interface

### DIFF
--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -51,23 +51,23 @@ from abc import ABCMeta, abstractmethod
 class FluidBoundary(metaclass=ABCMeta):
     r"""Abstract interface to fluid boundary treatment.
 
-    .. automethod:: inviscid_boundary_flux
+    .. automethod:: inviscid_divergence_flux
     """
 
     @abstractmethod
-    def inviscid_boundary_flux(self, discr, btag, cv, eos, **kwargs):
+    def inviscid_divergence_flux(self, discr, btag, cv, eos, **kwargs):
         """Get the inviscid flux across the boundary faces."""
 
 
 class FluidBC(FluidBoundary):
     r"""Abstract interface to boundary conditions.
 
-    .. automethod:: inviscid_boundary_flux
+    .. automethod:: inviscid_divergence_flux
     .. automethod:: boundary_pair
     """
 
     @abstractmethod
-    def inviscid_boundary_flux(self, discr, btag, cv, eos, **kwargs):
+    def inviscid_divergence_flux(self, discr, btag, cv, eos, **kwargs):
         """Get the inviscid part of the physical flux across the boundary *btag*."""
 
     @abstractmethod
@@ -80,15 +80,15 @@ class PrescribedInviscidBoundary(FluidBC):
 
     .. automethod:: __init__
     .. automethod:: boundary_pair
-    .. automethod:: inviscid_boundary_flux
+    .. automethod:: inviscid_divergence_flux
     """
 
-    def __init__(self, inviscid_boundary_flux_func=None, boundary_pair_func=None,
+    def __init__(self, inviscid_divergence_flux_func=None, boundary_pair_func=None,
                  inviscid_facial_flux_func=None, fluid_solution_func=None,
                  fluid_solution_flux_func=None):
         """Initialize the PrescribedInviscidBoundary and methods."""
         self._bnd_pair_func = boundary_pair_func
-        self._inviscid_bnd_flux_func = inviscid_boundary_flux_func
+        self._inviscid_bnd_flux_func = inviscid_divergence_flux_func
         self._inviscid_facial_flux_func = inviscid_facial_flux_func
         if not self._inviscid_facial_flux_func:
             self._inviscid_facial_flux_func = inviscid_facial_flux
@@ -109,7 +109,7 @@ class PrescribedInviscidBoundary(FluidBC):
         ext_soln = self._fluid_soln_func(nodes, cv=int_soln, normal=nhat, **kwargs)
         return TracePair(btag, interior=int_soln, exterior=ext_soln)
 
-    def inviscid_boundary_flux(self, discr, btag, cv, eos, **kwargs):
+    def inviscid_divergence_flux(self, discr, btag, cv, eos, **kwargs):
         """Get the inviscid flux across the boundary faces."""
         if self._inviscid_bnd_flux_func:
             actx = cv.array_context

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -56,7 +56,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
     @abstractmethod
     def inviscid_divergence_flux(self, discr, btag, cv, eos, **kwargs):
-        """Get the inviscid flux across the boundary faces."""
+        """Get the inviscid boundary flux for the divergence operator."""
 
 
 class FluidBC(FluidBoundary):
@@ -68,7 +68,7 @@ class FluidBC(FluidBoundary):
 
     @abstractmethod
     def inviscid_divergence_flux(self, discr, btag, cv, eos, **kwargs):
-        """Get the inviscid part of the physical flux across the boundary *btag*."""
+        """Get the inviscid boundary flux for the divergence operator."""
 
     @abstractmethod
     def boundary_pair(self, discr, btag, cv, eos, **kwargs):
@@ -110,7 +110,7 @@ class PrescribedInviscidBoundary(FluidBC):
         return TracePair(btag, interior=int_soln, exterior=ext_soln)
 
     def inviscid_divergence_flux(self, discr, btag, cv, eos, **kwargs):
-        """Get the inviscid flux across the boundary faces."""
+        """Get the inviscid boundary flux for the divergence operator."""
         if self._inviscid_bnd_flux_func:
             actx = cv.array_context
             boundary_discr = discr.discr_from_dd(btag)

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -108,8 +108,8 @@ def euler_operator(discr, eos, boundaries, cv, time=0.0):
                 part_tpair.dd, interior=make_conserved(discr.dim, q=part_tpair.int),
                 exterior=make_conserved(discr.dim, q=part_tpair.ext)))
               for part_tpair in cross_rank_trace_pairs(discr, cv.join()))
-        + sum(boundaries[btag].inviscid_boundary_flux(discr, btag=btag, cv=cv,
-                                                      eos=eos, time=time)
+        + sum(boundaries[btag].inviscid_divergence_flux(discr, btag=btag, cv=cv,
+                                                        eos=eos, time=time)
               for btag in boundaries)
     )
     q = -div_operator(discr, inviscid_flux_vol.join(), inviscid_flux_bnd.join())


### PR DESCRIPTION
This change set just renames `inviscid_boundary_flux` --> `inviscid_divergence_flux` per discussions in downstream viscous/NS PRs.  

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
