### PR TITLE
Factor control of limiting up into the sim driver

### DIFF
--- a/doc/operators/limiters.rst
+++ b/doc/operators/limiters.rst
@@ -1,0 +1,4 @@
+Limiters
+========
+
+.. automodule:: mirgecom.limiter

--- a/doc/operators/operators.rst
+++ b/doc/operators/operators.rst
@@ -8,3 +8,4 @@ Operators
    diffusion
    artificial_viscosity
    gas-dynamics
+   limiters

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -563,8 +563,10 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     def my_limiter(cv):
         return \
-            cv.replace(species_mass=limiter_liu_osher(discr,
-                                                      cv.species_mass))
+            cv.replace(
+                species_mass=cv.mass*limiter_liu_osher(discr,
+                                                       cv.species_mass_fractions)
+            )
 
     def my_rhs(t, state):
         cv, tseed = state

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -559,11 +559,17 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         return make_obj_array([cv, fluid_state.temperature]), dt
 
     from mirgecom.inviscid import inviscid_flux_rusanov
+    from mirgecom.limiter import limiter_liu_osher
+
+    def my_limiter(cv):
+        return \
+            cv.replace(species_mass=limiter_liu_osher(discr,
+                                                      cv.species_mass))
 
     def my_rhs(t, state):
         cv, tseed = state
         from mirgecom.gas_model import make_fluid_state
