### PR TITLE
Purge `.join()` from mirgecom

### DIFF
--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -8,7 +8,7 @@ set -x
 # The production capability may be in a CEESD-local mirgecom branch or in a
 # fork, and is specified through the following settings:
 #
-# export PRODUCTION_BRANCH=""   # The base production branch to be installed by emirge
+export PRODUCTION_BRANCH="production-purge-join"   # The base production branch to be installed by emirge
 # export PRODUCTION_FORK=""  # The fork/home of production changes (if any)
 #
 # Multiple production drivers are supported. The user should provide a ':'-delimited

--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -8,7 +8,7 @@ set -x
 # The production capability may be in a CEESD-local mirgecom branch or in a
 # fork, and is specified through the following settings:
 #
-export PRODUCTION_BRANCH="production-purge-join"   # The base production branch to be installed by emirge
+# export PRODUCTION_BRANCH=""   # The base production branch to be installed by emirge
 # export PRODUCTION_FORK=""  # The fork/home of production changes (if any)
 #
 # Multiple production drivers are supported. The user should provide a ':'-delimited

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -98,7 +98,7 @@ def euler_operator(discr, eos, boundaries, cv, time=0.0,
         flow equations.
     """
     # Compute volume contributions
-    inviscid_flux_vol = inviscid_flux(discr, eos.pressure(cv), cv)
+    inviscid_flux_vol = inviscid_flux(discr, eos, cv)
     interior_cv = interior_trace_pairs(discr, cv)
     # Compute interface contributions
     inviscid_flux_bnd = (
@@ -106,7 +106,7 @@ def euler_operator(discr, eos, boundaries, cv, time=0.0,
         + sum(inviscid_facial_flux(discr, eos=eos, cv_tpair=part_tpair)
               for part_tpair in interior_cv)
         # Domain boundaries
-        + sum(boundaries[btag].inviscid_divergence_flux(discr, btag=btag, cv=cv,
+        + sum(boundaries[btag].inviscid_boundary_flux(discr, btag=btag, cv=cv,
                                                       eos=eos, time=time)
               for btag in boundaries)
     )

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -62,8 +62,7 @@ from grudge.trace_pair import interior_trace_pairs
 from mirgecom.operators import div_operator
 
 
-def euler_operator(discr, eos, boundaries, cv, time=0.0,
-                   dv=None):
+def euler_operator(discr, eos, boundaries, cv, time=0.0):
     r"""Compute RHS of the Euler flow equations.
 
     Returns

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -105,8 +105,8 @@ def euler_operator(discr, eos, boundaries, cv, time=0.0):
         + sum(inviscid_facial_flux(discr, eos=eos, cv_tpair=part_tpair)
               for part_tpair in interior_cv)
         # Domain boundaries
-        + sum(boundaries[btag].inviscid_boundary_flux(discr, btag=btag, cv=cv,
-                                                      eos=eos, time=time)
+        + sum(boundaries[btag].inviscid_divergence_flux(discr, btag=btag, cv=cv,
+                                                        eos=eos, time=time)
               for btag in boundaries)
     )
 

--- a/mirgecom/filter.py
+++ b/mirgecom/filter.py
@@ -201,7 +201,13 @@ def filter_modally(dcoll, dd, cutoff, mode_resp_func, field):
     dd_modal = dof_desc.DD_VOLUME_MODAL
     discr = dcoll.discr_from_dd(dd)
 
-    assert isinstance(field, DOFArray)
+    from arraycontext import map_array_container
+    from functools import partial
+    if not isinstance(field, DOFArray):
+        return map_array_container(
+            partial(filter_modally, dcoll, dd, cutoff, mode_resp_func), field
+        )
+
     actx = field.array_context
 
     modal_map = dcoll.connection_from_dds(dd, dd_modal)

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -327,8 +327,8 @@ def max_component_norm(discr, fields, order=np.inf):
         This is a collective routine and must be called by all MPI ranks.
     """
     actx = fields.array_context
-    return max(actx.to_numpy(flatten(
-        componentwise_norms(discr, fields, order), actx)))
+    return actx.to_numpy(actx.np.max(
+        componentwise_norms(discr, fields, order), actx))
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -12,6 +12,7 @@ Diagnostic utilities
 --------------------
 
 .. autofunction:: compare_fluid_solutions
+.. autofunction:: componentwise_norms
 .. autofunction:: check_naninf_local
 .. autofunction:: check_range_local
 
@@ -304,6 +305,11 @@ def compare_fluid_solutions(discr, red_state, blue_state):
 
 
 def componentwise_norms(discr, fields, order=np.inf):
+    """Return the *order*-norm for each component of *fields*.
+
+    .. note::
+        This is a collective routine and must be called by all MPI ranks.
+    """
     if not isinstance(fields, DOFArray):
         return map_array_container(
             partial(componentwise_norms, discr, order=order), fields)

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -316,7 +316,8 @@ def componentwise_norms(discr, fields, order=np.inf):
             partial(componentwise_norms, discr, order=order), fields)
     if len(fields) > 0:
         return discr.norm(fields, order)
-    else:
+    else:  
+        # FIXME: This work-around for #575 can go away after #569
         return 0
 
 

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -316,7 +316,7 @@ def componentwise_norms(discr, fields, order=np.inf):
             partial(componentwise_norms, discr, order=order), fields)
     if len(fields) > 0:
         return discr.norm(fields, order)
-    else:  
+    else:
         # FIXME: This work-around for #575 can go away after #569
         return 0
 

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -13,6 +13,7 @@ Diagnostic utilities
 
 .. autofunction:: compare_fluid_solutions
 .. autofunction:: componentwise_norms
+.. autofunction:: componentwise_max_error
 .. autofunction:: check_naninf_local
 .. autofunction:: check_range_local
 
@@ -313,8 +314,21 @@ def componentwise_norms(discr, fields, order=np.inf):
     if not isinstance(fields, DOFArray):
         return map_array_container(
             partial(componentwise_norms, discr, order=order), fields)
+    if len(fields) > 0:
+        return discr.norm(fields, order)
+    else:
+        return 0
 
-    return discr.norm(fields, order)
+
+def max_component_norm(discr, fields, order=np.inf):
+    """Return the *order*-norm for each component of *fields*.
+
+    .. note::
+        This is a collective routine and must be called by all MPI ranks.
+    """
+    actx = fields.array_context
+    return max(actx.to_numpy(flatten(
+        componentwise_norms(discr, fields, order), actx)))
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -13,7 +13,7 @@ Diagnostic utilities
 
 .. autofunction:: compare_fluid_solutions
 .. autofunction:: componentwise_norms
-.. autofunction:: componentwise_max_error
+.. autofunction:: max_component_norm
 .. autofunction:: check_naninf_local
 .. autofunction:: check_range_local
 
@@ -321,7 +321,7 @@ def componentwise_norms(discr, fields, order=np.inf):
 
 
 def max_component_norm(discr, fields, order=np.inf):
-    """Return the *order*-norm for each component of *fields*.
+    """Return the max *order*-norm over the components of *fields*.
 
     .. note::
         This is a collective routine and must be called by all MPI ranks.

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -327,8 +327,8 @@ def max_component_norm(discr, fields, order=np.inf):
         This is a collective routine and must be called by all MPI ranks.
     """
     actx = fields.array_context
-    return actx.to_numpy(actx.np.max(
-        componentwise_norms(discr, fields, order), actx))
+    return max(actx.to_numpy(flatten(
+        componentwise_norms(discr, fields, order), actx)))
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -234,7 +234,7 @@ def test_vortex_rhs(actx_factory, order):
             discr, eos=IdealSingleGas(), boundaries=boundaries,
             cv=vortex_soln, time=0.0)
 
