### PR TITLE
Generalize symbolic helper code so it can be used more easily with other tests

### DIFF
--- a/doc/support/math.rst
+++ b/doc/support/math.rst
@@ -1,0 +1,4 @@
+Math
+====
+
+.. automodule:: mirgecom.math

--- a/doc/support/support.rst
+++ b/doc/support/support.rst
@@ -12,5 +12,6 @@ Simulation Support
    input-output
    tools
    symbolic
+   math
    operators
    thermochem

--- a/mirgecom/math.py
+++ b/mirgecom/math.py
@@ -1,5 +1,29 @@
 """Utilities and functions for math.
 
+Functions not explicitly defined here fall back to the appropriate numpy-like math
+function for the provided inputs (if one exists), through :func:`__getattr__`.
+The inputs can be :mod:`numpy` arrays, :mod:`arraycontext` arrays, or :mod:`pymbolic`
+expressions.
+
+:example::
+
+    With :mod:`numpy` input data::
+
+        import mirgecom.math as mm
+
+        x_np = np.array([0, np.pi/2, np.pi])
+        s_np = mm.sin(x_np)  # Calls np.sin
+
+    or :mod:`arraycontext` input data::
+
+        x_device = actx.from_numpy(x_np)
+        s_device = mm.sin(x_device)  # Calls actx.np.sin
+
+    or :mod:`pymbolic` input expression::
+
+        x_sym = pmbl.var("x")
+        s_sym = mm.sin(x_sym)  # Creates an expression pmbl.var("sin")(x_sym)
+
 .. autofunction:: __getattr__
 """
 

--- a/mirgecom/math.py
+++ b/mirgecom/math.py
@@ -1,0 +1,60 @@
+"""Utilities and functions for math.
+
+.. autodata:: math_mapper
+"""
+
+__copyright__ = """Copyright (C) 2021 University of Illinois Board of Trustees"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+import numpy.linalg as la # noqa
+from pytools.obj_array import make_obj_array
+import pymbolic as pmbl
+from pymbolic.primitives import Expression
+from arraycontext import get_container_context_recursively
+
+
+class _SymbolicMathContainer:
+    def __getattr__(self, name):
+        return pmbl.var(name)
+
+
+class MathMapper:
+    """Dispatcher for math operations on symbolic/numeric input."""
+
+    @staticmethod
+    def _math_container_for(*args):
+        if any(isinstance(arg, Expression) for arg in args):
+            return _SymbolicMathContainer()
+        else:
+            actx = get_container_context_recursively(make_obj_array(args))
+            if actx is not None:
+                return actx.np
+            else:
+                return np
+
+    def __getattr__(self, name):
+        """Retrieve the function corresponding to *name*."""
+        return lambda *args: getattr(self._math_container_for(*args), name)(*args)
+
+
+math_mapper = MathMapper()

--- a/mirgecom/symbolic.py
+++ b/mirgecom/symbolic.py
@@ -30,12 +30,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
+import numpy as np  # noqa
 import numpy.linalg as la # noqa
 from pytools.obj_array import make_obj_array
 import pymbolic as pmbl
 from pymbolic.mapper.evaluator import EvaluationMapper as BaseEvaluationMapper
-from arraycontext import get_container_context_recursively
+from mirgecom.math import math_mapper as mm
 
 
 def diff(var):
@@ -78,34 +78,8 @@ class EvaluationMapper(BaseEvaluationMapper):
         """Map a symbolic code expression to actual function call."""
         from pymbolic.primitives import Variable
         assert isinstance(expr.function, Variable)
-        if expr.function.name == "sin":
-            par, = expr.parameters
-            return self._sin(self.rec(par))
-        elif expr.function.name == "cos":
-            par, = expr.parameters
-            return self._cos(self.rec(par))
-        elif expr.function.name == "exp":
-            par, = expr.parameters
-            return self._exp(self.rec(par))
-        else:
-            raise ValueError("Unrecognized function '%s'" % expr.function)
-
-    @staticmethod
-    def _np_like_for(val):
-        actx = get_container_context_recursively(val)
-        if actx is None:
-            return np
-        else:
-            return actx.np
-
-    def _sin(self, val):
-        return self._np_like_for(val).sin(val)
-
-    def _cos(self, val):
-        return self._np_like_for(val).cos(val)
-
-    def _exp(self, val):
-        return self._np_like_for(val).exp(val)
+        par, = expr.parameters
+        return getattr(mm, expr.function.name)(self.rec(par))
 
 
 def evaluate(expr, mapper_type=EvaluationMapper, **kwargs):

--- a/mirgecom/symbolic.py
+++ b/mirgecom/symbolic.py
@@ -5,6 +5,7 @@
 .. autofunction:: grad
 
 .. autoclass:: EvaluationMapper
+.. autofunction:: evaluate
 """
 
 __copyright__ = """Copyright (C) 2020 University of Illinois Board of Trustees"""
