### PR TITLE
Force source build for mpi4py during CI

### DIFF
--- a/.ci-support/install.sh
+++ b/.ci-support/install.sh
@@ -26,5 +26,11 @@ rm -rf $MINIFORGE_INSTALL_DIR/envs/testing/x86_64-conda-linux-gnu/sysroot
 
 MINIFORGE_INSTALL_DIR=.miniforge3
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+
+# mpi4py seems to ship with outdated cython files, this forces a source build
+# https://stackoverflow.com/a/65696724
+pip install cython
+pip install --global-option build --global-option --force mpi4py
+
 pip install -r requirements.txt
 python setup.py install

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -18,7 +18,11 @@ dependencies:
 - pyopencl
 - pymetis
 - python=3.9
+
+# https://github.com/pypa/setuptools/issues/2969
+- setuptools!=60.1.0
 - pip
+
 - pytest
 - cantera
 - h5py * nompi_*  # Make sure cantera does not pull in MPI through h5py


### PR DESCRIPTION
CI is currently broken, with lots of mpi4py build failures that, potentially, are due to outdated generated Cython code. This forces a source build for mpi4py. This may be necessary in a number of other code paths, including emirge.

cc @matthiasdiener 

See https://stackoverflow.com/a/65696724 for context.