### PR TITLE
Revert "Work around mpi4py installation issues from setuptools vendor…

### DIFF
--- a/.ci-support/install.sh
+++ b/.ci-support/install.sh
@@ -26,10 +26,5 @@ rm -rf $MINIFORGE_INSTALL_DIR/envs/testing/x86_64-conda-linux-gnu/sysroot
 
 MINIFORGE_INSTALL_DIR=.miniforge3
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-
-# Workaround for https://github.com/mpi4py/mpi4py/issues/157
-# Revisit this by Feb 2022
-export SETUPTOOLS_USE_DISTUTILS=stdlib
-
 pip install -r requirements.txt
 python setup.py install


### PR DESCRIPTION
Revert "Work around mpi4py installation issues from setuptools vendoring distutils (#585)"

This reverts commit 6ae28905dbb9d073a9f778111d12b10e474fe799.

The underlying setuptools bug has been fixed:
https://github.com/pypa/setuptools/pull/2987

See also https://github.com/illinois-ceesd/emirge/pull/144