@@ -33,7 +34,7 @@ import numpy as np
 import numpy.linalg as la # noqa
 from pytools.obj_array import make_obj_array
 import pymbolic as pmbl
-import pymbolic.mapper.evaluator as ev
+from pymbolic.mapper.evaluator import EvaluationMapper as BaseEvaluationMapper
 from arraycontext import get_container_context_recursively
 
 
@@ -67,7 +68,7 @@ def grad(dim, func):
     return make_obj_array([diff(coords[i])(func) for i in range(dim)])
 
 
-class EvaluationMapper(ev.EvaluationMapper):
+class EvaluationMapper(BaseEvaluationMapper):
     """Evaluates symbolic expressions given a mapping from variables to values.
 
     Inherits from :class:`pymbolic.mapper.evaluator.EvaluationMapper`.
@@ -105,3 +106,8 @@ class EvaluationMapper(ev.EvaluationMapper):
 
     def _exp(self, val):
         return self._np_like_for(val).exp(val)
+
+
+def evaluate(expr, mapper_type=EvaluationMapper, **kwargs):
+    """Evaluate a symbolic expression using a specified mapper."""
+    return mapper_type(kwargs)(expr)

--- a/mirgecom/symbolic.py
+++ b/mirgecom/symbolic.py
@@ -35,7 +35,7 @@ import numpy.linalg as la # noqa
 from pytools.obj_array import make_obj_array
 import pymbolic as pmbl
 from pymbolic.mapper.evaluator import EvaluationMapper as BaseEvaluationMapper
-from mirgecom.math import math_mapper as mm
+import mirgecom.math as mm
 
 
 def diff(var):

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -31,7 +31,7 @@ from mirgecom.symbolic import (
     grad as sym_grad,
     div as sym_div,
     evaluate)
-from mirgecom.math import math_mapper as mm
+import mirgecom.math as mm
 from mirgecom.diffusion import (
     diffusion_operator,
     DirichletDiffusionBoundary,

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -31,6 +31,7 @@ from mirgecom.symbolic import (
     grad as sym_grad,
     div as sym_div,
     evaluate)
+from mirgecom.math import math_mapper as mm
 from mirgecom.diffusion import (
     diffusion_operator,
     DirichletDiffusionBoundary,
@@ -48,36 +49,6 @@ from numbers import Number
 
 import logging
 logger = logging.getLogger(__name__)
-
-
-def _np_like_for(val):
-    from arraycontext import get_container_context_recursively
-    actx = get_container_context_recursively(val)
-    if actx is None:
-        return np
-    else:
-        return actx.np
-
-
-def _cos(val):
-    if isinstance(val, Expression):
-        return pmbl.var("cos")(val)
-    else:
-        return _np_like_for(val).cos(val)
-
-
-def _sin(val):
-    if isinstance(val, Expression):
-        return pmbl.var("sin")(val)
-    else:
-        return _np_like_for(val).sin(val)
-
-
-def _exp(val):
-    if isinstance(val, Expression):
-        return pmbl.var("exp")(val)
-    else:
-        return _np_like_for(val).exp(val)
 
 
 class HeatProblem(metaclass=ABCMeta):
@@ -147,10 +118,10 @@ class DecayingTrig(HeatProblem):
         return get_box_mesh(self.dim, -0.5*np.pi, 0.5*np.pi, n)
 
     def get_solution(self, x, t):
-        u = _exp(-self.dim*self._alpha*t)
+        u = mm.exp(-self.dim*self._alpha*t)
         for i in range(self.dim-1):
-            u = u * _sin(x[i])
-        u = u * _cos(x[self.dim-1])
+            u = u * mm.sin(x[i])
+        u = u * mm.cos(x[self.dim-1])
         return u
 
     def get_alpha(self, x, t, u):
@@ -185,10 +156,10 @@ class DecayingTrigTruncatedDomain(HeatProblem):
         return get_box_mesh(self.dim, -0.5*np.pi, 0.25*np.pi, n)
 
     def get_solution(self, x, t):
-        u = _exp(-self.dim*self._alpha*t)
+        u = mm.exp(-self.dim*self._alpha*t)
         for i in range(self.dim-1):
-            u = u * _sin(x[i])
-        u = u * _cos(x[self.dim-1])
+            u = u * mm.sin(x[i])
+        u = u * mm.cos(x[self.dim-1])
         return u
 
     def get_alpha(self, x, t, u):
@@ -237,16 +208,16 @@ class OscillatingTrigVarDiff(HeatProblem):
         return get_box_mesh(self.dim, -0.5*np.pi, 0.5*np.pi, n)
 
     def get_solution(self, x, t):
-        u = _cos(t)
+        u = mm.cos(t)
         for i in range(self.dim-1):
-            u = u * _sin(x[i])
-        u = u * _cos(x[self.dim-1])
+            u = u * mm.sin(x[i])
+        u = u * mm.cos(x[self.dim-1])
         return u
 
     def get_alpha(self, x, t, u):
         alpha = 1
         for i in range(self.dim):
-            alpha = alpha * _cos(3.*x[i])
+            alpha = alpha * mm.cos(3.*x[i])
         alpha = 1 + 0.2*alpha
         return alpha
 
@@ -279,10 +250,10 @@ class OscillatingTrigNonlinearDiff(HeatProblem):
         return get_box_mesh(self.dim, -0.5*np.pi, 0.5*np.pi, n)
 
     def get_solution(self, x, t):
-        u = _cos(t)
+        u = mm.cos(t)
         for i in range(self.dim-1):
-            u = u * _sin(x[i])
-        u = u * _cos(x[self.dim-1])
+            u = u * mm.sin(x[i])
+        u = u * mm.cos(x[self.dim-1])
         return u
 
     def get_alpha(self, x, t, u):

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -26,8 +26,11 @@ import pyopencl.array as cla  # noqa
 import pyopencl.clmath as clmath # noqa
 from pytools.obj_array import make_obj_array
 import pymbolic as pmbl
-from pymbolic.primitives import Expression
-import mirgecom.symbolic as sym
+from mirgecom.symbolic import (
+    diff as sym_diff,
+    grad as sym_grad,
+    div as sym_div,
+    evaluate)
 from mirgecom.diffusion import (
     diffusion_operator,
     DirichletDiffusionBoundary,
@@ -75,10 +78,6 @@ def _exp(val):
         return pmbl.var("exp")(val)
     else:
         return _np_like_for(val).exp(val)
-
-
-def _sym_eval(expr, **kwargs):
-    return sym.EvaluationMapper(kwargs)(expr)
 
 
 class HeatProblem(metaclass=ABCMeta):
@@ -201,8 +200,8 @@ class DecayingTrigTruncatedDomain(HeatProblem):
         sym_exact_u = self.get_solution(
             pmbl.make_sym_vector("x", self.dim), pmbl.var("t"))
 
-        exact_u = _sym_eval(sym_exact_u, x=nodes, t=t)
-        exact_grad_u = _sym_eval(sym.grad(self.dim, sym_exact_u), x=nodes, t=t)
+        exact_u = evaluate(sym_exact_u, x=nodes, t=t)
+        exact_grad_u = evaluate(sym_grad(self.dim, sym_exact_u), x=nodes, t=t)
 
         boundaries = {}
 
@@ -308,7 +307,7 @@ class OscillatingTrigNonlinearDiff(HeatProblem):
 def sym_diffusion(dim, sym_alpha, sym_u):
     """Return a symbolic expression for the diffusion operator applied to a function.
     """
-    return sym.div(sym_alpha * sym.grad(dim, sym_u))
+    return sym_div(sym_alpha * sym_grad(dim, sym_u))
 
 
 # Note: Must integrate in time for a while in order to achieve expected spatial
@@ -346,7 +345,7 @@ def test_diffusion_accuracy(actx_factory, problem, nsteps, dt, scales, order,
 
     # In order to support manufactured solutions, we modify the heat equation
     # to add a source term f. If the solution is exact, this term should be 0.
-    sym_f = sym.diff(sym_t)(sym_u) - sym_diffusion_u
+    sym_f = sym_diff(sym_t)(sym_u) - sym_diffusion_u
 
     from pytools.convergence import EOCRecorder
     eoc_rec = EOCRecorder()
@@ -376,7 +375,7 @@ def test_diffusion_accuracy(actx_factory, problem, nsteps, dt, scales, order,
                 discr_tag = DISCR_TAG_BASE
             return (diffusion_operator(discr, quad_tag=discr_tag, alpha=alpha,
                     boundaries=p.get_boundaries(discr, actx, t), u=u)
-                + _sym_eval(sym_f, x=nodes, t=t))
+                + evaluate(sym_f, x=nodes, t=t))
 
         t = 0.
 
@@ -573,7 +572,7 @@ def test_diffusion_compare_to_nodal_dg(actx_factory, problem, order,
                         / inf_norm(diffusion_u_ndg))
 
             if print_err:
-                diffusion_u_exact = _sym_eval(sym_diffusion_u, x=nodes_mirgecom, t=t)
+                diffusion_u_exact = evaluate(sym_diffusion_u, x=nodes_mirgecom, t=t)
                 err_exact = (inf_norm(diffusion_u_mirgecom-diffusion_u_exact)
                             / inf_norm(diffusion_u_exact))
                 print(err, err_exact)
@@ -636,7 +635,7 @@ def test_diffusion_obj_array_vectorize(actx_factory):
 
     assert isinstance(diffusion_u1, DOFArray)
 
-    expected_diffusion_u1 = _sym_eval(sym_diffusion_u1, x=nodes, t=t)
+    expected_diffusion_u1 = evaluate(sym_diffusion_u1, x=nodes, t=t)
     rel_linf_err = actx.to_numpy(
         discr.norm(diffusion_u1 - expected_diffusion_u1, np.inf)
         / discr.norm(expected_diffusion_u1, np.inf))
@@ -654,8 +653,8 @@ def test_diffusion_obj_array_vectorize(actx_factory):
     assert diffusion_u_vector.shape == (2,)
 
     expected_diffusion_u_vector = make_obj_array([
-        _sym_eval(sym_diffusion_u1, x=nodes, t=t),
-        _sym_eval(sym_diffusion_u2, x=nodes, t=t)
+        evaluate(sym_diffusion_u1, x=nodes, t=t),
+        evaluate(sym_diffusion_u2, x=nodes, t=t)
     ])
     rel_linf_err = actx.to_numpy(
         discr.norm(diffusion_u_vector - expected_diffusion_u_vector, np.inf)


### PR DESCRIPTION
Mostly minor changes here; the only real noteworthy change is the addition of ~~the `MathMapper` class, which is intended to be a numpy-like object~~ the math module and its `__getattr__` function that dispatches math function calls to either `np`, `np.actx`, or `pymbl.var(...)` depending on the types of the arguments.

I'm not sure if having the math mapper be a module instance is the best way to implement this, so I'm open to changing it if there's another way that's cleaner. I mainly just wanted to be able to `import mirgecom.math as mm` and then `mm.sin(...)` instead of having to `from mirgecom.math import sin`, etc. for each function used. Maybe this isn't such a big deal? I dunno. 🤷‍♂️ 

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