-        err_max = actx.to_numpy(discr.norm(inviscid_rhs.join(), np.inf))
+        err_max = actx.to_numpy(discr.norm(inviscid_rhs, np.inf))
         eoc_rec.add_data_point(1.0 / nel_1d, err_max)
 
     logger.info(
@@ -294,7 +294,7 @@ def test_lump_rhs(actx_factory, dim, order):
         expected_rhs = lump.exact_rhs(discr, cv=lump_soln, time=0)
 
         err_max = actx.to_numpy(
-            discr.norm((inviscid_rhs-expected_rhs).join(), np.inf))
+            discr.norm((inviscid_rhs-expected_rhs), np.inf))
         if err_max > maxxerr:
             maxxerr = err_max
 
@@ -371,7 +371,7 @@ def test_multilump_rhs(actx_factory, dim, order, v0):
         print(f"expected_rhs = {expected_rhs}")
 
         err_max = actx.to_numpy(
-            discr.norm((inviscid_rhs-expected_rhs).join(), np.inf))
+            discr.norm((inviscid_rhs-expected_rhs), np.inf))
         if err_max > maxxerr:
             maxxerr = err_max
 
@@ -437,7 +437,7 @@ def _euler_flow_stepper(actx, parameters):
     def write_soln(state, write_status=True):
         dv = eos.dependent_vars(cv=state)
         expected_result = initializer(nodes, t=t)
