### PR TITLE
Operator overhaul and overintegration support for all fluid-based operators

### DIFF
--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -8,7 +8,7 @@ set -x
 # The production capability may be in a CEESD-local mirgecom branch or in a
 # fork, and is specified through the following settings:
 #
-export PRODUCTION_BRANCH="production-state-handling"   # The base production branch to be installed by emirge
+export PRODUCTION_BRANCH="production-state-handling-overintegration"   # The base production branch to be installed by emirge
 # export PRODUCTION_FORK=""  # The fork/home of production changes (if any)
 #
 # Multiple production drivers are supported. The user should provide a ':'-delimited

--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -8,7 +8,7 @@ set -x
 # The production capability may be in a CEESD-local mirgecom branch or in a
 # fork, and is specified through the following settings:
 #
-export PRODUCTION_BRANCH="production-state-handling-overintegration"   # The base production branch to be installed by emirge
+export PRODUCTION_BRANCH="thg/production-state-handling-overintegration"   # The base production branch to be installed by emirge
 # export PRODUCTION_FORK=""  # The fork/home of production changes (if any)
 #
 # Multiple production drivers are supported. The user should provide a ':'-delimited

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -80,7 +80,8 @@ class MyRuntimeError(RuntimeError):
 
 @mpi_entry_point
 def main(ctx_factory=cl.create_some_context, use_logmgr=True,
-         use_leap=False, use_profiling=False, casename=None,
+         use_leap=False, use_overintegration=False,
+         use_profiling=False, casename=None,
          rst_filename=None, actx_class=PyOpenCLArrayContext,
          log_dependent=True):
     """Drive example."""
@@ -172,10 +173,26 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
+    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
+    from meshmode.discretization.poly_element import \
+        default_simplex_group_factory, QuadratureSimplexGroupFactory
+
     discr = EagerDGDiscretization(
-        actx, local_mesh, order=order, mpi_communicator=comm
+        actx, local_mesh,
+        discr_tag_to_group_factory={
+            DISCR_TAG_BASE: default_simplex_group_factory(
+                base_dim=local_mesh.dim, order=order),
+            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order + 1)
+        },
+        mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)
+
+    if use_overintegration:
+        quadrature_tag = DISCR_TAG_QUAD
+    else:
+        quadrature_tag = None
+
     ones = discr.zeros(actx) + 1.0
 
     vis_timer = None
@@ -573,7 +590,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         return make_obj_array([
             euler_operator(discr, state=fluid_state, time=t, boundaries=boundaries,
                            gas_model=gas_model,
-                           inviscid_numerical_flux_func=inviscid_flux_rusanov)
+                           inviscid_numerical_flux_func=inviscid_flux_rusanov,
+                           quadrature_tag=quadrature_tag)
             + eos.get_species_source_terms(cv, fluid_state.temperature),
             0*tseed])
 
@@ -616,6 +634,8 @@ if __name__ == "__main__":
     import argparse
     casename = "autoignition"
     parser = argparse.ArgumentParser(description=f"MIRGE-Com Example: {casename}")
+    parser.add_argument("--overintegration", action="store_true",
+        help="use overintegration in the RHS computations")
     parser.add_argument("--lazy", action="store_true",
         help="switch to a lazy computation mode")
     parser.add_argument("--profiling", action="store_true",
@@ -646,7 +666,9 @@ if __name__ == "__main__":
     if args.restart_file:
         rst_filename = args.restart_file
 
-    main(use_logmgr=args.log, use_leap=args.leap, use_profiling=args.profiling,
+    main(use_logmgr=args.log, use_leap=args.leap,
+         use_overintegration=args.overintegration,
+         use_profiling=args.profiling,
          casename=casename, rst_filename=rst_filename, actx_class=actx_class,
          log_dependent=log_dependent)
 

--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -50,7 +50,6 @@ from mirgecom.artificial_viscosity import (
 )
 from mirgecom.io import make_init_message
 from mirgecom.mpi import mpi_entry_point
-from mirgecom.fluid import make_conserved
 from mirgecom.integrators import rk4_step
 from mirgecom.steppers import advance_state
 from mirgecom.boundary import (

--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -45,7 +45,7 @@ from grudge.shortcuts import make_visualizer
 
 from mirgecom.euler import euler_operator
 from mirgecom.artificial_viscosity import (
-    av_operator,
+    av_laplacian_operator,
     smoothness_indicator
 )
 from mirgecom.io import make_init_message
@@ -418,11 +418,12 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                            boundaries=boundaries,
                            gas_model=gas_model,
                            quadrature_tag=quadrature_tag)
-            + av_operator(discr, cv=fluid_state.cv,
-                          boundaries=boundaries,
-                          boundary_kwargs={"time": t, "gas_model": gas_model},
-                          alpha=alpha, s0=s0, kappa=kappa,
-                          quadrature_tag=quadrature_tag)
+            + av_laplacian_operator(discr, cv=fluid_state.cv,
+                                    boundaries=boundaries,
+                                    boundary_kwargs={"time": t,
+                                                     "gas_model": gas_model},
+                                    alpha=alpha, s0=s0, kappa=kappa,
+                                    quadrature_tag=quadrature_tag)
         )
 
     current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,

--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -413,22 +413,16 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
-        return euler_operator(
-            discr,
-            state=fluid_state,
-            time=t,
-            boundaries=boundaries,
-            gas_model=gas_model,
-            quadrature_tag=quadrature_tag
-        ) + av_operator(
-            discr,
-            cv=fluid_state.cv,
-            boundaries=boundaries,
-            boundary_kwargs={"time": t, "gas_model": gas_model},
-            alpha=alpha,
-            s0=s0,
-            kappa=kappa,
-            quadrature_tag=quadrature_tag
+        return (
+            euler_operator(discr, state=fluid_state, time=t,
+                           boundaries=boundaries,
+                           gas_model=gas_model,
+                           quadrature_tag=quadrature_tag)
+            + av_operator(discr, cv=fluid_state.cv,
+                          boundaries=boundaries,
+                          boundary_kwargs={"time": t, "gas_model": gas_model},
+                          alpha=alpha, s0=s0, kappa=kappa,
+                          quadrature_tag=quadrature_tag)
         )
 
     current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,

--- a/examples/poiseuille-mpi.py
+++ b/examples/poiseuille-mpi.py
@@ -90,6 +90,7 @@ def _get_box_mesh(dim, a, b, n, t=None):
 
 @mpi_entry_point
 def main(ctx_factory=cl.create_some_context, use_logmgr=True,
+         use_overintegration=False,
          use_leap=False, use_profiling=False, casename=None,
          rst_filename=None, actx_class=PyOpenCLArrayContext):
     """Drive the example."""
@@ -165,11 +166,26 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
+    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
+    from meshmode.discretization.poly_element import \
+        default_simplex_group_factory, QuadratureSimplexGroupFactory
+
     order = 2
     discr = EagerDGDiscretization(
-        actx, local_mesh, order=order, mpi_communicator=comm
+        actx, local_mesh,
+        discr_tag_to_group_factory={
+            DISCR_TAG_BASE: default_simplex_group_factory(
+                base_dim=local_mesh.dim, order=order),
+            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order + 1)
+        },
+        mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)
+
+    if use_overintegration:
+        quadrature_tag = DISCR_TAG_QUAD
+    else:
+        quadrature_tag = None
 
     if logmgr:
         logmgr_add_device_name(logmgr, queue)
@@ -417,7 +433,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
         return ns_operator(discr, gas_model=gas_model, boundaries=boundaries,
-                           state=fluid_state, time=t)
+                           state=fluid_state, time=t,
+                           quadrature_tag=quadrature_tag)
 
     current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
@@ -457,6 +474,8 @@ if __name__ == "__main__":
     import argparse
     casename = "poiseuille"
     parser = argparse.ArgumentParser(description=f"MIRGE-Com Example: {casename}")
