### PR TITLE
Remove extraneous indentation in PR dev docs

### DIFF
--- a/doc/development/pullrequests.rst
+++ b/doc/development/pullrequests.rst
@@ -286,11 +286,11 @@ with this process.  If the PR is accepted for merging to main, then mirgecom
 developers will update the production capabilities to be compatible with
 the changes before merging.
 
-   .. important::
+ .. important::
 
-      Any production environment customizations must be backed out before
-      merging the PR development to main. Never merge a PR development with
-      production environment customizations in-place.
+    Any production environment customizations must be backed out before
+    merging the PR development to main. Never merge a PR development with
+    production environment customizations in-place.
 
 Merging a pull request
 ----------------------


### PR DESCRIPTION
I think it makes sphinx view this as a quote, leading to an inexplicable extra vertical ine:

![image](https://user-images.githubusercontent.com/352067/140523640-18a14c6f-d035-4a11-983b-71ba3a259e7a.png)
