### PR TITLE
Drop Vtk from conda-env

### DIFF
--- a/.ci-support/merge-install-production-branch.sh
+++ b/.ci-support/merge-install-production-branch.sh
@@ -12,31 +12,67 @@ set -x
 #
 # PRODUCTION_BRANCH = The production branch (default=production)
 # PRODUCTION_FORK = The production fork (default=illinois-ceesd)
-#
+
 MIRGE_HOME=${1:-"."}
-
-PRODUCTION_BRANCH=${PRODUCTION_BRANCH:-"production"}
-PRODUCTION_FORK=${PRODUCTION_FORK:-"illinois-ceesd"}
-
 echo "MIRGE_HOME=${MIRGE_HOME}"
+
+if [[ "$GITHUB_HEAD_REF" == "$PRODUCTION_PR_MAIN_BRANCH" ]]; then
+  # GITHUB_HEAD_REF is only set for PR builds.
+  # https://docs.github.com/en/actions/learn-github-actions/environment-variables
+  PRODUCTION_BRANCH="production-merge/${PRODUCTION_PR_MAIN_BRANCH}"
+  PRODUCTION_FORK=${PRODUCTION_PR_FORK:-"illinois-ceesd"}
+else
+  PRODUCTION_BRANCH="${PRODUCTION_BRANCH:-"production"}"
+  PRODUCTION_FORK=${PRODUCTION_FORK:-"illinois-ceesd"}
+fi
+
+
 echo "PRODUCTION_FORK=$PRODUCTION_FORK"
 echo "PRODUCTION_BRANCH=$PRODUCTION_BRANCH"
 
 cd "${MIRGE_HOME}" || exit 1
 git status
 
+# $CI is set by Github Actions
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables
 if [[ "$CI" == "true" ]]; then
   # This is needed in order for git to create a merge commit
   git config user.email "ci-runner@ci.machine.com"
   git config user.name "CI Runner"
 fi
 
-# Making a dedicated production remote adds production forks
-git remote add production "https://github.com/${PRODUCTION_FORK}/mirgecom"
-git fetch production
+git fetch -f \
+        "https://github.com/${PRODUCTION_FORK}/mirgecom.git" \
+        "$PRODUCTION_BRANCH":ci-prod-test
 
-# Merge the production branch for testing the production drivers
-git merge "production/${PRODUCTION_BRANCH}" --no-edit
+git fetch -f \
+        "https://github.com/illinois-ceesd/mirgecom.git" \
+        production:ci-prod-upstream
+
+if ! git merge ci-prod-test --no-edit; then
+  echo "*** The branch of this CI run failed to merge with"
+  echo "*** the current production-targeted branch:"
+  echo "*** ${PRODUCTION_BRANCH}"
+  if [[ "$PRODUCTION_BRANCH" == "production" && -n "$GITHUB_HEAD_REF" ]]; then
+    echo "*** You must create a branch off of '$GITHUB_HEAD_REF'"
+    echo "*** that is up-to-date with respect to the 'production' branch in the main"
+    echo "*** mirgecom repo and make it known to the CI in"
+    echo "*** .ci-support/production-testing-env.sh. See the comments there."
+  else
+    echo "*** You must update this branch to be up-to-date with"
+    echo "*** respect to the branch of this test run."
+  fi
+  exit 1
+fi
+
+if ! git merge ci-prod-upstream --no-edit; then
+  echo "*** The current mirgecom branch failed to merge with"
+  echo "*** mirgecom's current production branch."
+  echo "*** You must update this branch to be up-to-date with"
+  echo "*** respect to 'production' in the main mirgecom repository."
+  exit 1
+fi
+
 # Pick up any requirements.txt
 pip install -r requirements.txt
 cd - || exit 1

--- a/.ci-support/merge-install-production-branch.sh
+++ b/.ci-support/merge-install-production-branch.sh
@@ -14,6 +14,7 @@ set -x
 # PRODUCTION_FORK = The production fork (default=illinois-ceesd)
 #
 MIRGE_HOME=${1:-"."}