+    parser.add_argument("--overintegration", action="store_true",
+        help="use overintegration in the RHS computations")
     parser.add_argument("--lazy", action="store_true",
         help="switch to a lazy computation mode")
     parser.add_argument("--profiling", action="store_true",
@@ -484,6 +503,7 @@ if __name__ == "__main__":
         rst_filename = args.restart_file
 
     main(use_logmgr=args.log, use_leap=args.leap, use_profiling=args.profiling,
+         use_overintegration=args.overintegration,
          casename=casename, rst_filename=rst_filename, actx_class=actx_class)
 
 # vim: foldmethod=marker

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -81,6 +81,7 @@ class MyRuntimeError(RuntimeError):
 
 @mpi_entry_point
 def main(ctx_factory=cl.create_some_context, use_logmgr=True,
+         use_overintegration=False,
          use_leap=False, use_profiling=False, casename=None,
          rst_filename=None, actx_class=PyOpenCLArrayContext):
     """Drive the example."""
@@ -153,11 +154,26 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
+    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
+    from meshmode.discretization.poly_element import \
+        default_simplex_group_factory, QuadratureSimplexGroupFactory
+
     order = 1
     discr = EagerDGDiscretization(
-        actx, local_mesh, order=order, mpi_communicator=comm
+        actx, local_mesh,
+        discr_tag_to_group_factory={
+            DISCR_TAG_BASE: default_simplex_group_factory(
+                base_dim=local_mesh.dim, order=order),
+            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order + 1)
+        },
+        mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)
+
+    if use_overintegration:
+        quadrature_tag = DISCR_TAG_QUAD
+    else:
+        quadrature_tag = None
 
     vis_timer = None
 
@@ -299,7 +315,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_rhs(t, state):
         fluid_state = make_fluid_state(cv=state, gas_model=gas_model)
         return euler_operator(discr, state=fluid_state, time=t,
-                              boundaries=boundaries, gas_model=gas_model)
+                              boundaries=boundaries,
+                              gas_model=gas_model,
+                              quadrature_tag=quadrature_tag)
 
     current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
@@ -332,6 +350,8 @@ if __name__ == "__main__":
     import argparse
     casename = "pulse"
     parser = argparse.ArgumentParser(description=f"MIRGE-Com Example: {casename}")
