### PR TITLE
Add option to use grudge-based pre-compiled timestep.

### DIFF
--- a/examples/combozzle-mpi.py
+++ b/examples/combozzle-mpi.py
@@ -182,7 +182,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     # {{{ Some discretization parameters
 
     dim = 3
-    order = 1
+    order = 3
 
     # - scales the size of the domain
     x_scale = 1
@@ -260,7 +260,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     # coarse-scale grid/domain control
     n_refine = 1  # scales npts/axis uniformly
-    weak_scale = 1  # scales domain and npts/axis keeping dt constant
+    weak_scale = 2  # scales domain uniformly, keeping dt constant
 
     # AV / Shock-capturing parameters
     alpha_sc = 0.5
@@ -642,6 +642,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     timestepper = rk4_step
     use_local_timestepping = False
+    integrator = "compiled_lsrk45"
 
     if integrator == "euler":
         timestepper = euler_step
@@ -1026,7 +1027,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_pre_step(step, t, dt, state):
         cv, tseed = state
         fluid_state = construct_fluid_state(cv, tseed)
-        fluid_state = thaw(freeze(fluid_state, actx), actx)
+        # fluid_state = thaw(freeze(fluid_state, actx), actx)
 
         dv = fluid_state.dv
 
@@ -1197,8 +1198,8 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                     pre_step_func(state=current_state, step=istep, t=current_t,
                                       dt=current_dt)
 
-                current_state = timestepper(state=current_state, t=current_t,
-                                            dt=current_dt, rhs=compiled_rhs)
+                current_state = timestepper(current_state, current_t, current_dt,
+                                            compiled_rhs)
 
                 current_t = current_t + current_dt
                 istep = istep + 1

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -32,7 +32,7 @@ Simulation support utilities
 Lazy eval utilities
 -------------------
 
-.. autofunction:: force_eval
+.. autofunction:: force_evaluation
 """
 
 __copyright__ = """
@@ -497,6 +497,7 @@ def species_fraction_anomaly_relaxation(cv, alpha=1.):
     return 0.*cv
 
 
-def force_eval(actx, expn):
+def force_evaluation(actx, expn):
     """Convenience wrapper for forcing evaluation of expressions."""
+    from arraycontext import thaw, freeze
     return thaw(freeze(expn, actx), actx)

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -28,6 +28,11 @@ Simulation support utilities
 
 .. autofunction:: limit_species_mass_fractions
 .. autofunction:: species_fraction_anomaly_relaxation
+
+Lazy eval utilities
+-------------------
+
+.. autofunction:: force_eval
 """
 
 __copyright__ = """
@@ -490,3 +495,8 @@ def species_fraction_anomaly_relaxation(cv, alpha=1.):
                               momentum=0.*cv.momentum, energy=0.*cv.energy,
                               species_mass=alpha*cv.mass*new_y)
     return 0.*cv
+
+
+def force_eval(actx, expn):
+    """Convenience wrapper for forcing evaluation of expressions."""
+    return thaw(freeze(expn, actx), actx)

--- a/mirgecom/steppers.py
+++ b/mirgecom/steppers.py
@@ -70,7 +70,7 @@ def _force_evaluation(actx, state):
 
 def _advance_state_stepper_func(rhs, timestepper, state, t_final, dt=0,
                                 t=0.0, istep=0, pre_step_callback=None,
-                                post_step_callback=None):
+                                post_step_callback=None, force_eval=True):
     """Advance state from some time (t) to some time (t_final).
 
     Parameters
@@ -102,6 +102,9 @@ def _advance_state_stepper_func(rhs, timestepper, state, t_final, dt=0,
         An optional user-defined function, with signature:
         ``state, dt = post_step_callback(step, t, dt, state)``,
         to be called after the timestepper is called for that particular step.
+    force_eval
+        An optional boolean indicating whether to force lazy evaluation between
+        timesteps.  Defaults to True.
 
     Returns
     -------
@@ -121,10 +124,12 @@ def _advance_state_stepper_func(rhs, timestepper, state, t_final, dt=0,
     compiled_rhs = _compile_rhs(actx, rhs)
 
     while t < t_final:
-        state = _force_evaluation(actx, state)
 
         if pre_step_callback is not None:
             state, dt = pre_step_callback(state=state, step=istep, t=t, dt=dt)
+
+        if force_eval:
+            state = _force_evaluation(actx, state)
 
         state = timestepper(state=state, t=t, dt=dt, rhs=compiled_rhs)
 
@@ -139,7 +144,8 @@ def _advance_state_stepper_func(rhs, timestepper, state, t_final, dt=0,
 
 def _advance_state_leap(rhs, timestepper, state, t_final, dt=0,
                         component_id="state", t=0.0, istep=0,
-                        pre_step_callback=None, post_step_callback=None):
+                        pre_step_callback=None, post_step_callback=None,
+                        force_eval=True):
     """Advance state from some time *t* to some time *t_final* using :mod:`leap`.
 
     Parameters
@@ -190,13 +196,15 @@ def _advance_state_leap(rhs, timestepper, state, t_final, dt=0,
                                                     compiled_rhs, t, dt, state)
 
     while t < t_final:
-        state = _force_evaluation(actx, state)
 
         if pre_step_callback is not None:
             state, dt = pre_step_callback(state=state,
                                           step=istep,
                                           t=t, dt=dt)
             stepper_cls.dt = dt
+
+        if force_eval:
+            state = _force_evaluation(actx, state)
 
         # Leap interface here is *a bit* different.
         for event in stepper_cls.run(t_end=t+dt):
@@ -256,7 +264,7 @@ def generate_singlerate_leap_advancer(timestepper, component_id, rhs, t, dt,
 
 def advance_state(rhs, timestepper, state, t_final, t=0, istep=0, dt=0,
                   component_id="state", pre_step_callback=None,
-                  post_step_callback=None):
+                  post_step_callback=None, force_eval=True):
     """Determine what stepper we're using and advance the state from (t) to (t_final).
 
     Parameters
@@ -294,7 +302,9 @@ def advance_state(rhs, timestepper, state, t_final, t=0, istep=0, dt=0,
         An optional user-defined function, with signature:
         ``state, dt = post_step_callback(step, t, dt, state)``,
         to be called after the timestepper is called for that particular step.
-
+    force_eval
+        An optional boolean indicating whether to force lazy evaluation between
+        timesteps.  Defaults to True.
     Returns
     -------
     istep: int
@@ -323,7 +333,8 @@ def advance_state(rhs, timestepper, state, t_final, t=0, istep=0, dt=0,
                 state=state, t=t, t_final=t_final, dt=dt,
                 pre_step_callback=pre_step_callback,
                 post_step_callback=post_step_callback,
-                component_id=component_id, istep=istep
+                component_id=component_id, istep=istep,
+                force_eval=force_eval
             )
     else:
         (current_step, current_t, current_state) = \
@@ -332,7 +343,7 @@ def advance_state(rhs, timestepper, state, t_final, t=0, istep=0, dt=0,
                 state=state, t=t, t_final=t_final, dt=dt,
                 pre_step_callback=pre_step_callback,
                 post_step_callback=post_step_callback,
-                istep=istep
+                istep=istep, force_eval=force_eval
             )
 
     return current_step, current_t, current_state


### PR DESCRIPTION
Just testing using grudge compiled time integrator.  Not intended for merge (yet).  

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