+
 PRODUCTION_BRANCH=${PRODUCTION_BRANCH:-"production"}
 PRODUCTION_FORK=${PRODUCTION_FORK:-"illinois-ceesd"}
 
@@ -21,19 +22,21 @@ echo "MIRGE_HOME=${MIRGE_HOME}"
 echo "PRODUCTION_FORK=$PRODUCTION_FORK"
 echo "PRODUCTION_BRANCH=$PRODUCTION_BRANCH"
 
-cd ${MIRGE_HOME}
+cd "${MIRGE_HOME}" || exit 1
 git status
 
-# This junk is needed to be able to execute git commands properly
-git config user.email "ci-runner@ci.machine.com"
-git config user.name "CI Runner"
+if [[ "$CI" == "true" ]]; then
+  # This is needed in order for git to create a merge commit
+  git config user.email "ci-runner@ci.machine.com"
+  git config user.name "CI Runner"
+fi
 
 # Making a dedicated production remote adds production forks
-git remote add production https://github.com/${PRODUCTION_FORK}/mirgecom
+git remote add production "https://github.com/${PRODUCTION_FORK}/mirgecom"
 git fetch production
 
 # Merge the production branch for testing the production drivers
-git merge production/${PRODUCTION_BRANCH} --no-edit
+git merge "production/${PRODUCTION_BRANCH}" --no-edit
 # Pick up any requirements.txt
 pip install -r requirements.txt
-cd -
+cd - || exit 1

--- a/.ci-support/production-testing-env.sh
+++ b/.ci-support/production-testing-env.sh
@@ -1,22 +1,37 @@
 #!/bin/bash
 set -x
+
+# Set this to the mirgecom branch you intend to land in main.  Overwrite
+# whatever value is already here. This branch may live in the main repo or your
+# personal fork, it does not matter.  If what is here does not match the branch
+# name on which you are currently working, then none of this will have any
+# effect.  As a consequence, this change will automatically deactivate itself
+# once merged to main. The production branch must then manually be updated to
+# track the PR production branch.
 #
-# This script is designed to help customize the production environment
-# under which CEESD production capability is tested under a proposed change
-# to illinois-ceesd/mirgecom@main.
+# The corresponding branch intended to land in production must be
+# called "production-merge/$PRODUCTION_PR_MAIN_BRANCH". It may live in the main
+# mirgecom repo or your personal fork, see below.
 #
-# The production capability may be in a CEESD-local mirgecom branch or in a
-# fork, and is specified through the following settings:
-#
-# export PRODUCTION_BRANCH=""   # The base production branch to be installed by emirge
-# export PRODUCTION_FORK=""  # The fork/home of production changes (if any)
-#
+# This branch for production testing must be up-to-date with respect to the
+# production branch in the main mirgecom repo as well as the PR branch. It will
+# only be considered for production testing if the CI is currently testing a
+# branch named $PRODUCTION_PR_MAIN_BRANCH, i.e.
+
+export PRODUCTION_PR_MAIN_BRANCH=drop-vtk-from-env
+
+# If your production branch lives in your personal mirgecom fork,
+# set this to your Github user name. Otherwise, set this to an empty
+# value.
+
+export PRODUCTION_PR_FORK=
+
 # Multiple production drivers are supported. The user should provide a ':'-delimited
 # list of driver locations, where each driver location is of the form:
-# "fork/repo@branch". The defaults are provided below as an example. Provide custom
+# "user/repo@branch". The defaults are provided below as an example. Provide custom
 # production drivers in this variable:
-#
+
 export PRODUCTION_DRIVERS="illinois-ceesd/drivers_y1-nozzle@parallel-lazy-state-handling:illinois-ceesd/drivers_flame1d@state-handling:illinois-ceesd/drivers_y2-isolator@state-handling"