-        fluid_state = make_fluid_state(cv=cv, gas_model=gas_model,
+        fluid_state = make_fluid_state(cv=my_limiter(cv), gas_model=gas_model,
                                        temperature_seed=tseed)
         return make_obj_array([
             euler_operator(discr, state=fluid_state, time=t, boundaries=boundaries,

--- a/mirgecom/integrators/__init__.py
+++ b/mirgecom/integrators/__init__.py
@@ -34,9 +34,9 @@ __doc__ = """
 """
 
 
-def lsrk4_step(state, t, dt, rhs, limiter=None):
+def lsrk4_step(state, t, dt, rhs):
     """Call lsrk54_step with backwards-compatible interface."""
     from warnings import warn
     warn("Do not call lsrk4; it is now callled lsrk54_step. This function will "
          "disappear August 1, 2021", DeprecationWarning, stacklevel=2)
-    return lsrk54_step(state, t, dt, rhs, limiter=limiter)
+    return lsrk54_step(state, t, dt, rhs)

--- a/mirgecom/integrators/explicit_rk.py
+++ b/mirgecom/integrators/explicit_rk.py
@@ -28,7 +28,7 @@ THE SOFTWARE.
 """
 
 
-def rk4_step(state, t, dt, rhs, limiter=None):
+def rk4_step(state, t, dt, rhs):
     """Take one step using the fourth-order Classical Runge-Kutta method."""
     k1 = rhs(t, state)
     k2 = rhs(t+dt/2, state + dt/2*k1)

--- a/mirgecom/integrators/lsrk.py
+++ b/mirgecom/integrators/lsrk.py
@@ -46,7 +46,7 @@ class LSRKCoefficients:
     C: np.ndarray
 
 
-def lsrk_step(coefs, state, t, dt, rhs, limiter=None):
+def lsrk_step(coefs, state, t, dt, rhs):
     """Take one step using a low-storage Runge-Kutta method."""
     k = 0.0 * state
     for i in range(len(coefs.A)):
@@ -61,9 +61,9 @@ EulerCoefs = LSRKCoefficients(
     C=np.array([0.]))
 
 
-def euler_step(state, t, dt, rhs, limiter=None):
+def euler_step(state, t, dt, rhs):
     """Take one step using the explicit, 1st-order accurate, Euler method."""
-    return lsrk_step(EulerCoefs, state, t, dt, rhs, limiter=limiter)
+    return lsrk_step(EulerCoefs, state, t, dt, rhs)
 
 
 LSRK54CarpenterKennedyCoefs = LSRKCoefficients(
@@ -87,13 +87,13 @@ LSRK54CarpenterKennedyCoefs = LSRKCoefficients(
         2802321613138/2924317926251]))
 
 
-def lsrk54_step(state, t, dt, rhs, limiter=None):
+def lsrk54_step(state, t, dt, rhs):
     """Take one step using an explicit 5-stage, 4th-order, LSRK method.
 
     Coefficients are summarized in [Hesthaven_2008]_, Section 3.4.
     """
     return lsrk_step(
-        LSRK54CarpenterKennedyCoefs, state, t, dt, rhs, limiter=limiter)
+        LSRK54CarpenterKennedyCoefs, state, t, dt, rhs)
 
 
 LSRK144NiegemannDiehlBuschCoefs = LSRKCoefficients(
@@ -144,7 +144,7 @@ LSRK144NiegemannDiehlBuschCoefs = LSRKCoefficients(
         0.8734213127600976]))
 
 
-def lsrk144_step(state, t, dt, rhs, limiter=None):
+def lsrk144_step(state, t, dt, rhs):
     """Take one step using an explicit 14-stage, 4th-order, LSRK method.
 
     This method is derived by Niegemann, Diehl, and Busch (2012), with
@@ -152,4 +152,4 @@ def lsrk144_step(state, t, dt, rhs, limiter=None):
     LSRK coefficients are summarized in [Niegemann_2012]_, Table 3.
     """
     return lsrk_step(
-        LSRK144NiegemannDiehlBuschCoefs, state, t, dt, rhs, limiter=limiter)
+        LSRK144NiegemannDiehlBuschCoefs, state, t, dt, rhs)

--- a/mirgecom/integrators/ssprk.py
+++ b/mirgecom/integrators/ssprk.py
@@ -27,30 +27,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from arraycontext import thaw, freeze
 
-
-def ssprk43_step(state, t, dt, rhs, limiter=None):
+def ssprk43_step(state, t, dt, rhs):
     """Take one step using an explicit 4-stage, 3rd-order, SSPRK method."""
-    actx = state.array_context
 
     def rhs_update(t, y):
         return y + dt*rhs(t, y)
 
     y1 = 1/2*state + 1/2*rhs_update(t, state)
-    if limiter is not None:
-        y1 = thaw(freeze(limiter(y1), actx), actx)
-
     y2 = 1/2*y1 + 1/2*rhs_update(t + dt/2, y1)
-    if limiter is not None:
-        y2 = thaw(freeze(limiter(y2), actx), actx)
-
     y3 = 2/3*state + 1/6*y2 + 1/6*rhs_update(t + dt, y2)
-    if limiter is not None:
-        y3 = thaw(freeze(limiter(y3), actx), actx)
-
-    result = 1/2*y3 + 1/2*rhs_update(t + dt/2, y3)
-    if limiter is not None:
-        result = thaw(freeze(limiter(result), actx), actx)
-
-    return result
+    return 1/2*y3 + 1/2*rhs_update(t + dt/2, y3)

--- a/mirgecom/limiter.py
+++ b/mirgecom/limiter.py
@@ -1,4 +1,10 @@
 """:mod:`mirgecom.limiter` is for limiters and limiter-related constructs.
+
+Field limiter functions
+-----------------------
+
+.. autofunction:: limiter_liu_osher
+
 """
 
 __copyright__ = """
@@ -25,23 +31,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from functools import partial
+
 from arraycontext import map_array_container
-
 from meshmode.dof_array import DOFArray
-
 from grudge.discretization import DiscretizationCollection
-
-from mirgecom.fluid import ConservedVars
-
 import grudge.op as op
 
 
-def limiter_liu_osher(dcoll: DiscretizationCollection, state):    
-    """Implements the positivity-preserving limiter of Liu and Osher (1996).
+def limiter_liu_osher(dcoll: DiscretizationCollection, field):
+    """Implement the positivity-preserving limiter of Liu and Osher (1996).
 
     The limiter is summarized in the review paper [Zhang_2011]_, Section 2.3,
     equation 2.9, which uses a linear scaling factor.
-    
+
     .. note:
         This limiter is applied only to mass fields
         (e.g. mass or species masses for multi-component flows)
@@ -50,49 +53,43 @@ def limiter_liu_osher(dcoll: DiscretizationCollection, state):
     ----------
     dcoll: :class:`grudge.discretization.DiscretizationCollection`
         Grudge discretization with boundaries object
-    state: :class:`mirgecom.fluid.ConservedVars`
-        An array container containing the conserved variables.
+    field: meshmode.dof_array.DOFArray or numpy.ndarray
+        A field or collection of scalar fields to limit
 
     Returns
     -------
-    result: :class:`mirgecom.fluid.ConservedVars`
-        An array container containing the filtered field(s).
+    meshmode.dof_array.DOFArray or numpy.ndarray
+        An array container containing the limited field(s).
     """
     from grudge.geometry import area_element
 
-    actx = state.array_context
+    pick_apart = partial(limiter_liu_osher, dcoll)
 
-    def compute_limited_field(field):
-        if not isinstance(field, DOFArray):
-            # vecs is not a DOFArray -> treat as array container
-            return map_array_container(compute_limited_field, field)
+    if not isinstance(field, DOFArray):
+        # vecs is not a DOFArray -> treat as array container
+        return map_array_container(pick_apart, field)
 
-        # Compute nodal and elementwise max/mins of the field
-        _mmax = op.nodal_max(dcoll, "banana", field)
-        _mmin = op.nodal_min(dcoll, "avocado", field)
-        _mmax_i = op.elementwise_max(dcoll, field)
-        _mmin_i = op.elementwise_min(dcoll, field)
+    actx = field.array_context
+    # Compute nodal and elementwise max/mins of the field
+    _mmax = op.nodal_max(dcoll, "banana", field)
+    _mmin = op.nodal_min(dcoll, "avocado", field)
+    _mmax_i = op.elementwise_max(dcoll, field)
+    _mmin_i = op.elementwise_min(dcoll, field)
 
-        # Compute cell averages of the state
-        inv_area_elements = 1./area_element(
-            actx, dcoll,
-            _use_geoderiv_connection=actx.supports_nonscalar_broadcasting)
-        cell_avgs = \
-            inv_area_elements * op.elementwise_integral(dcoll, field)
+    # Compute cell averages of the state
+    inv_area_elements = 1./area_element(
+        actx, dcoll,
+        _use_geoderiv_connection=actx.supports_nonscalar_broadcasting)
+    cell_avgs = \
+        inv_area_elements * op.elementwise_integral(dcoll, field)
 
-        # Compute minmod factor (Eq. 2.9)
-        theta = actx.np.minimum(
-            1.,
-            actx.np.minimum(
-                abs((_mmax - cell_avgs)/(_mmax_i - cell_avgs)),
-                abs((_mmin - cell_avgs)/(_mmin_i - cell_avgs))
-            )
+    # Compute minmod factor (Eq. 2.9)
+    theta = actx.np.minimum(
+        1.,
+        actx.np.minimum(
+            abs((_mmax - cell_avgs)/(_mmax_i - cell_avgs)),
+            abs((_mmin - cell_avgs)/(_mmin_i - cell_avgs))
         )
-        return theta*(field - cell_avgs) + cell_avgs
-
-    return ConservedVars(
-        mass=compute_limited_field(state.mass),
-        energy=state.energy,
-        momentum=state.momentum,
-        species_mass=compute_limited_field(state.species_mass)
     )
+
+    return theta*(field - cell_avgs) + cell_avgs

--- a/mirgecom/steppers.py
+++ b/mirgecom/steppers.py
@@ -75,7 +75,6 @@ def _advance_state_stepper_func(rhs, timestepper,
                                 t=0.0, istep=0,
                                 pre_step_callback=None,
                                 post_step_callback=None,
-                                limiter=None,
                                 logmgr=None, eos=None, dim=None):
     """Advance state from some time (t) to some time (t_final).
 
@@ -136,7 +135,7 @@ def _advance_state_stepper_func(rhs, timestepper,
             state, dt = pre_step_callback(state=state, step=istep, t=t, dt=dt)
 
         state = timestepper(
-            state=state, t=t, dt=dt, rhs=compiled_rhs, limiter=limiter)
+            state=state, t=t, dt=dt, rhs=compiled_rhs)
 
         t += dt
         istep += 1
@@ -158,7 +157,6 @@ def _advance_state_leap(rhs, timestepper, state,
                         t=0.0, istep=0,
                         pre_step_callback=None,
                         post_step_callback=None,
-                        limiter=None,
                         logmgr=None, eos=None, dim=None):
     """Advance state from some time *t* to some time *t_final* using :mod:`leap`.
 
@@ -279,7 +277,6 @@ def advance_state(rhs, timestepper, state, t_final,
                   t=0.0, istep=0, dt=0,
                   pre_step_callback=None,
                   post_step_callback=None,
-                  limiter=None,
                   logmgr=None, eos=None, dim=None):
     """Determine what stepper we're using and advance the state from (t) to (t_final).
 
@@ -353,7 +350,7 @@ def advance_state(rhs, timestepper, state, t_final,
                 state=state, t=t, t_final=t_final, dt=dt,
                 pre_step_callback=pre_step_callback,
                 post_step_callback=post_step_callback,
-                limiter=limiter, component_id=component_id,
+                component_id=component_id,
                 istep=istep, logmgr=logmgr, eos=eos, dim=dim,
             )
     else:
@@ -363,7 +360,6 @@ def advance_state(rhs, timestepper, state, t_final,
                 state=state, t=t, t_final=t_final, dt=dt,
                 pre_step_callback=pre_step_callback,
                 post_step_callback=post_step_callback,
-                limiter=limiter,
                 istep=istep, logmgr=logmgr, eos=eos, dim=dim
             )
 


### PR DESCRIPTION
This change set is a slight refactor of the @thomasgibson 's limiter to give control of limiting and how it is applied to the user and lift it into the driver.  This also obviates support for limiting down inside the timestepping, and allows the limiter to be compiled inline with the RHS, instead of strictly eager down inside the stepper.



**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