-        result_resid = (state - expected_result).join()
+        result_resid = state - expected_result
         maxerr = [np.max(np.abs(result_resid[i].get())) for i in range(dim + 2)]
         mindv = [np.min(dvfld.get()) for dvfld in dv]
         maxdv = [np.max(dvfld.get()) for dvfld in dv]
@@ -493,7 +493,7 @@ def _euler_flow_stepper(actx, parameters):
 
         cv = rk4_step(cv, t, dt, rhs)
         cv = make_conserved(
-            dim, q=filter_modally(discr, "vol", cutoff, frfunc, cv.join())
+            dim, q=filter_modally(discr, "vol", cutoff, frfunc, cv)
         )
 
         t += dt
@@ -506,7 +506,7 @@ def _euler_flow_stepper(actx, parameters):
         maxerr = max(write_soln(cv, False))
     else:
         expected_result = initializer(nodes, time=t)
-        maxerr = actx.to_numpy(discr.norm((cv - expected_result).join(), np.inf))
+        maxerr = actx.to_numpy(discr.norm(cv - expected_result, np.inf))
 
     logger.info(f"Max Error: {maxerr}")
     if maxerr > exittol:

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -53,6 +53,7 @@ from meshmode.array_context import (  # noqa
     pytest_generate_tests_for_pyopencl_array_context
     as pytest_generate_tests)
 
+from mirgecom.simutil import max_component_norm
 
 from grudge.shortcuts import make_visualizer
 from mirgecom.inviscid import get_inviscid_timestep
@@ -234,7 +235,8 @@ def test_vortex_rhs(actx_factory, order):
             discr, eos=IdealSingleGas(), boundaries=boundaries,
             cv=vortex_soln, time=0.0)
 
-        err_max = actx.to_numpy(discr.norm(inviscid_rhs, np.inf))
+        err_max = max_component_norm(discr, inviscid_rhs, np.inf)
+
         eoc_rec.add_data_point(1.0 / nel_1d, err_max)
 
     logger.info(
@@ -293,8 +295,7 @@ def test_lump_rhs(actx_factory, dim, order):
         )
         expected_rhs = lump.exact_rhs(discr, cv=lump_soln, time=0)
 
-        err_max = actx.to_numpy(
-            discr.norm((inviscid_rhs-expected_rhs), np.inf))
+        err_max = max_component_norm(discr, inviscid_rhs-expected_rhs, np.inf)
         if err_max > maxxerr:
             maxxerr = err_max
 
@@ -492,9 +493,7 @@ def _euler_flow_stepper(actx, parameters):
                 write_soln(state=cv)
 
         cv = rk4_step(cv, t, dt, rhs)