-#
+
 # Example:
 # PRODUCTION_DRIVERS="illinois-ceesd/drivers_y1-nozzle@main:w-hagen/isolator@NS"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+Production changes (delete this if there are none):
+
+https://github.com/illinois-ceesd/mirgecom/compare/production...production-merge/YOURBRANCHNAME
 
 **Questions for the review**:
 - [ ] Is the scope and purpose of the PR clear?

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,7 @@ jobs:
             cd mirgecom/examples
             python -m mpi4py ./pulse-mpi.py
 
-    y1:
+    production:
         name: Production testing
         runs-on: ${{ matrix.os }}
         strategy:
@@ -173,7 +173,9 @@ jobs:
           run: |
             [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
             [[ $(uname) == Darwin ]] && brew update && brew install mpich
-            MIRGEDIR=$(pwd)
+
+            MIRGEDIR="$(pwd)"
+
             cat .ci-support/production-testing-env.sh
             . .ci-support/production-testing-env.sh
             cd ..

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,9 @@ jobs:
           run: |
             . .ci-support/install.sh
 
+            # for mirgecompare
+            conda install vtk
+
         - name: Test lazy accuracy
           run: |
             MINIFORGE_INSTALL_DIR=.miniforge3
@@ -105,7 +108,7 @@ jobs:
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             export XDG_CACHE_HOME=/tmp
             examples/run_examples.sh ./examples
- 
+
     doc:
         name: Documentation
         runs-on: ubuntu-latest
@@ -155,7 +158,7 @@ jobs:
             cd mirgecom/examples
             python -m mpi4py ./pulse-mpi.py
 
-    y1: 
+    y1:
         name: Production testing
         runs-on: ${{ matrix.os }}
         strategy:

--- a/bin/mirgecompare.py
+++ b/bin/mirgecompare.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python
+import sys
+import numpy as np
 
 
-def compare_files_vtu(first_file, second_file, file_type, tolerance = 1e-12):
-    import vtk
+class MissingVtk(Exception):
+    pass
+
+
+def compare_files_vtu(first_file, second_file, file_type, tolerance=1e-12):
+    try:
+        import vtk
+    except ImportError:
+        raise MissingVtk()
 
     # read files:
     if file_type == "vtu":
@@ -26,7 +35,13 @@ def compare_files_vtu(first_file, second_file, file_type, tolerance = 1e-12):
 
     # verify same number of PointData arrays in both files
     if point_data1.GetNumberOfArrays() != point_data2.GetNumberOfArrays():
-        print("File 1:", point_data1.GetNumberOfArrays(), "\n", "File 2:", point_data2.GetNumberOfArrays())
+        print(
+            "File 1:",
+            point_data1.GetNumberOfArrays(),
+            "\n",
+            "File 2:",
+            point_data2.GetNumberOfArrays(),
+        )
         raise ValueError("Fidelity test failed: Mismatched data array count")
 
     for i in range(point_data1.GetNumberOfArrays()):
@@ -35,36 +50,57 @@ def compare_files_vtu(first_file, second_file, file_type, tolerance = 1e-12):
 
         # verify both files contain same arrays
         if point_data1.GetArrayName(i) != point_data2.GetArrayName(i):
-            print("File 1:", point_data1.GetArrayName(i), "\n", "File 2:", point_data2.GetArrayName(i))
+            print(
+                "File 1:",
+                point_data1.GetArrayName(i),
+                "\n",
+                "File 2:",
+                point_data2.GetArrayName(i),
+            )
             raise ValueError("Fidelity test failed: Mismatched data array names")
 
         # verify arrays are same sizes in both files
         if arr1.GetSize() != arr2.GetSize():
-            print("File 1, DataArray", i, ":", arr1.GetSize(), "\n", "File 2, DataArray", i, ":", arr2.GetSize())
+            print(
+                "File 1, DataArray",
+                i,
+                ":",
+                arr1.GetSize(),
+                "\n",
+                "File 2, DataArray",
+                i,
+                ":",
+                arr2.GetSize(),
+            )
             raise ValueError("Fidelity test failed: Mismatched data array sizes")
 
         # verify individual values w/in given tolerance
         for j in range(arr1.GetSize()):
-            if abs(arr1.GetValue(j) - arr2.GetValue(j)) > tolerance: 
+            if abs(arr1.GetValue(j) - arr2.GetValue(j)) > tolerance:
                 print("Tolerance:", tolerance)
-                raise ValueError("Fidelity test failed: Mismatched data array values with given tolerance")
+                raise ValueError(
+                    "Fidelity test failed: Mismatched data array "
+                    "values with given tolerance"
+                )
 
     print("VTU Fidelity test completed successfully with tolerance", tolerance)
 
-class Hdf5Reader():
+
+class Hdf5Reader:
     def __init__(self, filename):
         import h5py
 
-        self.file_obj = h5py.File(filename, 'r')
-    
+        self.file_obj = h5py.File(filename, "r")
+
     def read_specific_data(self, datapath):
         return self.file_obj[datapath]
 
-class XdmfReader():
+
+class XdmfReader:
     # CURRENTLY DOES NOT SUPPORT MULTIPLE Grids
 
-    def __init__(self, filename): 
-        import xml.etree.ElementTree as ET
+    def __init__(self, filename):
+        import xml.etree.ElementTree as ET  # noqa: N817
 
         tree = ET.parse(filename)
         root = tree.getroot()
@@ -81,8 +117,8 @@ class XdmfReader():
             if a.tag == "Topology":
                 connectivity = a
 
-        if connectivity == None:
-            raise ValueError("File is missing grid connectivity data") 
+        if connectivity is None:
+            raise ValueError("File is missing grid connectivity data")
 
         return connectivity
 
@@ -92,19 +128,19 @@ class XdmfReader():
         for a in self.uniform_grid:
             if a.tag == "Geometry":
                 geometry = a
-        
-        if geometry == None:
-            raise ValueError("File is missing grid node location data") 
+
+        if geometry is None:
+            raise ValueError("File is missing grid node location data")
 
         return geometry
-            
+
     def read_data_item(self, data_item):
         # CURRENTLY DOES NOT SUPPORT 'DataItem' THAT STORES VALUES DIRECTLY
 
         # check that data stored as separate hdf5 file
         if data_item.get("Format") != "HDF":
             raise TypeError("Data stored in unrecognized format")
-        
+
         # get corresponding hdf5 file
         source_info = data_item.text
         split_source_info = source_info.partition(":")
@@ -118,32 +154,47 @@ class XdmfReader():
         h5_reader = Hdf5Reader(h5_filename)
         return h5_reader.read_specific_data(h5_datapath)
 
-import numpy as np
 
-def compare_files_xdmf(first_file, second_file, tolerance = 1e-12):
+def compare_files_xdmf(first_file, second_file, tolerance=1e-12):
     # read files
     file_reader1 = XdmfReader(first_file)
     file_reader2 = XdmfReader(second_file)
 
     # check same number of grids
     if len(file_reader1.grids) != len(file_reader2.grids):
-        print("File 1:", len(file_reader1.grids), "\n", "File 2:", len(file_reader2.grids))
+        print(
+            "File 1:", len(file_reader1.grids), "\n",
+            "File 2:", len(file_reader2.grids)
+        )
         raise ValueError("Fidelity test failed: Mismatched grid count")
-    
+
     # check same number of cells in grid
     if len(file_reader1.uniform_grid) != len(file_reader2.uniform_grid):
-        print("File 1:", len(file_reader1.uniform_grid), "\n", "File 2:", len(file_reader2.uniform_grid))
-        raise ValueError("Fidelity test failed: Mismatched cell count in uniform grid")
+        print(
+            "File 1:",
+            len(file_reader1.uniform_grid),
+            "\n",
+            "File 2:",
+            len(file_reader2.uniform_grid),
+        )
+        raise ValueError(
+            "Fidelity test failed: Mismatched cell count in uniform grid")
 
-    # compare Topology: 
+    # compare Topology:
     top1 = file_reader1.get_topology()
     top2 = file_reader2.get_topology()
 
     # check TopologyType
     if top1.get("TopologyType") != top2.get("TopologyType"):
-        print("File 1:", top1.get("TopologyType"), "\n", "File 2:", top2.get("TopologyType"))
+        print(
+            "File 1:",
+            top1.get("TopologyType"),
+            "\n",
+            "File 2:",
+            top2.get("TopologyType"),
+        )
         raise ValueError("Fidelity test failed: Mismatched topology type")
-    
+
     # check number of connectivity values
     connectivities1 = file_reader1.read_data_item(tuple(top1)[0])
     connectivities2 = file_reader2.read_data_item(tuple(top2)[0])
@@ -152,12 +203,16 @@ def compare_files_xdmf(first_file, second_file, tolerance = 1e-12):
     connectivities2 = np.array(connectivities2)
 
     if connectivities1.shape != connectivities2.shape:
-        print("File 1:", connectivities1.shape, "\n", "File 2:", connectivities2.shape)
+        print("File 1:", connectivities1.shape, "\n",
+                "File 2:", connectivities2.shape)
         raise ValueError("Fidelity test failed: Mismatched connectivities count")
-    
-    if not np.allclose(connectivities1, connectivities2, atol = tolerance):
+
+    if not np.allclose(connectivities1, connectivities2, atol=tolerance):
         print("Tolerance:", tolerance)
-        raise ValueError("Fidelity test failed: Mismatched connectivity values with given tolerance")
+        raise ValueError(
+            "Fidelity test failed: "
+            "Mismatched connectivity values with given tolerance"
+        )
 
     # compare Geometry:
     geo1 = file_reader1.get_geometry()
@@ -165,7 +220,13 @@ def compare_files_xdmf(first_file, second_file, tolerance = 1e-12):
 
     # check GeometryType
     if geo1.get("GeometryType") != geo2.get("GeometryType"):
-        print("File 1:", geo1.get("GeometryType"), "\n", "File 2:", geo2.get("GeometryType"))
+        print(
+            "File 1:",
+            geo1.get("GeometryType"),
+            "\n",
+            "File 2:",
+            geo2.get("GeometryType"),
+        )
         raise ValueError("Fidelity test failed: Mismatched geometry type")
 
     # check number of node values
@@ -178,10 +239,12 @@ def compare_files_xdmf(first_file, second_file, tolerance = 1e-12):
     if nodes1.shape != nodes2.shape:
         print("File 1:", nodes1.shape, "\n", "File 2:", nodes2.shape)
         raise ValueError("Fidelity test failed: Mismatched nodes count")
-    
-    if not np.allclose(nodes1, nodes2, atol = tolerance):
+
+    if not np.allclose(nodes1, nodes2, atol=tolerance):
         print("Tolerance:", tolerance)
-        raise ValueError("Fidelity test failed: Mismatched node values with given tolerance")
+        raise ValueError(
+            "Fidelity test failed: Mismatched node values with given tolerance"
+        )
 
     # compare other Attributes:
     for i in range(len(file_reader1.uniform_grid)):
@@ -194,12 +257,24 @@ def compare_files_xdmf(first_file, second_file, tolerance = 1e-12):
 
         # check AttributeType
         if curr_cell1.get("AttributeType") != curr_cell2.get("AttributeType"):
-            print("File 1:", curr_cell1.get("AttributeType"), "\n", "File 2:", curr_cell2.get("AttributeType"))
+            print(
+                "File 1:",
+                curr_cell1.get("AttributeType"),
+                "\n",
+                "File 2:",
+                curr_cell2.get("AttributeType"),
+            )
             raise ValueError("Fidelity test failed: Mismatched cell type")
 
         # check Attribtue name
         if curr_cell1.get("Name") != curr_cell2.get("Name"):
-            print("File 1:", curr_cell1.get("Name"), "\n", "File 2:", curr_cell2.get("Name"))
+            print(
+                "File 1:",
+                curr_cell1.get("Name"),
+                "\n",
+                "File 2:",
+                curr_cell2.get("Name"),
+            )
             raise ValueError("Fidelity test failed: Mismatched cell name")
 
         # check number of Attribute values
@@ -207,25 +282,39 @@ def compare_files_xdmf(first_file, second_file, tolerance = 1e-12):
         values2 = file_reader2.read_data_item(tuple(curr_cell2)[0])
 
         if len(values1) != len(values2):
-            print("File 1,", curr_cell1.get("Name"), ":", len(values1), "\n", "File 2,", curr_cell2.get("Name"), ":", len(values2))
+            print(
+                "File 1,",
+                curr_cell1.get("Name"),
+                ":",
+                len(values1),
+                "\n",
+                "File 2,",
+                curr_cell2.get("Name"),
+                ":",
+                len(values2),
+            )
             raise ValueError("Fidelity test failed: Mismatched data values count")
 
         # check values w/in tolerance
         for i in range(len(values1)):
             if abs(values1[i] - values2[i]) > tolerance:
                 print("Tolerance:", tolerance, "\n", "Cell:", curr_cell1.get("Name"))
-                raise ValueError("Fidelity test failed: Mismatched data values with given tolerance")
+                raise ValueError(
+                    "Fidelity test failed: "
+                    "Mismatched data values with given tolerance"
+                )
 
     print("XDMF Fidelity test completed successfully with tolerance", tolerance)
 
-def compare_files_hdf5(first_file, second_file, tolerance = 1e-12):
+
+def compare_files_hdf5(first_file, second_file, tolerance=1e-12):
     file_reader1 = Hdf5Reader(first_file)
     file_reader2 = Hdf5Reader(second_file)
 
     f1 = file_reader1.file_obj
     f2 = file_reader2.file_obj
 
-    objects1 = list(f1.keys()) 
+    objects1 = list(f1.keys())
     objects2 = list(f2.keys())
 
     # check number of Grids
@@ -235,23 +324,33 @@ def compare_files_hdf5(first_file, second_file, tolerance = 1e-12):
 
     # loop through Grids
     for i in range(len(objects1)):
-        obj_name1 = objects1[i] 
+        obj_name1 = objects1[i]
         obj_name2 = objects2[i]
 
         if obj_name1 != obj_name2:
             print("File 1:", obj_name1, "\n", "File 2:", obj_name2)
             raise ValueError("Fidelity test failed: Mismatched grid names")
 
-        curr_o1 = list(f1[obj_name1]) 
+        curr_o1 = list(f1[obj_name1])
         curr_o2 = list(f2[obj_name2])
 
         if len(curr_o1) != len(curr_o2):
-            print("File 1,", obj_name1, ":", len(curr_o1), "\n", "File 2,", obj_name2, ":", len(curr_o2))
+            print(
+                "File 1,",
+                obj_name1,
+                ":",
+                len(curr_o1),
+                "\n",
+                "File 2,",
+                obj_name2,
+                ":",
+                len(curr_o2),
+            )
             raise ValueError("Fidelity test failed: Mismatched group count")
 
         # loop through Groups
         for j in range(len(curr_o1)):
-            subobj_name1 = curr_o1[j] 
+            subobj_name1 = curr_o1[j]
             subobj_name2 = curr_o2[j]
 
             if subobj_name1 != subobj_name2:
@@ -265,17 +364,28 @@ def compare_files_hdf5(first_file, second_file, tolerance = 1e-12):
             data_arrays_list2 = list(f2[subpath2])
 
             if len(data_arrays_list1) != len(data_arrays_list2):
-                print("File 1,", subobj_name1, ":", len(data_arrays_list1), "\n", "File 2,", subobj_name2, ":", len(data_arrays_list2))
+                print(
+                    "File 1,",
+                    subobj_name1,
+                    ":",
+                    len(data_arrays_list1),
+                    "\n",
+                    "File 2,",
+                    subobj_name2,
+                    ":",
+                    len(data_arrays_list2),
+                )
                 raise ValueError("Fidelity test failed: Mismatched data list count")
 
             # loop through data arrays
             for k in range(len(data_arrays_list1)):
-                curr_listname1 = data_arrays_list1[k] 
+                curr_listname1 = data_arrays_list1[k]
                 curr_listname2 = data_arrays_list2[k]
 
                 if curr_listname1 != curr_listname2:
                     print("File 1:", curr_listname1, "\n", "File 2:", curr_listname2)
-                    raise ValueError("Fidelity test failed: Mismatched data list names")
+                    raise ValueError(
+                        "Fidelity test failed: Mismatched data list names")
 
                 curr_listname1 = subpath1 + "/" + curr_listname1
                 curr_listname2 = subpath2 + "/" + curr_listname2
@@ -284,15 +394,30 @@ def compare_files_hdf5(first_file, second_file, tolerance = 1e-12):
                 curr_datalist2 = np.array(list(f2[curr_listname2]))
 
                 if curr_datalist1.shape != curr_datalist2.shape:
-                    print("File 1,", curr_listname1, ":", curr_datalist1.shape, "\n", 
-                          "File 2,", curr_listname2, ":", curr_datalist2.shape)
-                    raise ValueError("Fidelity test failed: Mismatched data list size")
-                
-                if not np.allclose(curr_datalist1, curr_datalist2, atol = tolerance):
-                    print("Tolerance:", tolerance, "\n", "Data List:", curr_listname1)
-                    raise ValueError("Fidelity test failed: Mismatched data values with given tolerance")
+                    print(
+                        "File 1,",
+                        curr_listname1,
+                        ":",
+                        curr_datalist1.shape,
+                        "\n",
+                        "File 2,",
+                        curr_listname2,
+                        ":",
+                        curr_datalist2.shape,
+                    )
+                    raise ValueError(
+                        "Fidelity test failed: Mismatched data list size")
+
+                if not np.allclose(curr_datalist1, curr_datalist2, atol=tolerance):
+                    print("Tolerance:", tolerance, "\n",
+                            "Data List:", curr_listname1)
+                    raise ValueError(
+                        "Fidelity test failed: "
+                        "Mismatched data values with given tolerance"
+                    )
 
     print("HDF5 Fidelity test completed successfully with tolerance", tolerance)
+
 
 # run fidelity check
 if __name__ == "__main__":
@@ -300,13 +425,15 @@ if __name__ == "__main__":
     import os
 
     # read in file and comparison info from command line
-    parser = argparse.ArgumentParser(description = 'Process files to perform fidelity check')
-    parser.add_argument('files', nargs = 2, type = str)
-    parser.add_argument('--tolerance', type = float)
-    args = parser.parse_args();
+    parser = argparse.ArgumentParser(
+        description="Process files to perform fidelity check"
+    )
+    parser.add_argument("files", nargs=2, type=str)
+    parser.add_argument("--tolerance", type=float)
+    args = parser.parse_args()
 
-    first_file = args.files[0]  
-    second_file = args.files[1] 
+    first_file = args.files[0]
+    second_file = args.files[1]
 
     file_split = os.path.splitext(first_file)[1]
     file_type = file_split[1:]  # remove dot
@@ -315,12 +442,20 @@ if __name__ == "__main__":
     if args.tolerance:
         user_tolerance = args.tolerance
 
-    # use appropriate comparison function for file type
-    if file_type == "vtu" or file_type == "pvtu":
-        compare_files_vtu(first_file, second_file, file_type, user_tolerance)
-    elif file_type == "xmf":
-        compare_files_xdmf(first_file, second_file, user_tolerance)
-    elif file_type == "h5":
-        compare_files_hdf5(first_file, second_file, user_tolerance)
-    else:
-        raise TypeError("File type not supported")
+    try:
+        # use appropriate comparison function for file type
+        if file_type == "vtu" or file_type == "pvtu":
+            compare_files_vtu(first_file, second_file, file_type, user_tolerance)
+        elif file_type == "xmf":
+            compare_files_xdmf(first_file, second_file, user_tolerance)
+        elif file_type == "h5":
+            compare_files_hdf5(first_file, second_file, user_tolerance)
+        else:
+            raise TypeError("File type not supported")
+    except MissingVtk:
+        print(
+            "Vtk is needed for mirgecompare but was not found. "
+            "Say 'conda install vtk' to install it.",
+            file=sys.stderr,
+        )
+        sys.exit(1)

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -22,4 +22,3 @@ dependencies:
 - pytest
 - cantera
 - h5py * nompi_*  # Make sure cantera does not pull in MPI through h5py
-- vtk

--- a/doc/development/pullrequests.rst
+++ b/doc/development/pullrequests.rst
@@ -241,7 +241,7 @@ does for executing the production tests.
       $ git switch -c branch-name-production  # Optional production branch
 
 2. Set up the production environment and capability
-   
+
    .. code:: bash
 
       $ # Load the customizable production environment
@@ -250,9 +250,10 @@ does for executing the production tests.
       $ . .ci-support/merge-install-production-branch.sh .
 
    If Step 2 fails, i.e. if there are merge conflicts, then those must
-   be resolved. Push the merged result to CEESD or a fork, and indicate
-   that version in the PRODUCTION_FORK, and PRODUCTION_BRANCH env vars in
-   ``.ci-support/production-testing-env.sh``.
+   be resolved. Push the merged result to the main mirgecom repo or a fork,
+   and indicate that version via ``PRODUCTION_PR_MAIN_BRANCH`` and ``PRODUCTION_PR_FORK``
+   in ``.ci-support/production-testing-env.sh``. See the comments there. Note
+   that the branch must be called ``production-merge/base_branch``.
 
 3. Grab and run the production tests
 
@@ -283,14 +284,7 @@ If the PR development requires production environment customization in order to
 pass production tests, then care and coordination will be required to get these
 changes merged into the main mirgecom development.  PR reviewers will help
 with this process.  If the PR is accepted for merging to main, then mirgecom
-developers will update the production capabilities to be compatible with
-the changes before merging.
-
- .. important::
-
-    Any production environment customizations must be backed out before
-    merging the PR development to main. Never merge a PR development with
-    production environment customizations in-place.
+developers will update the production branch to track your proposed one.
 
 Merging a pull request
 ----------------------

--- a/examples/compare_lazy_solution.sh
+++ b/examples/compare_lazy_solution.sh
@@ -28,6 +28,6 @@ python ${MPIARGS} ${SIM} --casename ${casename_base}-eager
 python ${MPIARGS} ${SIM} --casename ${casename_base}-lazy --lazy
 for vizfile in $(ls ${casename_base}-eager-*.vtu)
 do
-    lazy_vizfile=$(echo ${vizfile/eager/lazy}) 
+    lazy_vizfile=$(echo ${vizfile/eager/lazy})
     python ${BINDIR}/mirgecompare.py ${TOL} ${vizfile} ${lazy_vizfile}
 done


### PR DESCRIPTION
Vtk pulls in a lot of heavyweight dependencies. Its only purpose at this point seems to be to enable `mirgecompare`, but that doesn't justify a few extra gigabytes and a few extra minutes of install time, at least to me.

@matthiasdiener How do you feel about that? `mirgecompare` could simply have instructions to `conda install vtk` if the relevant packages are missing. Happy to add that if you agree.

Production changes to be merged alongside this:

https://github.com/illinois-ceesd/mirgecom/compare/production...production-merge/drop-vtk-from-env