### PR TITLE
check_range_local: report failing values

### DIFF
--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -272,16 +272,23 @@ def allsync(local_values, comm=None, op=None):
 
 
 def check_range_local(discr, dd, field, min_value, max_value):
-    """Check for any negative values."""
+    """Return the values that are outside the range [min_value, max_value]."""
     actx = field.array_context
-    return (
-        actx.to_numpy(op.nodal_min_loc(discr, dd, field)) < min_value
-        or actx.to_numpy(op.nodal_max_loc(discr, dd, field)) > max_value
-    )
+    local_min = np.asscalar(actx.to_numpy(op.nodal_min_loc(discr, dd, field)))
+    local_max = np.asscalar(actx.to_numpy(op.nodal_max_loc(discr, dd, field)))
+
+    failing_values = []
+
+    if local_min < min_value:
+        failing_values.append(local_min)
+    if local_max > max_value:
+        failing_values.append(local_max)
+
+    return failing_values
 
 
 def check_naninf_local(discr, dd, field):
-    """Check for any NANs or Infs in the field."""
+    """Return True if there are any NaNs or Infs in the field."""
     actx = field.array_context
     s = actx.to_numpy(op.nodal_sum_loc(discr, dd, field))
     return not np.isfinite(s)

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -56,6 +56,9 @@ from functools import partial
 
 from meshmode.dof_array import DOFArray
 
+from typing import List
+from grudge.discretization import DiscretizationCollection
+
 
 logger = logging.getLogger(__name__)
 
@@ -271,7 +274,8 @@ def allsync(local_values, comm=None, op=None):
     return global_reduce(local_values, op_string, comm=comm)
 
 
-def check_range_local(discr, dd, field, min_value, max_value):
+def check_range_local(discr: DiscretizationCollection, dd: str, field: DOFArray,
+                      min_value: float, max_value: float) -> List[float]:
     """Return the values that are outside the range [min_value, max_value]."""
     actx = field.array_context
     local_min = np.asscalar(actx.to_numpy(op.nodal_min_loc(discr, dd, field)))
@@ -287,7 +291,8 @@ def check_range_local(discr, dd, field, min_value, max_value):
     return failing_values
 
 
-def check_naninf_local(discr, dd, field):
+def check_naninf_local(discr: DiscretizationCollection, dd: str,
+                       field: DOFArray) -> bool:
     """Return True if there are any NaNs or Infs in the field."""
     actx = field.array_context
     s = actx.to_numpy(op.nodal_sum_loc(discr, dd, field))


### PR DESCRIPTION
This maintains the same 'truthy' API as before, ie, returns `False` for a passing check, `True` for a failing check.
Drivers therefore don't necessarily have to be updated for this.

Driver code can use the values like this:

```python
failing_pres = global_reduce(check_range_local(discr, "vol", dv.pressure,
                                     health_pres_min, health_pres_max),
                                     op="lor")
if failing_pres:
    logger.info(f"Pressure range violation ({health_pres_min=}, {health_pres_max=}, {failing_pres=})")
```
This helps with e.g. debugging https://github.com/illinois-ceesd/drivers_y2-isolator/issues/18

---


**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