+    parser.add_argument("--overintegration", action="store_true",
+        help="use overintegration in the RHS computations")
     parser.add_argument("--lazy", action="store_true",
         help="switch to a lazy computation mode")
     parser.add_argument("--profiling", action="store_true",
@@ -358,7 +378,8 @@ if __name__ == "__main__":
     if args.restart_file:
         rst_filename = args.restart_file
 
-    main(use_logmgr=args.log, use_leap=args.leap, use_profiling=args.profiling,
+    main(use_logmgr=args.log, use_overintegration=args.overintegration,
+         use_leap=args.leap, use_profiling=args.profiling,
          casename=casename, rst_filename=rst_filename, actx_class=actx_class)
 
 # vim: foldmethod=marker

--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -182,30 +182,20 @@ def av_operator(discr, boundaries, cv, alpha, boundary_kwargs=None, **kwargs):
     def central_flux(utpair):
         dd = utpair.dd
         normal = thaw(actx, discr.normal(dd))
-        return op.project(
-            discr,
-            dd,
-            dd.with_dtag("all_faces"),
-            # This uses a central scalar flux along nhat:
-            # flux = 1/2 * (Q- + Q+) * nhat
-            gradient_flux_central(utpair, normal)
-        )
+        return op.project(discr, dd, dd.with_dtag("all_faces"),
+                          # This uses a central scalar flux along nhat:
+                          # flux = 1/2 * (Q- + Q+) * nhat
+                          gradient_flux_central(utpair, normal))
 
     cv_bnd = (
         # Rank-local and cross-rank (across parallel partitions) contributions
-        + sum(
-            central_flux(interp_to_surf_quad(tpair))
-            for tpair in interior_trace_pairs(discr, cv)
-        )
+        + sum(central_flux(interp_to_surf_quad(tpair))
+              for tpair in interior_trace_pairs(discr, cv))
         # Contributions from boundary fluxes
-        + sum(
-            boundaries[btag].soln_gradient_flux(
-                discr,
-                btag=as_dofdesc(btag).with_discr_tag(quadrature_tag),
-                cv=cv,
-                **boundary_kwargs
-            ) for btag in boundaries
-        )
+        + sum(boundaries[btag].soln_gradient_flux(
+            discr,
+            btag=as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            cv=cv, **boundary_kwargs) for btag in boundaries)
     )
 
     # Compute R = alpha*grad(Q)
@@ -215,31 +205,21 @@ def av_operator(discr, boundaries, cv, alpha, boundary_kwargs=None, **kwargs):
     def central_flux_div(utpair):
         dd = utpair.dd
         normal = thaw(actx, discr.normal(dd))
-        return op.project(
-            discr,
-            dd,
-            dd.with_dtag("all_faces"),
-            # This uses a central vector flux along nhat:
-            # flux = 1/2 * (grad(Q)- + grad(Q)+) .dot. nhat
-            divergence_flux_central(utpair, normal)
-        )
+        return op.project(discr, dd, dd.with_dtag("all_faces"),
+                          # This uses a central vector flux along nhat:
+                          # flux = 1/2 * (grad(Q)- + grad(Q)+) .dot. nhat
+                          divergence_flux_central(utpair, normal))
 
     # Total flux of grad(Q) across element boundaries
     r_bnd = (
         # Rank-local and cross-rank (across parallel partitions) contributions
-        + sum(
-            central_flux_div(interp_to_surf_quad(tpair))
-            for tpair in interior_trace_pairs(discr, r)
-        )
+        + sum(central_flux_div(interp_to_surf_quad(tpair))
+              for tpair in interior_trace_pairs(discr, r))
         # Contributions from boundary fluxes
-        + sum(
-            boundaries[btag].av_flux(
-                discr,
-                btag=as_dofdesc(btag).with_discr_tag(quadrature_tag),
-                diffusion=r,
-                **boundary_kwargs
-            ) for btag in boundaries
-        )
+        + sum(boundaries[btag].av_flux(
+            discr,
+            btag=as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            diffusion=r, **boundary_kwargs) for btag in boundaries)
     )
 
     # Return the AV RHS term

--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -67,7 +67,7 @@ Smoothness Indicator Evaluation
 AV RHS Evaluation
 ^^^^^^^^^^^^^^^^^
 
-.. autofunction:: av_operator
+.. autofunction:: av_laplacian_operator
 """
 
 __copyright__ = """
@@ -95,6 +95,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
+from mirgecom.fluid import make_conserved
 
 from pytools import memoize_in, keyed_memoize_in
 
@@ -117,7 +118,8 @@ from grudge.dof_desc import (
 import grudge.op as op
 
 
-def av_operator(discr, boundaries, cv, alpha, boundary_kwargs=None, **kwargs):
+def av_laplacian_operator(discr, boundaries, cv, alpha,
+                          boundary_kwargs=None, **kwargs):
     r"""Compute the artificial viscosity right-hand-side.
 
     Computes the the right-hand-side term for artificial viscosity.
@@ -227,12 +229,23 @@ def av_operator(discr, boundaries, cv, alpha, boundary_kwargs=None, **kwargs):
 
 
 def artificial_viscosity(discr, t, eos, boundaries, q, alpha, **kwargs):
-    """Interface :function:`av_operator` with backwards-compatible API."""
+    """Interface :function:`av_laplacian_operator` with backwards-compatible API."""
     from warnings import warn
-    warn("Do not call artificial_viscosity; it is now called av_operator. This"
-         "function will disappear in 2021", DeprecationWarning, stacklevel=2)
-    return av_operator(discr=discr, boundaries=boundaries,
-        boundary_kwargs={"t": t, "eos": eos}, q=q, alpha=alpha, **kwargs)
+    warn("Do not call artificial_viscosity; it is now called av_laplacian_operator."
+         " This function will disappear in 2022", DeprecationWarning, stacklevel=2)
+    return av_laplacian_operator(
+        discr=discr, cv=make_conserved(discr.dim, q=q), alpha=alpha,
+        boundaries=boundaries, boundary_kwargs={"t": t, "eos": eos}, **kwargs)
+
+
+def av_operator(discr, boundaries, q, alpha, boundary_kwargs=None, **kwargs):
+    """Interface :function:`av_laplacian_operator` with backwards-compatible API."""
+    from warnings import warn
+    warn("Do not call av_operator; it is now called av_laplacian_operator. This"
+         "function will disappear in 2022", DeprecationWarning, stacklevel=2)
+    return av_laplacian_operator(
+        discr=discr, cv=make_conserved(discr.dim, q=q), alpha=alpha,
+        boundaries=boundaries, boundary_kwargs=boundary_kwargs, **kwargs)
 
 
 def smoothness_indicator(discr, u, kappa=1.0, s0=-6.0):

--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -97,62 +97,26 @@ THE SOFTWARE.
 import numpy as np
 
 from pytools import memoize_in, keyed_memoize_in
-from pytools.obj_array import obj_array_vectorize
+
 from meshmode.dof_array import thaw, DOFArray
-from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import interior_trace_pair, cross_rank_trace_pairs
-from grudge.symbolic.primitives import TracePair
-from grudge.dof_desc import DD_VOLUME_MODAL, DD_VOLUME
+
+from mirgecom.flux import gradient_flux_central, divergence_flux_central
+
+from grudge.trace_pair import (
+    TracePair,
+    interior_trace_pairs
+)
+from grudge.dof_desc import (
+    DOFDesc,
+    as_dofdesc,
+    DD_VOLUME_MODAL,
+    DD_VOLUME
+)
+
+import grudge.op as op
 
 
-# FIXME: Remove when get_array_container_context is added to meshmode
-def _get_actx(obj):
-    if isinstance(obj, TracePair):
-        return _get_actx(obj.int)
-    if isinstance(obj, np.ndarray):
-        return _get_actx(obj[0])
-    elif isinstance(obj, DOFArray):
-        return obj.array_context
-    else:
-        raise ValueError("Unknown type; can't retrieve array context.")
-
-
-# Tweak the behavior of np.outer to return a lower-dimensional object if either/both
-# of the arguments are scalars (np.outer always returns a matrix)
-def _outer(a, b):
-    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
-        return np.outer(a, b)
-    else:
-        return a*b
-
-
-def _facial_flux_q(discr, q_tpair):
-    """Compute facial flux for each scalar component of Q."""
-    actx = _get_actx(q_tpair)
-
-    normal = thaw(actx, discr.normal(q_tpair.dd))
-
-    # This uses a central scalar flux along nhat:
-    # flux = 1/2 * (Q- + Q+) * nhat
-    flux_out = _outer(q_tpair.avg, normal)
-
-    return discr.project(q_tpair.dd, "all_faces", flux_out)
-
-
-def _facial_flux_r(discr, r_tpair):
-    """Compute facial flux for vector component of grad(Q)."""
-    actx = _get_actx(r_tpair)
-
-    normal = thaw(actx, discr.normal(r_tpair.dd))
-
-    # This uses a central vector flux along nhat:
-    # flux = 1/2 * (grad(Q)- + grad(Q)+) .dot. nhat
-    flux_out = r_tpair.avg @ normal
-
-    return discr.project(r_tpair.dd, "all_faces", flux_out)
-
-
-def av_operator(discr, boundaries, q, alpha, boundary_kwargs=None, **kwargs):
+def av_operator(discr, boundaries, cv, alpha, boundary_kwargs=None, **kwargs):
     r"""Compute the artificial viscosity right-hand-side.
 
     Computes the the right-hand-side term for artificial viscosity.
@@ -163,16 +127,8 @@ def av_operator(discr, boundaries, q, alpha, boundary_kwargs=None, **kwargs):
 
     Parameters
     ----------
-    q: :class:`~meshmode.dof_array.DOFArray` or :class:`~numpy.ndarray`
-
-        Single :class:`~meshmode.dof_array.DOFArray` for a scalar or an object array
-        (:class:`~numpy.ndarray`) for a vector of
-        :class:`~meshmode.dof_array.DOFArray` on which to operate.
-
-        When used with fluid solvers, *q* is expected to be the fluid state array
-        of the canonical conserved variables (mass, energy, momentum)
-        for the fluid along with a vector of species masses for multi-component
-        fluids.
+    cv: :class:`mirgecom.fluid.ConservedVars`
+        Fluid conserved state object with the conserved variables.
 
     boundaries: float
 
@@ -182,54 +138,124 @@ def av_operator(discr, boundaries, q, alpha, boundary_kwargs=None, **kwargs):
 
         The maximum artificial viscosity coefficient to be applied
 
+    quadrature_tag
+        An optional identifier denoting a particular quadrature
+        discretization to use during operator evaluations.
+        The default value is *None*.
+
     boundary_kwargs: :class:`dict`
 
         dictionary of extra arguments to pass through to the boundary conditions
 
     Returns
     -------
-    numpy.ndarray
+    :class:`mirgecom.fluid.ConservedVars`
 
         The artificial viscosity operator applied to *q*.
     """
     if boundary_kwargs is None:
         boundary_kwargs = dict()
 
-    # Get smoothness indicator based on first component
-    indicator_field = q[0] if isinstance(q, np.ndarray) else q
-    alpha_ind = -alpha*smoothness_indicator(discr, indicator_field, **kwargs)
+    actx = cv.array_context
+    quadrature_tag = kwargs.get("quadrature_tag", None)
+    dd_vol = DOFDesc("vol", quadrature_tag)
+    dd_faces = DOFDesc("all_faces", quadrature_tag)
 
-    # R=Grad(Q) volume part
-    if isinstance(q, np.ndarray):
-        grad_q_vol = np.stack(obj_array_vectorize(discr.weak_grad, q), axis=0)
-    else:
-        grad_q_vol = discr.weak_grad(q)
+    def interp_to_vol_quad(u):
+        return op.project(discr, "vol", dd_vol, u)
 
-    # Total flux of fluid soln Q across element boundaries
-    q_bnd_flux = (_facial_flux_q(discr, q_tpair=interior_trace_pair(discr, q))
-                  + sum(_facial_flux_q(discr, q_tpair=pb_tpair)
-                    for pb_tpair in cross_rank_trace_pairs(discr, q)))
-    q_bnd_flux2 = sum(bnd.soln_gradient_flux(discr, btag, soln=q, **boundary_kwargs)
-                      for btag, bnd in boundaries.items())
-    # if isinstance(q, np.ndarray):
-    #     q_bnd_flux2 = np.stack(q_bnd_flux2)
-    q_bnd_flux = q_bnd_flux + q_bnd_flux2
 
-    # Compute R
-    r = discr.inverse_mass(
-        alpha_ind*(grad_q_vol - discr.face_mass(q_bnd_flux))
+    def interp_to_surf_quad(utpair):
+        local_dd = utpair.dd
+        local_dd_quad = local_dd.with_discr_tag(quadrature_tag)
+        return TracePair(
+            local_dd_quad,
+            interior=op.project(discr, local_dd, local_dd_quad, utpair.int),
+            exterior=op.project(discr, local_dd, local_dd_quad, utpair.ext)
+        )
+
+
+    # Get smoothness indicator based on mass component
+    kappa = kwargs.get("kappa", 1.0)
+    s0 = kwargs.get("s0", -6.0)
+    indicator = smoothness_indicator(discr, cv.mass, kappa=kappa, s0=s0)
+
+    def central_flux(utpair):
+        dd = utpair.dd
+        normal = thaw(actx, discr.normal(dd))
+        return op.project(
+            discr,
+            dd,
+            dd.with_dtag("all_faces"),
+            # This uses a central scalar flux along nhat:
+            # flux = 1/2 * (Q- + Q+) * nhat
+            gradient_flux_central(utpair, normal)
+        )
+
+
+    cv_bnd = (
+        # Rank-local and cross-rank (across parallel partitions) contributions
+        + sum(
+            central_flux(interp_to_surf_quad(tpair))
+            for tpair in interior_trace_pairs(discr, cv)
+        )
+        # Contributions from boundary fluxes
+        + sum(
+            boundaries[btag].soln_gradient_flux(
+                discr,
+                btag=as_dofdesc(btag).with_discr_tag(quadrature_tag),
+                cv=cv,
+                **boundary_kwargs
+            ) for btag in boundaries
+        )
     )
-    # RHS_av = div(R) volume part
-    div_r_vol = discr.weak_div(r)
+
+    # Compute R = grad(Q)
+    r = op.inverse_mass(
+        discr,
+        -alpha * indicator * (
+            op.weak_local_grad(discr, dd_vol, interp_to_vol_quad(cv))
+            - op.face_mass(discr, dd_faces, cv_bnd)
+        )
+    )
+
+    def central_flux_div(utpair):
+        dd = utpair.dd
+        normal = thaw(actx, discr.normal(dd))
+        return op.project(
+            discr,
+            dd,
+            dd.with_dtag("all_faces"),
+            # This uses a central vector flux along nhat:
+            # flux = 1/2 * (grad(Q)- + grad(Q)+) .dot. nhat
+            divergence_flux_central(utpair, normal)
+        )
+
+
     # Total flux of grad(Q) across element boundaries
-    r_bnd_flux = (_facial_flux_r(discr, r_tpair=interior_trace_pair(discr, r))
-                  + sum(_facial_flux_r(discr, r_tpair=pb_tpair)
-                    for pb_tpair in cross_rank_trace_pairs(discr, r))
-                  + sum(bnd.av_flux(discr, btag, diffusion=r, **boundary_kwargs)
-                        for btag, bnd in boundaries.items()))
+    r_bnd = (
+        # Rank-local and cross-rank (across parallel partitions) contributions
+        + sum(
+            central_flux_div(interp_to_surf_quad(tpair))
+            for tpair in interior_trace_pairs(discr, r)
+        )
+        # Contributions from boundary fluxes
+        + sum(
+            boundaries[btag].av_flux(
+                discr,
+                btag=as_dofdesc(btag).with_discr_tag(quadrature_tag),
+                diffusion=r,
+                **boundary_kwargs
+            ) for btag in boundaries
+        )
+    )
 
     # Return the AV RHS term
-    return discr.inverse_mass(-div_r_vol + discr.face_mass(r_bnd_flux))
+    return op.inverse_mass(
+        discr,
+        -op.weak_local_div(discr, dd_vol, interp_to_vol_quad(r))
+        + op.face_mass(discr, dd_faces, r_bnd)
+    )
 
 
 def artificial_viscosity(discr, t, eos, boundaries, q, alpha, **kwargs):

--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -233,9 +233,15 @@ def artificial_viscosity(discr, t, eos, boundaries, q, alpha, **kwargs):
     from warnings import warn
     warn("Do not call artificial_viscosity; it is now called av_laplacian_operator."
          " This function will disappear in 2022", DeprecationWarning, stacklevel=2)
+    from mirgecom.fluid import ConservedVars
+
+    if not isinstance(q, ConservedVars):
+        q = make_conserved(discr.dim, q=q)
+
     return av_laplacian_operator(
         discr=discr, cv=make_conserved(discr.dim, q=q), alpha=alpha,
-        boundaries=boundaries, boundary_kwargs={"t": t, "eos": eos}, **kwargs)
+        boundaries=boundaries,
+        boundary_kwargs={"t": t, "eos": eos}, **kwargs).join()
 
 
 def av_operator(discr, boundaries, q, alpha, boundary_kwargs=None, **kwargs):
@@ -243,9 +249,15 @@ def av_operator(discr, boundaries, q, alpha, boundary_kwargs=None, **kwargs):
     from warnings import warn
     warn("Do not call av_operator; it is now called av_laplacian_operator. This"
          "function will disappear in 2022", DeprecationWarning, stacklevel=2)
+    from mirgecom.fluid import ConservedVars
+
+    if not isinstance(q, ConservedVars):
+        q = make_conserved(discr.dim, q=q)
+
     return av_laplacian_operator(
-        discr=discr, cv=make_conserved(discr.dim, q=q), alpha=alpha,
-        boundaries=boundaries, boundary_kwargs=boundary_kwargs, **kwargs)
+        discr=discr, cv=q, alpha=alpha,
+        boundaries=boundaries,
+        boundary_kwargs=boundary_kwargs, **kwargs).join()
 
 
 def smoothness_indicator(discr, u, kappa=1.0, s0=-6.0):

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -167,6 +167,8 @@ class PrescribedFluidBoundary(FluidBoundary):
 
     def _boundary_quantity(self, discr, btag, quantity, **kwargs):
         """Get a boundary quantity on local boundary, or projected to "all_faces"."""
+        from grudge.dof_desc import as_dofdesc
+        btag = as_dofdesc(btag)
         if "local" in kwargs:
             if kwargs["local"]:
                 return quantity

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -170,7 +170,7 @@ class PrescribedFluidBoundary(FluidBoundary):
         if "local" in kwargs:
             if kwargs["local"]:
                 return quantity
-        return discr.project(btag, "all_faces", quantity)
+        return discr.project(btag, btag.with_dtag("all_faces"), quantity)
 
     def _boundary_state_pair(self, discr, btag, gas_model, state_minus, **kwargs):
         return TracePair(btag,

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -133,14 +133,11 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
 
     boundary_states = {
         btag: project_fluid_state(
-            discr,
-            dd_base,
+            discr, dd_base,
             # Make sure we get the state on the quadrature grid
             # restricted to the tag *btag*
             as_dofdesc(btag).with_discr_tag(quadrature_tag),
-            state,
-            gas_model
-        ) for btag in boundaries
+            state, gas_model) for btag in boundaries
     }
 
     cv_interior_pairs = [
@@ -192,13 +189,8 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
               for state_pair in interior_states)
     )
 
-    return -div_operator(
-        discr,
-        dd_vol,
-        dd_faces,
-        inviscid_flux_vol,
-        inviscid_flux_bnd
-    )
+    return -div_operator(discr, dd_vol, dd_faces,
+                         inviscid_flux_vol, inviscid_flux_bnd)
 
 
 # By default, run unitless

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -52,18 +52,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np  # noqa
 from mirgecom.inviscid import (
     inviscid_flux,
     inviscid_facial_flux,
     inviscid_flux_rusanov
 )
-from grudge.trace_pair import interior_trace_pairs
 from mirgecom.operators import div_operator
+from mirgecom.gas_model import (
+    project_fluid_state,
+    make_fluid_state_trace_pairs
+)
+from grudge.trace_pair import (
+    TracePair,
+    interior_trace_pairs
+)
+from grudge.dof_desc import DOFDesc, as_dofdesc
+
+import grudge.op as op
 
 
 def euler_operator(discr, state, gas_model, boundaries, time=0.0,
-                   inviscid_numerical_flux_func=inviscid_flux_rusanov):
+                   inviscid_numerical_flux_func=inviscid_flux_rusanov,
+                   quadrature_tag=None):
     r"""Compute RHS of the Euler flow equations.
 
     Returns
@@ -96,19 +106,50 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
         Physical gas model including equation of state, transport,
         and kinetic properties as required by fluid state
 
+    quadrature_tag
+        An optional identifier denoting a particular quadrature
+        discretization to use during operator evaluations.
+        The default value is *None*.
+
     Returns
     -------
-    numpy.ndarray
+    :class:`mirgecom.fluid.ConservedVars`
 
         Agglomerated object array of DOF arrays representing the RHS of the Euler
         flow equations.
     """
-    from mirgecom.gas_model import project_fluid_state
-    boundary_states = {btag:
-                       project_fluid_state(discr, btag, state, gas_model)
-                       for btag in boundaries}
+    dd_base = as_dofdesc("vol")
+    dd_vol = DOFDesc("vol", quadrature_tag)
+    dd_faces = DOFDesc("all_faces", quadrature_tag)
 
-    cv_interior_pairs = interior_trace_pairs(discr, state.cv)
+    def interp_to_surf_quad(utpair):
+        local_dd = utpair.dd
+        local_dd_quad = local_dd.with_discr_tag(quadrature_tag)
+        return TracePair(
+            local_dd_quad,
+            interior=op.project(discr, local_dd, local_dd_quad, utpair.int),
+            exterior=op.project(discr, local_dd, local_dd_quad, utpair.ext)
+        )
+
+
+    boundary_states = {
+        btag: project_fluid_state(
+            discr,
+            dd_base,
+            # Make sure we get the state on the quadrature grid
+            # restricted to the tag *btag*
+            as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            state,
+            gas_model
+        ) for btag in boundaries
+    }
+
+    cv_interior_pairs = [
+        # Get the interior trace pairs onto the surface quadrature
+        # discretization (if any)
+        interp_to_surf_quad(tpair)
+        for tpair in interior_trace_pairs(discr, state.cv)
+    ]
 
     tseed_interior_pairs = None
     if state.is_mixture > 0:
@@ -116,18 +157,33 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
         # mixture pressure (used in the inviscid flux calculations) depends on
         # temperature and we need to seed the temperature calculation for the
         # (+) part of the partition boundary with the remote temperature data.
-        tseed_interior_pairs = interior_trace_pairs(discr, state.temperature)
+        tseed_interior_pairs = [
+            # Get the interior trace pairs onto the surface quadrature
+            # discretization (if any)
+            interp_to_surf_quad(tpair)
+            for tpair in interior_trace_pairs(discr, state.temperature)
+        ]
 
-    from mirgecom.gas_model import make_fluid_state_trace_pairs
-    interior_states = make_fluid_state_trace_pairs(cv_interior_pairs, gas_model,
+    interior_states = make_fluid_state_trace_pairs(cv_interior_pairs,
+                                                   gas_model,
                                                    tseed_interior_pairs)
 
-    inviscid_flux_vol = inviscid_flux(state)
+    # Interpolate the fluid state to the volume quadrature grid
+    # (conserved vars and derived vars if applicable)
+    state_quad = project_fluid_state(discr, dd_base, dd_vol, state, gas_model)
+
+    inviscid_flux_vol = inviscid_flux(state_quad)
     inviscid_flux_bnd = (
 
         # Domain boundaries
         sum(boundaries[btag].inviscid_divergence_flux(
-            discr, btag, gas_model, state_minus=boundary_states[btag], time=time,
+            discr,
+            # Make sure we get the state on the quadrature grid
+            # restricted to the tag *btag*
+            as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            gas_model,
+            state_minus=boundary_states[btag],
+            time=time,
             numerical_flux_func=inviscid_numerical_flux_func)
             for btag in boundaries)
 
@@ -137,7 +193,13 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
               for state_pair in interior_states)
     )
 
-    return -div_operator(discr, inviscid_flux_vol, inviscid_flux_bnd)
+    return -div_operator(
+        discr,
+        dd_vol,
+        dd_faces,
+        inviscid_flux_vol,
+        inviscid_flux_bnd
+    )
 
 
 # By default, run unitless

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -131,7 +131,6 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
             exterior=op.project(discr, local_dd, local_dd_quad, utpair.ext)
         )
 
-
     boundary_states = {
         btag: project_fluid_state(
             discr,

--- a/mirgecom/gas_model.py
+++ b/mirgecom/gas_model.py
@@ -272,7 +272,7 @@ def make_fluid_state(cv, gas_model, temperature_seed=None):
     return FluidState(cv=cv, dv=dv)
 
 
-def project_fluid_state(discr, btag, state, gas_model):
+def project_fluid_state(discr, src, tgt, state, gas_model):
     """Project a fluid state onto a boundary consistent with the gas model.
 
     If required by the gas model, (e.g. gas is a mixture), this routine will
@@ -284,9 +284,17 @@ def project_fluid_state(discr, btag, state, gas_model):
 
         A discretization collection encapsulating the DG elements
 
-    btag:
+    src:
 
-        A boundary tag indicating the boundary to which to project the state
+        A :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one
+        indicating where the state is currently defined
+        (e.g. "vol" or "all_faces")
+
+    tgt:
+
+        A :class:`~grudge.dof_desc.DOFDesc`, or a value convertible to one
+        indicating where to interpolate/project the state
+        (e.g. "all_faces" or a boundary tag *btag*)
 
     state: :class:`~mirgecom.gas_model.FluidState`
 
@@ -302,10 +310,10 @@ def project_fluid_state(discr, btag, state, gas_model):
 
         Thermally consistent fluid state
     """
-    cv_sd = discr.project("vol", btag, state.cv)
+    cv_sd = discr.project(src, tgt, state.cv)
     temperature_seed = None
     if state.is_mixture > 0:
-        temperature_seed = discr.project("vol", btag, state.dv.temperature)
+        temperature_seed = discr.project(src, tgt, state.dv.temperature)
     return make_fluid_state(cv=cv_sd, gas_model=gas_model,
                             temperature_seed=temperature_seed)
 

--- a/mirgecom/inviscid.py
+++ b/mirgecom/inviscid.py
@@ -143,7 +143,9 @@ def inviscid_facial_flux(discr, gas_model, state_pair,
     from arraycontext import thaw
     normal = thaw(discr.normal(state_pair.dd), state_pair.int.array_context)
     num_flux = numerical_flux_func(normal, gas_model, state_pair)
-    return num_flux if local else discr.project(state_pair.dd, "all_faces", num_flux)
+    dd = state_pair.dd
+    dd_allfaces = dd.with_dtag("all_faces")
+    return num_flux if local else discr.project(dd, dd_allfaces, num_flux)
 
 
 def get_inviscid_timestep(discr, state):

--- a/mirgecom/navierstokes.py
+++ b/mirgecom/navierstokes.py
@@ -55,9 +55,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np  # noqa
-from grudge.symbolic.primitives import TracePair
-from grudge.trace_pair import interior_trace_pairs
+from grudge.trace_pair import (
+    TracePair,
+    interior_trace_pairs
+)
+from grudge.dof_desc import DOFDesc, as_dofdesc
+
+import grudge.op as op
 
 from mirgecom.inviscid import (
     inviscid_flux,
@@ -75,13 +79,19 @@ from mirgecom.flux import (
 from mirgecom.operators import (
     div_operator, grad_operator
 )
+from mirgecom.gas_model import (
+    project_fluid_state,
+    make_fluid_state_trace_pairs
+)
+
 from arraycontext import thaw
 
 
 def ns_operator(discr, gas_model, state, boundaries, time=0.0,
                 inviscid_numerical_flux_func=inviscid_flux_rusanov,
                 gradient_numerical_flux_func=gradient_flux_central,
-                viscous_numerical_flux_func=viscous_flux_central):
+                viscous_numerical_flux_func=viscous_flux_central,
+                quadrature_tag=None):
     r"""Compute RHS of the Navier-Stokes equations.
 
     Returns
@@ -95,11 +105,10 @@ def ns_operator(discr, gas_model, state, boundaries, time=0.0,
 
     Parameters
     ----------
-    cv: :class:`~mirgecom.fluid.ConservedVars`
-        Fluid solution
+    state: :class:`~mirgecom.gas_model.FluidState`
 
-    dv: :class:`~mirgecom.eos.EOSDependentVars`
-        Fluid solution-dependent quantities (e.g. pressure, temperature)
+        Fluid state object with the conserved state, and dependent
+        quantities.
 
     boundaries
         Dictionary of boundary functions, one for each valid btag
@@ -113,9 +122,15 @@ def ns_operator(discr, gas_model, state, boundaries, time=0.0,
         Implementing the transport properties including heat conductivity,
         and species diffusivities type(mirgecom.transport.TransportModel).
 
+    quadrature_tag
+        An optional identifier denoting a particular quadrature
+        discretization to use during operator evaluations.
+        The default value is *None*.
+
     Returns
     -------
-    numpy.ndarray
+    :class:`mirgecom.fluid.ConservedVars`
+
         Agglomerated object array of DOF arrays representing the RHS of the
         Navier-Stokes equations.
     """
@@ -123,52 +138,96 @@ def ns_operator(discr, gas_model, state, boundaries, time=0.0,
         raise ValueError("Navier-Stokes operator expects viscous gas model.")
 
     actx = state.array_context
+    dd_base = as_dofdesc("vol")
+    dd_vol = DOFDesc("vol", quadrature_tag)
+    dd_faces = DOFDesc("all_faces", quadrature_tag)
 
-    from mirgecom.gas_model import project_fluid_state
-    boundary_states = {btag:
-                       project_fluid_state(discr, btag, state, gas_model)
-                       for btag in boundaries}
-
-    cv_interior_pairs = interior_trace_pairs(discr, state.cv)
-
-    tseed_interior_pairs = \
-        interior_trace_pairs(discr, state.temperature) if state.is_mixture else None
-
-    from mirgecom.gas_model import make_fluid_state_trace_pairs
-    interior_state_pairs = make_fluid_state_trace_pairs(cv_interior_pairs, gas_model,
-                                                        tseed_interior_pairs)
-
-    # Operator-independent boundary flux interface
-    def _sum_element_boundary_fluxes(discr, compute_interior_flux,
-                                   compute_boundary_flux, interior_trace_pairs,
-                                   boundary_states):
-        return (sum(compute_interior_flux(tpair)
-                    for tpair in interior_trace_pairs)
-                + sum(compute_boundary_flux(btag, boundary_states[btag])
-                      for btag in boundary_states))
-
-    # Data-independent grad flux for faces
-    def _grad_flux_interior(q_pair):
-        normal = thaw(discr.normal(q_pair.dd), actx)
-        # Hard-coding central per [Bassi_1997]_ eqn 13
-        flux_weak = gradient_numerical_flux_func(q_pair, normal)
-        return discr.project(q_pair.dd, "all_faces", flux_weak)
-
-    # CV-specific boundary flux for grad operator
-    def _cv_grad_flux_bnd(btag, boundary_state):
-        return boundaries[btag].cv_gradient_flux(
-            discr, btag=btag, gas_model=gas_model, state_minus=boundary_state,
-            time=time, numerical_flux_func=gradient_numerical_flux_func
+    def interp_to_surf_quad(utpair):
+        local_dd = utpair.dd
+        local_dd_quad = local_dd.with_discr_tag(quadrature_tag)
+        return TracePair(
+            local_dd_quad,
+            interior=op.project(discr, local_dd, local_dd_quad, utpair.int),
+            exterior=op.project(discr, local_dd, local_dd_quad, utpair.ext)
         )
 
-    cv_flux_bnd = \
-        _sum_element_boundary_fluxes(discr, _grad_flux_interior, _cv_grad_flux_bnd,
-                                     cv_interior_pairs, boundary_states)
+    boundary_states = {
+        btag: project_fluid_state(
+            discr,
+            dd_base,
+            # Make sure we get the state on the quadrature grid
+            # restricted to the tag *btag*
+            as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            state,
+            gas_model
+        ) for btag in boundaries
+    }
+
+    cv_interior_pairs = [
+        # Get the interior trace pairs onto the surface quadrature
+        # discretization (if any)
+        interp_to_surf_quad(tpair)
+        for tpair in interior_trace_pairs(discr, state.cv)
+    ]
+
+    tseed_interior_pairs = None
+    if state.is_mixture > 0:
+        # If this is a mixture, we need to exchange the temperature field because
+        # mixture pressure (used in the flux calculations) depends on
+        # temperature and we need to seed the temperature calculation for the
+        # (+) part of the partition boundary with the remote temperature data.
+        tseed_interior_pairs = [
+            # Get the interior trace pairs onto the surface quadrature
+            # discretization (if any)
+            interp_to_surf_quad(tpair)
+            for tpair in interior_trace_pairs(discr, state.temperature)
+        ]
+
+    quadrature_state = \
+        project_fluid_state(discr, dd_base, dd_vol, state, gas_model)
+    interior_state_pairs = make_fluid_state_trace_pairs(cv_interior_pairs,
+                                                        gas_model,
+                                                        tseed_interior_pairs)
+
+    def gradient_flux_interior(tpair):
+        dd = tpair.dd
+        normal = thaw(discr.normal(dd), actx)
+        flux = gradient_numerical_flux_func(tpair, normal)
+        return op.project(discr, dd, dd.with_dtag("all_faces"), flux)
+
+    cv_flux_bnd = (
+
+        # Domain boundaries
+        sum(boundaries[btag].cv_gradient_flux(
+            discr,
+            # Make sure we get the state on the quadrature grid
+            # restricted to the tag *btag*
+            as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            gas_model=gas_model,
+            state_minus=boundary_states[btag],
+            time=time,
+            numerical_flux_func=gradient_numerical_flux_func)
+            for btag in boundary_states)
+
+        # Interior boundaries
+        + sum(gradient_flux_interior(tpair) for tpair in cv_interior_pairs)
+    )
 
     # [Bassi_1997]_ eqn 15 (s = grad_q)
-    grad_cv = grad_operator(discr, state.cv, cv_flux_bnd)
+    grad_cv = grad_operator(
+        discr,
+        dd_vol,
+        dd_faces,
+        quadrature_state.cv,
+        cv_flux_bnd
+    )
 
-    grad_cv_interior_pairs = interior_trace_pairs(discr, grad_cv)
+    grad_cv_interior_pairs = [
+        # Get the interior trace pairs onto the surface quadrature
+        # discretization (if any)
+        interp_to_surf_quad(tpair)
+        for tpair in interior_trace_pairs(discr, grad_cv)
+    ]
 
     # Temperature gradient for conductive heat flux: [Ihme_2014]_ eqn (3b)
     # Capture the temperature for the interior faces for grad(T) calc
@@ -179,18 +238,38 @@ def ns_operator(discr, gas_model, state, boundaries, time=0.0,
                                   exterior=state_pair.ext.temperature)
                         for state_pair in interior_state_pairs]
 
-    def _t_grad_flux_bnd(btag, boundary_state):
-        return boundaries[btag].temperature_gradient_flux(
-            discr, btag=btag, gas_model=gas_model,
-            state_minus=boundary_state, time=time)
+    t_flux_bnd = (
 
-    t_flux_bnd = \
-        _sum_element_boundary_fluxes(discr, _grad_flux_interior, _t_grad_flux_bnd,
-                                     t_interior_pairs, boundary_states)
+        # Domain boundaries
+        sum(boundaries[btag].temperature_gradient_flux(
+            discr,
+            # Make sure we get the state on the quadrature grid
+            # restricted to the tag *btag*
+            as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            gas_model=gas_model,
+            state_minus=boundary_states[btag],
+            time=time)
+            for btag in boundary_states)
+
+        # Interior boundaries
+        + sum(gradient_flux_interior(tpair) for tpair in t_interior_pairs)
+    )
 
     # Fluxes in-hand, compute the gradient of temperature and mpi exchange it
-    grad_t = grad_operator(discr, state.temperature, t_flux_bnd)
-    grad_t_interior_pairs = interior_trace_pairs(discr, grad_t)
+    grad_t = grad_operator(
+        discr,
+        dd_vol,
+        dd_faces,
+        quadrature_state.temperature,
+        t_flux_bnd
+    )
+
+    grad_t_interior_pairs = [
+        # Get the interior trace pairs onto the surface quadrature
+        # discretization (if any)
+        interp_to_surf_quad(tpair)
+        for tpair in interior_trace_pairs(discr, grad_t)
+    ]
 
     # inviscid flux divergence-specific flux function for interior faces
     def finv_divergence_flux_interior(state_pair):
@@ -201,20 +280,18 @@ def ns_operator(discr, gas_model, state, boundaries, time=0.0,
     # inviscid part of bcs applied here
     def finv_divergence_flux_boundary(btag, boundary_state):
         return boundaries[btag].inviscid_divergence_flux(
-            discr, btag=btag, gas_model=gas_model, state_minus=boundary_state,
-            time=time, numerical_flux_func=inviscid_numerical_flux_func)
-
-    # glob viscous flux inputs for use by the _sum_element_boundary_fluxes wrapper
-    viscous_states_int_bnd = [
-        (state_pair, grad_cv_pair, grad_t_pair)
-        for state_pair, grad_cv_pair, grad_t_pair in
-        zip(interior_state_pairs, grad_cv_interior_pairs, grad_t_interior_pairs)]
+            discr,
+            # Make sure we fields on the quadrature grid
+            # restricted to the tag *btag*
+            as_dofdesc(btag).with_discr_tag(quadrature_tag),
+            gas_model=gas_model,
+            state_minus=boundary_state,
+            time=time,
+            numerical_flux_func=inviscid_numerical_flux_func
+        )
 
     # viscous fluxes across interior faces (including partition and periodic bnd)
-    def fvisc_divergence_flux_interior(tpair_tuple):
-        state_pair = tpair_tuple[0]
-        grad_cv_pair = tpair_tuple[1]
-        grad_t_pair = tpair_tuple[2]
+    def fvisc_divergence_flux_interior(state_pair, grad_cv_pair, grad_t_pair):
         return viscous_facial_flux(discr=discr, gas_model=gas_model,
                                    state_pair=state_pair, grad_cv_pair=grad_cv_pair,
                                    grad_t_pair=grad_t_pair,
@@ -222,27 +299,67 @@ def ns_operator(discr, gas_model, state, boundaries, time=0.0,
 
     # viscous part of bcs applied here
     def fvisc_divergence_flux_boundary(btag, boundary_state):
-        grad_cv_minus = discr.project("vol", btag, grad_cv)
-        grad_t_minus = discr.project("vol", btag, grad_t)
+        # Make sure we fields on the quadrature grid
+        # restricted to the tag *btag*
+        dd_btag = as_dofdesc(btag).with_discr_tag(quadrature_tag)
+        grad_cv_minus = op.project(discr, dd_base, dd_btag, grad_cv)
+        grad_t_minus = op.project(discr, dd_base, dd_btag, grad_t)
         return boundaries[btag].viscous_divergence_flux(
-            discr=discr, btag=btag, gas_model=gas_model,
+            discr=discr,
+            btag=dd_btag,
+            gas_model=gas_model,
             state_minus=boundary_state,
-            grad_cv_minus=grad_cv_minus, grad_t_minus=grad_t_minus, time=time,
-            numerical_flux_func=viscous_numerical_flux_func)
+            grad_cv_minus=grad_cv_minus,
+            grad_t_minus=grad_t_minus,
+            time=time,
+            numerical_flux_func=viscous_numerical_flux_func
+        )
 
     vol_term = (
-        viscous_flux(state=state, grad_cv=grad_cv, grad_t=grad_t)
-        - inviscid_flux(state=state)
+
+        # Compute the volume contribution of the viscous flux terms
+        # using field values on the quadrature grid
+        viscous_flux(state=quadrature_state,
+                     # Interpolate gradients to the quadrature grid
+                     grad_cv=op.project(discr, dd_base, dd_vol, grad_cv),
+                     grad_t=op.project(discr, dd_base, dd_vol, grad_t))
+
+        # Compute the volume contribution of the inviscid flux terms
+        # using field values on the quadrature grid
+        - inviscid_flux(state=quadrature_state)
     )
 
     bnd_term = (
-        _sum_element_boundary_fluxes(
-            discr, fvisc_divergence_flux_interior, fvisc_divergence_flux_boundary,
-            viscous_states_int_bnd, boundary_states)
-        - _sum_element_boundary_fluxes(
-            discr, finv_divergence_flux_interior, finv_divergence_flux_boundary,
-            interior_state_pairs, boundary_states)
+
+        # All surface contributions from the viscous fluxes
+        (
+            # Domain boundary contributions for the viscous terms
+            sum(fvisc_divergence_flux_boundary(btag, boundary_states[btag])
+                for btag in boundary_states)
+
+            # Interior interface contributions for the viscous terms
+            + sum(
+                fvisc_divergence_flux_interior(state_pair, grad_cv_pair, grad_t_pair)
+
+                for state_pair, grad_cv_pair, grad_t_pair in zip(
+                    interior_state_pairs,
+                    grad_cv_interior_pairs,
+                    grad_t_interior_pairs
+                )
+            )
+        )
+
+        # All surface contributions from the inviscid fluxes
+        - (
+            # Domain boundary contributions for the inviscid terms
+            sum(finv_divergence_flux_boundary(btag, boundary_states[btag])
+                for btag in boundary_states)
+
+            # Interior interface contributions for the inviscid terms
+            + sum(finv_divergence_flux_interior(tpair)
+                  for tpair in interior_state_pairs)
+        )
     )
 
     # NS RHS
-    return div_operator(discr, vol_term, bnd_term)
+    return div_operator(discr, dd_vol, dd_faces, vol_term, bnd_term)

--- a/mirgecom/operators.py
+++ b/mirgecom/operators.py
@@ -28,45 +28,62 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import grudge.op as op
 
-def grad_operator(discr, u, flux):
+
+def grad_operator(discr, dd_vol, dd_faces, volume_fluxes, boundary_fluxes):
     r"""Compute a DG gradient for the input *u* with flux given by *flux*.
 
     Parameters
     ----------
     discr: grudge.eager.EagerDGDiscretization
         the discretization to use
-    u: meshmode.dof_array.DOFArray or numpy.ndarray
-        the DOF array (or object array of DOF arrays) to which the operator should be
-        applied
-    flux: numpy.ndarray
+    dd_vol: grudge.dof_desc.DOFDesc
+        the degree-of-freedom tag associated with the volume discrezation.
+        This determines the type of quadrature to be used.
+    dd_faces: grudge.dof_desc.DOFDesc
+        the degree-of-freedom tag associated with the surface discrezation.
+        This determines the type of quadrature to be used.
+    volume_fluxes: :class:`mirgecom.fluid.ConservedVars`
+        the vector-valued function for which divergence is to be calculated
+    boundary_fluxes: :class:`mirgecom.fluid.ConservedVars`
         the boundary fluxes across the faces of the element
     Returns
     -------
     meshmode.dof_array.DOFArray or numpy.ndarray
         the dg gradient operator applied to *u*
     """
-    from grudge.op import weak_local_grad
-    return -discr.inverse_mass(weak_local_grad(discr, u, nested=False)
-                               - discr.face_mass(flux))
+    return -op.inverse_mass(
+        discr,
+        op.weak_local_grad(discr, dd_vol, volume_fluxes)
+        - op.face_mass(discr, dd_faces, boundary_fluxes)
+    )
 
 
-def div_operator(discr, u, flux):
+def div_operator(discr, dd_vol, dd_faces, volume_fluxes, boundary_fluxes):
     r"""Compute a DG divergence of vector-valued function *u* with flux given by *flux*.
 
     Parameters
     ----------
     discr: grudge.eager.EagerDGDiscretization
         the discretization to use
-    u: numpy.ndarray
+    dd_vol: grudge.dof_desc.DOFDesc
+        the degree-of-freedom tag associated with the volume discrezation.
+        This determines the type of quadrature to be used.
+    dd_faces: grudge.dof_desc.DOFDesc
+        the degree-of-freedom tag associated with the surface discrezation.
+        This determines the type of quadrature to be used.
+    volume_fluxes: :class:`mirgecom.fluid.ConservedVars`
         the vector-valued function for which divergence is to be calculated
-    flux: numpy.ndarray
+    boundary_fluxes: :class:`mirgecom.fluid.ConservedVars`
         the boundary fluxes across the faces of the element
     Returns
     -------
-    meshmode.dof_array.DOFArray or numpy.ndarray
+    :class:`mirgecom.fluid.ConservedVars`
         the dg divergence operator applied to vector-valued function *u*.
     """
-    from grudge.op import weak_local_div
-    return -discr.inverse_mass(weak_local_div(discr, u)
-                               - discr.face_mass(flux))
+    return -op.inverse_mass(
+        discr,
+        op.weak_local_div(discr, dd_vol, volume_fluxes)
+        - op.face_mass(discr, dd_faces, boundary_fluxes)
+    )

--- a/mirgecom/operators.py
+++ b/mirgecom/operators.py
@@ -53,8 +53,7 @@ def grad_operator(discr, dd_vol, dd_faces, volume_fluxes, boundary_fluxes):
     meshmode.dof_array.DOFArray or numpy.ndarray
         the dg gradient operator applied to *u*
     """
-    return -op.inverse_mass(
-        discr,
+    return -discr.inverse_mass(
         op.weak_local_grad(discr, dd_vol, volume_fluxes)
         - op.face_mass(discr, dd_faces, boundary_fluxes)
     )
@@ -82,8 +81,7 @@ def div_operator(discr, dd_vol, dd_faces, volume_fluxes, boundary_fluxes):
     :class:`mirgecom.fluid.ConservedVars`
         the dg divergence operator applied to vector-valued function *u*.
     """
-    return -op.inverse_mass(
-        discr,
+    return -discr.inverse_mass(
         op.weak_local_div(discr, dd_vol, volume_fluxes)
         - op.face_mass(discr, dd_faces, boundary_fluxes)
     )

--- a/mirgecom/utils.py
+++ b/mirgecom/utils.py
@@ -67,8 +67,8 @@ class StatisticsAccumulator:
         scale_factor
             Scale returned statistics by this factor.
         """
+        # Number of values stored in the StatisticsAccumulator
         self.num_values: int = 0
-        """Number of values stored in the StatisticsAccumulator."""
 
         self._sum = 0
         self._min = None

--- a/mirgecom/viscous.py
+++ b/mirgecom/viscous.py
@@ -368,7 +368,9 @@ def viscous_facial_flux(discr, gas_model, state_pair, grad_cv_pair, grad_t_pair,
                                    state_pair=state_pair,
                                    grad_cv_pair=grad_cv_pair,
                                    grad_t_pair=grad_t_pair)
-    return num_flux if local else discr.project(state_pair.dd, "all_faces", num_flux)
+    dd = state_pair.dd
+    dd_allfaces = dd.with_dtag("all_faces")
+    return num_flux if local else discr.project(dd, dd_allfaces, num_flux)
 
 
 def get_viscous_timestep(discr, state):

--- a/test/test_av.py
+++ b/test/test_av.py
@@ -29,17 +29,24 @@ import logging
 import numpy as np
 import pyopencl as cl
 import pytest
+
 from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.dof_array import thaw
 from meshmode.mesh import BTAG_ALL
+
 from mirgecom.artificial_viscosity import (
     av_operator,
     smoothness_indicator
 )
+from mirgecom.fluid import make_conserved
+
 from grudge.eager import EagerDGDiscretization
+
 from pyopencl.tools import (  # noqa
     pytest_generate_tests_for_pyopencl as pytest_generate_tests,
 )
+
+from pytools.obj_array import make_obj_array
 
 logger = logging.getLogger(__name__)
 
@@ -176,12 +183,12 @@ def test_artificial_viscosity(ctx_factory, dim, order):
     zeros = discr.zeros(actx)
 
     class TestBoundary:
-        def soln_gradient_flux(self, disc, btag, soln, **kwargs):
-            soln_int = disc.project("vol", btag, soln)
+        def soln_gradient_flux(self, disc, btag, cv, **kwargs):
+            cv_int = disc.project("vol", btag, cv)
             from grudge.trace_pair import TracePair
             bnd_pair = TracePair(btag,
-                                 interior=soln_int,
-                                 exterior=soln_int)
+                                 interior=cv_int,
+                                 exterior=cv_int)
             nhat = thaw(actx, disc.normal(btag))
             from mirgecom.flux import gradient_flux_central
             flux_weak = gradient_flux_central(bnd_pair, normal=nhat)
@@ -202,18 +209,39 @@ def test_artificial_viscosity(ctx_factory, dim, order):
 
     # Uniform field return 0 rhs
     soln = zeros + 1.0
-    rhs = av_operator(discr, boundaries=boundaries, q=soln, alpha=1.0, s0=-np.inf)
+    cv = make_conserved(
+        dim,
+        mass=soln,
+        energy=soln,
+        momentum=make_obj_array([soln for _ in range(dim)]),
+        species_mass=make_obj_array([soln for _ in range(dim)])
+    )
+    rhs = av_operator(discr, boundaries=boundaries, cv=cv, alpha=1.0, s0=-np.inf)
     err = discr.norm(rhs, np.inf)
     assert err < tolerance
 
     # Linear field return 0 rhs
     soln = nodes[0]
-    rhs = av_operator(discr, boundaries=boundaries, q=soln, alpha=1.0, s0=-np.inf)
+    cv = make_conserved(
+        dim,
+        mass=soln,
+        energy=soln,
+        momentum=make_obj_array([soln for _ in range(dim)]),
+        species_mass=make_obj_array([soln for _ in range(dim)])
+    )
+    rhs = av_operator(discr, boundaries=boundaries, cv=cv, alpha=1.0, s0=-np.inf)
     err = discr.norm(rhs, np.inf)
     assert err < tolerance
 
     # Quadratic field return constant 2
     soln = np.dot(nodes, nodes)
-    rhs = av_operator(discr, boundaries=boundaries, q=soln, alpha=1.0, s0=-np.inf)
+    cv = make_conserved(
+        dim,
+        mass=soln,
+        energy=soln,
+        momentum=make_obj_array([soln for _ in range(dim)]),
+        species_mass=make_obj_array([soln for _ in range(dim)])
+    )
+    rhs = av_operator(discr, boundaries=boundaries, cv=cv, alpha=1.0, s0=-np.inf)
     err = discr.norm(2.*dim-rhs, np.inf)
     assert err < tolerance

--- a/test/test_av.py
+++ b/test/test_av.py
@@ -35,7 +35,7 @@ from meshmode.dof_array import thaw
 from meshmode.mesh import BTAG_ALL
 
 from mirgecom.artificial_viscosity import (
-    av_operator,
+    av_laplacian_operator,
     smoothness_indicator
 )
 from mirgecom.fluid import make_conserved
@@ -216,7 +216,8 @@ def test_artificial_viscosity(ctx_factory, dim, order):
         momentum=make_obj_array([soln for _ in range(dim)]),
         species_mass=make_obj_array([soln for _ in range(dim)])
     )
-    rhs = av_operator(discr, boundaries=boundaries, cv=cv, alpha=1.0, s0=-np.inf)
+    rhs = av_laplacian_operator(discr, boundaries=boundaries,
+                                cv=cv, alpha=1.0, s0=-np.inf)
     err = discr.norm(rhs, np.inf)
     assert err < tolerance
 
@@ -229,7 +230,8 @@ def test_artificial_viscosity(ctx_factory, dim, order):
         momentum=make_obj_array([soln for _ in range(dim)]),
         species_mass=make_obj_array([soln for _ in range(dim)])
     )
-    rhs = av_operator(discr, boundaries=boundaries, cv=cv, alpha=1.0, s0=-np.inf)
+    rhs = av_laplacian_operator(discr, boundaries=boundaries,
+                                cv=cv, alpha=1.0, s0=-np.inf)
     err = discr.norm(rhs, np.inf)
     assert err < tolerance
 
@@ -242,6 +244,7 @@ def test_artificial_viscosity(ctx_factory, dim, order):
         momentum=make_obj_array([soln for _ in range(dim)]),
         species_mass=make_obj_array([soln for _ in range(dim)])
     )
-    rhs = av_operator(discr, boundaries=boundaries, cv=cv, alpha=1.0, s0=-np.inf)
+    rhs = av_laplacian_operator(discr, boundaries=boundaries,
+                                cv=cv, alpha=1.0, s0=-np.inf)
     err = discr.norm(2.*dim-rhs, np.inf)
     assert err < tolerance

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -38,7 +38,6 @@ from grudge.eager import (
     EagerDGDiscretization,
     interior_trace_pair
 )
-from mirgecom.fluid import make_conserved
 from grudge.trace_pair import TracePair
 from meshmode.array_context import (  # noqa
     pytest_generate_tests_for_pyopencl_array_context

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -134,7 +134,11 @@ def test_lazy_op_divergence(op_test_data, order):
     discr = get_discr(order)
 
     from grudge.trace_pair import interior_trace_pair
+    from grudge.dof_desc import as_dofdesc
     from mirgecom.operators import div_operator
+
+    dd_vol = as_dofdesc("vol")
+    dd_faces = as_dofdesc("all_faces")
 
     def get_flux(u_tpair):
         dd = u_tpair.dd
@@ -144,7 +148,8 @@ def test_lazy_op_divergence(op_test_data, order):
         return discr.project(dd, dd_allfaces, flux)
 
     def op(u):
-        return div_operator(discr, u, get_flux(interior_trace_pair(discr, u)))
+        return div_operator(discr, dd_vol, dd_faces,
+                            u, get_flux(interior_trace_pair(discr, u)))
 
     lazy_op = lazy_actx.compile(op)
 

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -236,14 +236,14 @@ def test_grad_operator(actx_factory, dim, order, sym_test_func_factory):
                                          test_data_int_tpair, boundaries)
 
         from mirgecom.operators import grad_operator
-        if isinstance(test_data, ConservedVars):
-            test_grad = make_conserved(
-                dim=dim, q=grad_operator(discr, test_data.join(),
-                                         test_data_flux_bnd.join())
-                )
+        from grudge.dof_desc import as_dofdesc
+        dd_vol = as_dofdesc("vol")
+        dd_faces = as_dofdesc("all_faces")
+        test_grad = grad_operator(discr, dd_vol, dd_faces,
+                                  test_data, test_data_flux_bnd)
+        if isinstance(test_grad, ConservedVars):
             grad_err = inf_norm((test_grad - exact_grad).join())/err_scale
         else:
-            test_grad = grad_operator(discr, test_data, test_data_flux_bnd)
             grad_err = inf_norm(test_grad - exact_grad)/err_scale
 
         print(f"{test_grad=}")

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -211,8 +211,10 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         cv_flux_bnd = _elbnd_flux(discr, cv_flux_interior, cv_flux_boundary,
                                   cv_int_tpair, boundaries)
         from mirgecom.operators import grad_operator
-        grad_cv = make_conserved(dim, q=grad_operator(discr, cv.join(),
-                                                      cv_flux_bnd.join()))
+        from grudge.dof_desc import as_dofdesc
+        dd_vol = as_dofdesc("vol")
+        dd_faces = as_dofdesc("all_faces")
+        grad_cv = grad_operator(discr, dd_vol, dd_faces, cv, cv_flux_bnd)
 
         xp_grad_cv = initializer.exact_grad(x_vec=nodes, eos=eos, cv_exact=cv)
         xp_grad_v = 1/cv.mass * xp_grad_cv.momentum


### PR DESCRIPTION
This PR add overintegration support for the main production branches (based on the new state-handling). In the process of adding overintegration to the AV and NS operators, I also did some rewriting to (hopefully) make it a bit easier to follow.

Update: since we plan to eventually add a NS-style artificial viscosity operator, I've taken this opportunity to rename `av_operator` to `av_laplacian_operator`. There is a backwards compact interface as well: https://github.com/illinois-ceesd/mirgecom/pull/570/commits/af8cccf7b088861649e02ded5623aded32dcb2aa

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