-        cv = make_conserved(
-            dim, q=filter_modally(discr, "vol", cutoff, frfunc, cv)
-        )
+        cv = filter_modally(discr, "vol", cutoff, frfunc, cv)
 
         t += dt
         istep += 1
@@ -506,7 +505,7 @@ def _euler_flow_stepper(actx, parameters):
         maxerr = max(write_soln(cv, False))
     else:
         expected_result = initializer(nodes, time=t)
-        maxerr = actx.to_numpy(discr.norm(cv - expected_result, np.inf))
+        maxerr = max_component_norm(discr, cv-expected_result, np.inf)
 
     logger.info(f"Max Error: {maxerr}")
     if maxerr > exittol:

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -186,13 +186,14 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
     # the filter unharmed.
     from mirgecom.initializers import Uniform
     initr = Uniform(dim=dim)
-    uniform_soln = initr(t=0, x_vec=nodes).join()
+    uniform_soln = initr(t=0, x_vec=nodes)
 
     from mirgecom.filter import filter_modally
     filtered_soln = filter_modally(discr, "vol", cutoff,
                                    frfunc, uniform_soln)
     soln_resid = uniform_soln - filtered_soln
-    max_errors = [actx.to_numpy(discr.norm(v, np.inf)) for v in soln_resid]
+    from mirgecom.simutil import componentwise_norms
+    max_errors = componentwise_norms(discr, soln_resid, np.inf)
 
     tol = 1e-14
 

--- a/test/test_fluid.py
+++ b/test/test_fluid.py
@@ -77,8 +77,7 @@ def test_velocity_gradient_sanity(actx_factory, dim, mass_exp, vel_fac):
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
     from grudge.op import local_grad
-    grad_cv = make_conserved(dim,
-                             q=local_grad(discr, cv.join()))
+    grad_cv = local_grad(discr, cv)
 
     grad_v = velocity_gradient(discr, cv, grad_cv)
 
@@ -123,8 +122,7 @@ def test_velocity_gradient_eoc(actx_factory, dim):
 
         cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
         from grudge.op import local_grad
-        grad_cv = make_conserved(dim,
-                                 q=local_grad(discr, cv.join()))
+        grad_cv = local_grad(discr, cv)
         grad_v = velocity_gradient(discr, cv, grad_cv)
 
         def exact_grad_row(xdata, gdim, dim):
@@ -178,8 +176,7 @@ def test_velocity_gradient_structure(actx_factory):
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
     from grudge.op import local_grad
-    grad_cv = make_conserved(dim,
-                             q=local_grad(discr, cv.join()))
+    grad_cv = local_grad(discr, cv)
     grad_v = velocity_gradient(discr, cv, grad_cv)
 
     tol = 1e-11
@@ -233,8 +230,8 @@ def test_species_mass_gradient(actx_factory, dim):
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom,
                         species_mass=species_mass)
     from grudge.op import local_grad
-    grad_cv = make_conserved(dim,
-                             q=local_grad(discr, cv.join()))
+    grad_cv = local_grad(discr, cv)
+
     from mirgecom.fluid import species_mass_fraction_gradient
     grad_y = species_mass_fraction_gradient(discr, cv, grad_cv)
 

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -22,7 +22,7 @@ THE SOFTWARE.
 
 import numpy as np
 from functools import partial
-from pytools.obj_array import make_obj_array, obj_array_vectorize
+from pytools.obj_array import make_obj_array, obj_array_vectorize  # noqa
 import pyopencl as cl
 import pyopencl.tools as cl_tools
 import pyopencl.array as cla  # noqa
@@ -75,19 +75,13 @@ def op_test_data(ctx_factory):
 
 # Mimics math.isclose for state arrays
 def _isclose(discr, x, y, rel_tol=1e-9, abs_tol=0, return_operands=False):
-    def componentwise_norm(a):
-        from mirgecom.fluid import ConservedVars
-        if isinstance(a, ConservedVars):
-            return componentwise_norm(a.join())
-        from arraycontext import get_container_context_recursively
-        actx = get_container_context_recursively(a)
-        return obj_array_vectorize(lambda b: actx.to_numpy(discr.norm(b, np.inf)), a)
 
