### PR TITLE
Remove stray space in PR docs

### DIFF
--- a/doc/development/pullrequests.rst
+++ b/doc/development/pullrequests.rst
@@ -286,7 +286,7 @@ with this process.  If the PR is accepted for merging to main, then mirgecom
 developers will update the production capabilities to be compatible with
 the changes before merging.
 
- .. important::
+.. important::
 
     Any production environment customizations must be backed out before
     merging the PR development to main. Never merge a PR development with


### PR DESCRIPTION
The additional space caused the `.. important` to be rendered inside a blockquote, which made it render oddly.