### PR TITLE
Fix `TracePair` imports now that `grudge.symbolic` is gone

### DIFF
--- a/test/test_flux.py
+++ b/test/test_flux.py
@@ -34,7 +34,7 @@ import pytest
 from pytools.obj_array import make_obj_array
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from meshmode.dof_array import DOFArray
-from grudge.symbolic.primitives import TracePair
+from grudge.trace_pair import TracePair
 from mirgecom.fluid import make_conserved
 from mirgecom.eos import IdealSingleGas
 from mirgecom.gas_model import (

--- a/test/test_inviscid.py
+++ b/test/test_inviscid.py
@@ -38,7 +38,7 @@ from pytools.obj_array import (
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.symbolic.primitives import TracePair
+from grudge.trace_pair import TracePair
 from mirgecom.fluid import make_conserved
 from mirgecom.eos import IdealSingleGas
 from grudge.eager import EagerDGDiscretization


### PR DESCRIPTION
https://github.com/inducer/grudge/pull/259 deleted the symbolic execution path in grudge. Since we got rid of mirgecom downstream CI in grudge (https://github.com/inducer/grudge/pull/221/files#r819008736), I had no idea about these now-stale references to the symbolic stuff in mirgecom.

This PR mops those up.