-    lhs = componentwise_norm(x - y)
+    from mirgecom.simutil import componentwise_norms
+    lhs = componentwise_norms(discr, x - y, np.inf)
     rhs = np.maximum(
         rel_tol * np.maximum(
-            componentwise_norm(x),
-            componentwise_norm(y)),
+            componentwise_norms(discr, x, np.inf),
+            componentwise_norms(discr, y, np.inf)),
         abs_tol)
 
     is_close = np.all(lhs <= rhs)

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -77,11 +77,14 @@ def op_test_data(ctx_factory):
 def _isclose(discr, x, y, rel_tol=1e-9, abs_tol=0, return_operands=False):
 
     from mirgecom.simutil import componentwise_norms
-    lhs = componentwise_norms(discr, x - y, np.inf)
+    from arraycontext import flatten
+    actx = x.array_context
+    lhs = actx.to_numpy(flatten(componentwise_norms(discr, x - y, np.inf), actx))
+
     rhs = np.maximum(
         rel_tol * np.maximum(
-            componentwise_norms(discr, x, np.inf),
-            componentwise_norms(discr, y, np.inf)),
+            actx.to_numpy(flatten(componentwise_norms(discr, x, np.inf), actx)),
+            actx.to_numpy(flatten(componentwise_norms(discr, y, np.inf), actx))),
         abs_tol)
 
     is_close = np.all(lhs <= rhs)

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -217,13 +217,12 @@ def test_grad_operator(actx_factory, dim, order, sym_test_func_factory):
         test_data = test_func(nodes)
         exact_grad = grad_test_func(nodes)
 
-        def inf_norm(x):
-            return actx.to_numpy(discr.norm(x, np.inf))
+        from mirgecom.simutil import componentwise_norms
+        from arraycontext import flatten
 
-        if isinstance(test_data, ConservedVars):
-            err_scale = inf_norm(exact_grad.join())
-        else:
-            err_scale = inf_norm(exact_grad)
+        err_scale = max(flatten(componentwise_norms(discr, exact_grad, np.inf),
+                                actx))
+
         if err_scale <= 1e-16:
             err_scale = 1
 
@@ -236,18 +235,12 @@ def test_grad_operator(actx_factory, dim, order, sym_test_func_factory):
                                          test_data_int_tpair, boundaries)
 
         from mirgecom.operators import grad_operator
-        if isinstance(test_data, ConservedVars):
-            test_grad = make_conserved(
-                dim=dim, q=grad_operator(discr, test_data.join(),
-                                         test_data_flux_bnd.join())
-                )
-            grad_err = inf_norm((test_grad - exact_grad).join())/err_scale
-        else:
-            test_grad = grad_operator(discr, test_data, test_data_flux_bnd)
-            grad_err = inf_norm(test_grad - exact_grad)/err_scale
+        test_grad = grad_operator(discr, test_data, test_data_flux_bnd)
+        grad_err = \
+            max(flatten(componentwise_norms(discr, test_grad - exact_grad, np.inf),
+                        actx)) / err_scale
 
-        print(f"{test_grad=}")
-        eoc.add_data_point(actx.to_numpy(h_max), grad_err)
+        eoc.add_data_point(actx.to_numpy(h_max), actx.to_numpy(grad_err))
 
     assert (
         eoc.order_estimate() >= order - 0.5

--- a/test/test_restart.py
+++ b/test/test_restart.py
@@ -76,4 +76,4 @@ def test_restart_cv(actx_factory, nspecies):
     restart_data = read_restart_data(actx, rst_filename)
 
     resid = test_state - restart_data["state"]
-    assert actx.to_numpy(discr.norm(resid.join(), np.inf)) == 0
+    assert actx.to_numpy(discr.norm(resid, np.inf)) == 0

--- a/test/test_restart.py
+++ b/test/test_restart.py
@@ -76,4 +76,5 @@ def test_restart_cv(actx_factory, nspecies):
     restart_data = read_restart_data(actx, rst_filename)
 
     resid = test_state - restart_data["state"]
-    assert actx.to_numpy(discr.norm(resid, np.inf)) == 0
+    from mirgecom.simutil import max_component_norm
+    assert max_component_norm(discr, resid, np.inf) == 0

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -244,7 +244,7 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
 
         # verify diffusive mass flux is zilch (no scalar components)
         # Don't call for non-multi CV
-        if cv.has_multispecies:
+        if cv.nspecies > 0:
             from mirgecom.viscous import diffusive_flux
             j = diffusive_flux(discr, eos, cv, grad_cv)
             assert len(j) == 0

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -83,7 +83,7 @@ def test_viscous_stress_tensor(actx_factory, transport_model):
     mom = mass * velocity
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
-    grad_cv = make_conserved(dim, q=op.local_grad(discr, cv.join()))
+    grad_cv = op.local_grad(discr, cv)
 
     if transport_model:
         tv_model = SimpleTransport(bulk_viscosity=1.0, viscosity=0.5)
@@ -203,8 +203,7 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         cv_flux_bnd = _elbnd_flux(discr, cv_flux_interior, cv_flux_boundary,
                                   cv_int_tpair, boundaries)
         from mirgecom.operators import grad_operator
-        grad_cv = make_conserved(dim, q=grad_operator(discr, cv.join(),
-                                                      cv_flux_bnd.join()))
+        grad_cv = grad_operator(discr, cv, cv_flux_bnd)
 
         xp_grad_cv = initializer.exact_grad(x_vec=nodes, eos=eos, cv_exact=cv)
         xp_grad_v = 1/cv.mass * xp_grad_cv.momentum
@@ -244,9 +243,11 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         assert inf_norm(heat_flux - xp_heat_flux) < 2e-8
 
         # verify diffusive mass flux is zilch (no scalar components)
-        from mirgecom.viscous import diffusive_flux
-        j = diffusive_flux(discr, eos, cv, grad_cv)
-        assert len(j) == 0
+        # Don't call for non-multi CV
+        if cv.has_multispecies:
+            from mirgecom.viscous import diffusive_flux
+            j = diffusive_flux(discr, eos, cv, grad_cv)
+            assert len(j) == 0
 
         xp_e_flux = np.dot(xp_tau, cv.velocity) - xp_heat_flux
         xp_mom_flux = xp_tau
@@ -319,7 +320,7 @@ def test_species_diffusive_flux(actx_factory):
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom,
                         species_mass=species_mass)
 
-    grad_cv = make_conserved(dim, q=op.local_grad(discr, cv.join()))
+    grad_cv = op.local_grad(discr, cv)
 
     mu_b = 1.0
     mu = 0.5
@@ -392,7 +393,7 @@ def test_diffusive_heat_flux(actx_factory):
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom,
                         species_mass=species_mass)
-    grad_cv = make_conserved(dim, q=op.local_grad(discr, cv.join()))
+    grad_cv = op.local_grad(discr, cv)
 
     mu_b = 1.0
     mu = 0.5

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -242,13 +242,6 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         xp_heat_flux = -kappa*xp_grad_t
         assert inf_norm(heat_flux - xp_heat_flux) < 2e-8
 
-        # verify diffusive mass flux is zilch (no scalar components)
-        # Don't call for non-multi CV
-        if cv.nspecies > 0:
-            from mirgecom.viscous import diffusive_flux
-            j = diffusive_flux(discr, eos, cv, grad_cv)
-            assert len(j) == 0
-
         xp_e_flux = np.dot(xp_tau, cv.velocity) - xp_heat_flux
         xp_mom_flux = xp_tau
         from mirgecom.viscous import viscous_flux


### PR DESCRIPTION
This PR does exactly what the title suggests. It removes all `.join()` calls!

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
