### PR TITLE
Convert examples to use op namespace

### DIFF
--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -30,7 +30,8 @@ import pyopencl.tools as cl_tools
 from functools import partial
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
+from mirgecom.discretization import create_discretization_collection
+from grudge.dof_desc import DISCR_TAG_QUAD
 from grudge.shortcuts import make_visualizer
 
 from logpyle import IntervalTimer, set_dt
@@ -168,19 +169,8 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
-    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
-    from meshmode.discretization.poly_element import \
-        default_simplex_group_factory, QuadratureSimplexGroupFactory
-
-    discr = EagerDGDiscretization(
-        actx, local_mesh,
-        discr_tag_to_group_factory={
-            DISCR_TAG_BASE: default_simplex_group_factory(
-                base_dim=local_mesh.dim, order=order),
-            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order + 1)
-        },
-        mpi_communicator=comm
-    )
+    discr = create_discretization_collection(actx, local_mesh, order=order,
+                                             mpi_communicator=comm)
     nodes = thaw(discr.nodes(), actx)
     ones = discr.zeros(actx) + 1.0
 
@@ -315,8 +305,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             temperature_seed = restart_data["temperature_seed"]
         else:
             rst_cv = restart_data["cv"]
-            old_discr = EagerDGDiscretization(actx, local_mesh, order=rst_order,
-                                              mpi_communicator=comm)
+            old_discr = \
+                create_discretization_collection(actx, local_mesh, order=rst_order,
+                                                 mpi_communicator=comm)
             from meshmode.discretization.connection import make_same_mesh_connection
             connection = make_same_mesh_connection(actx, discr.discr_from_dd("vol"),
                                                    old_discr.discr_from_dd("vol"))

--- a/examples/heat-source-mpi.py
+++ b/examples/heat-source-mpi.py
@@ -28,10 +28,10 @@ import numpy.linalg as la  # noqa
 import pyopencl as cl
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-
-from grudge.eager import EagerDGDiscretization
+import grudge.op as op
 from grudge.shortcuts import make_visualizer
 from grudge.dof_desc import DTAG_BOUNDARY
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.integrators import rk4_step
 from mirgecom.diffusion import (
     diffusion_operator,
@@ -111,7 +111,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     order = 3
 
-    discr = EagerDGDiscretization(actx, local_mesh, order=order,
+    discr = create_discretization_collection(actx, local_mesh, order=order,
                     mpi_communicator=comm)
 
     if dim == 2:
@@ -178,7 +178,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         if logmgr:
             set_dt(logmgr, dt)
             logmgr.tick_after()
-    final_answer = actx.to_numpy(discr.norm(u, np.inf))
+    final_answer = actx.to_numpy(op.norm(discr, u, np.inf))
     resid = abs(final_answer - 0.00020620711665201585)
     if resid > 1e-15:
         raise ValueError(f"Run did not produce the expected result {resid=}")

--- a/examples/hotplate-mpi.py
+++ b/examples/hotplate-mpi.py
@@ -32,10 +32,10 @@ from functools import partial
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 from grudge.dof_desc import DTAG_BOUNDARY
 
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.fluid import make_conserved
 from mirgecom.navierstokes import ns_operator
 from mirgecom.simutil import get_sim_timestep
@@ -169,7 +169,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -31,10 +31,9 @@ from functools import partial
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 
-
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     get_sim_timestep,
@@ -149,7 +148,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -31,10 +31,9 @@ from functools import partial
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 
-
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     get_sim_timestep,
@@ -149,7 +148,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)

--- a/examples/nsmix-mpi.py
+++ b/examples/nsmix-mpi.py
@@ -37,9 +37,9 @@ from meshmode.array_context import (
 from mirgecom.profiling import PyOpenCLProfilingArrayContext
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.transport import SimpleTransport
 from mirgecom.simutil import get_sim_timestep
 from mirgecom.navierstokes import ns_operator
@@ -156,7 +156,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)
@@ -310,8 +310,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     # }}}
 
-    visualizer = make_visualizer(discr, order + 3
-                                 if discr.dim == 2 else order)
+    visualizer = make_visualizer(discr, order + 3 if dim == 2 else order)
     initname = initializer.__class__.__name__
     eosname = gas_model.eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,

--- a/examples/poiseuille-mpi.py
+++ b/examples/poiseuille-mpi.py
@@ -38,10 +38,11 @@ from mirgecom.profiling import PyOpenCLProfilingArrayContext
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 from grudge.dof_desc import DTAG_BOUNDARY
+from grudge.dof_desc import DISCR_TAG_QUAD
 
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.fluid import make_conserved
 from mirgecom.navierstokes import ns_operator
 from mirgecom.simutil import get_sim_timestep
@@ -169,19 +170,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
-    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
-    from meshmode.discretization.poly_element import \
-        default_simplex_group_factory, QuadratureSimplexGroupFactory
-
     order = 2
-    discr = EagerDGDiscretization(
-        actx, local_mesh,
-        discr_tag_to_group_factory={
-            DISCR_TAG_BASE: default_simplex_group_factory(
-                base_dim=local_mesh.dim, order=order),
-            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order + 1)
-        },
-        mpi_communicator=comm
+    discr = create_discretization_collection(
+        actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)
 

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -33,9 +33,10 @@ import pyopencl.tools as cl_tools
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
+from grudge.dof_desc import DISCR_TAG_QUAD
 
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     get_sim_timestep,
@@ -152,19 +153,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
-    from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
-    from meshmode.discretization.poly_element import \
-        default_simplex_group_factory, QuadratureSimplexGroupFactory
-
     order = 1
-    discr = EagerDGDiscretization(
-        actx, local_mesh,
-        discr_tag_to_group_factory={
-            DISCR_TAG_BASE: default_simplex_group_factory(
-                base_dim=local_mesh.dim, order=order),
-            DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(2*order + 1)
-        },
-        mpi_communicator=comm
+    discr = create_discretization_collection(
+        actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)
 

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -32,10 +32,9 @@ from pytools.obj_array import make_obj_array
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 
-
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     get_sim_timestep,
@@ -148,7 +147,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -31,9 +31,9 @@ from functools import partial
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     get_sim_timestep,
@@ -146,7 +146,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -31,9 +31,9 @@ from functools import partial
 
 from arraycontext import thaw
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
 
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.euler import euler_operator
 from mirgecom.simutil import (
     get_sim_timestep,
@@ -151,7 +151,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = EagerDGDiscretization(
+    discr = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
     nodes = thaw(discr.nodes(), actx)

--- a/examples/wave-mpi.py
+++ b/examples/wave-mpi.py
@@ -32,8 +32,10 @@ from arraycontext import thaw, freeze
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
+import grudge.op as op
+
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.mpi import mpi_entry_point
 from mirgecom.integrators import rk4_step
 from mirgecom.wave import wave_operator
@@ -47,16 +49,16 @@ from mirgecom.logging_quantities import (initialize_logmgr,
                                          logmgr_add_device_memory_usage)
 
 
-def bump(actx, discr, t=0):
+def bump(actx, nodes, t=0):
     """Create a bump."""
-    source_center = np.array([0.2, 0.35, 0.1])[:discr.dim]
+    dim = len(nodes)
+    source_center = np.array([0.2, 0.35, 0.1])[:dim]
     source_width = 0.05
     source_omega = 3
 
-    nodes = thaw(discr.nodes(), actx)
     center_dist = flat_obj_array([
         nodes[i] - source_center[i]
-        for i in range(discr.dim)
+        for i in range(dim)
         ])
 
     return (
@@ -130,16 +132,17 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
 
     order = 3
 
-    discr = EagerDGDiscretization(actx, local_mesh, order=order,
-                                  mpi_communicator=comm)
+    discr = create_discretization_collection(
+        actx, local_mesh, order=order, mpi_communicator=comm
+    )
+    nodes = thaw(discr.nodes(), actx)
 
     current_cfl = 0.485
     wave_speed = 1.0
     from grudge.dt_utils import characteristic_lengthscales
     nodal_dt = characteristic_lengthscales(actx, discr) / wave_speed
 
-    from grudge.op import nodal_min
-    dt = actx.to_numpy(current_cfl * nodal_min(discr, "vol", nodal_dt))[()]
+    dt = actx.to_numpy(current_cfl * op.nodal_min(discr, "vol", nodal_dt))[()]
 
     t_final = 1
 
@@ -148,8 +151,8 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
         istep = 0
 
         fields = flat_obj_array(
-            bump(actx, discr),
-            [discr.zeros(actx) for i in range(discr.dim)]
+            bump(actx, nodes),
+            [discr.zeros(actx) for i in range(dim)]
             )
 
     else:
@@ -159,8 +162,9 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
         restart_fields = restart_data["fields"]
         old_order = restart_data["order"]
         if old_order != order:
-            old_discr = EagerDGDiscretization(actx, local_mesh, order=old_order,
-                                              mpi_communicator=comm)
+            old_discr = create_discretization_collection(
+                actx, local_mesh, order=old_order, mpi_communicator=comm
+            )
             from meshmode.discretization.connection import make_same_mesh_connection
             connection = make_same_mesh_connection(actx, discr.discr_from_dd("vol"),
                                                    old_discr.discr_from_dd("vol"))
@@ -215,7 +219,7 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
             )
 
         if istep % 10 == 0:
-            print(istep, t, actx.to_numpy(discr.norm(fields[0])))
+            print(istep, t, actx.to_numpy(op.norm(discr, fields[0], 2)))
             vis.write_parallel_vtk_file(
                 comm,
                 "fld-wave-mpi-%03d-%04d.vtu" % (rank, istep),
@@ -235,7 +239,7 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
             set_dt(logmgr, dt)
             logmgr.tick_after()
 
-    final_soln = actx.to_numpy(discr.norm(fields[0]))
+    final_soln = actx.to_numpy(op.norm(discr, fields[0], 2))
     assert np.abs(final_soln - 0.04409852463947439) < 1e-14
 
 

--- a/examples/wave.py
+++ b/examples/wave.py
@@ -30,9 +30,10 @@ import pyopencl.tools as cl_tools
 
 from pytools.obj_array import flat_obj_array
 
-from grudge.eager import EagerDGDiscretization
 from grudge.shortcuts import make_visualizer
-from grudge.op import nodal_min
+import grudge.op as op
+
+from mirgecom.discretization import create_discretization_collection
 from mirgecom.wave import wave_operator
 from mirgecom.integrators import rk4_step
 
@@ -49,16 +50,16 @@ from mirgecom.logging_quantities import (initialize_logmgr,
                                          logmgr_add_device_memory_usage)
 
 
-def bump(actx, discr, t=0):
+def bump(actx, nodes, t=0):
     """Create a bump."""
-    source_center = np.array([0.2, 0.35, 0.1])[:discr.dim]
+    dim = len(nodes)
+    source_center = np.array([0.2, 0.35, 0.1])[:dim]
     source_width = 0.05
     source_omega = 3
 
-    nodes = thaw(discr.nodes(), actx)
     center_dist = flat_obj_array([
         nodes[i] - source_center[i]
-        for i in range(discr.dim)
+        for i in range(dim)
         ])
 
     return (
@@ -102,19 +103,20 @@ def main(use_profiling=False, use_logmgr=False, lazy_eval: bool = False):
 
     order = 3
 
-    discr = EagerDGDiscretization(actx, mesh, order=order)
+    discr = create_discretization_collection(actx, mesh, order=order)
+    nodes = thaw(discr.nodes(), actx)
 
     current_cfl = 0.485
     wave_speed = 1.0
     from grudge.dt_utils import characteristic_lengthscales
     nodal_dt = characteristic_lengthscales(actx, discr) / wave_speed
-    dt = actx.to_numpy(current_cfl * nodal_min(discr, "vol",
-                                               nodal_dt))[()]
+    dt = actx.to_numpy(current_cfl * op.nodal_min(discr, "vol",
+                                                  nodal_dt))[()]
 
     print("%d elements" % mesh.nelements)
 
-    fields = flat_obj_array(bump(actx, discr),
-                            [discr.zeros(actx) for i in range(discr.dim)])
+    fields = flat_obj_array(bump(actx, nodes),
+                            [discr.zeros(actx) for i in range(dim)])
 
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
@@ -153,7 +155,7 @@ def main(use_profiling=False, use_logmgr=False, lazy_eval: bool = False):
         if istep % 10 == 0:
             if use_profiling:
                 print(actx.tabulate_profiling_data())
-            print(istep, t, actx.to_numpy(discr.norm(fields[0], np.inf)))
+            print(istep, t, actx.to_numpy(op.norm(discr, fields[0], 2)))
             vis.write_vtk_file("fld-wave-%04d.vtu" % istep,
                     [
                         ("u", fields[0]),

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -45,9 +45,10 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     """Create and return a grudge DG discretization object."""
     from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
     from grudge.eager import EagerDGDiscretization
-    from meshmode.discretization.poly_element import \
-        QuadratureSimplexGroupFactory, \
-        PolynomialRecursiveNodesGroupFactory
+    from meshmode.discretization.poly_element import (
+        QuadratureSimplexGroupFactory,
+        default_simplex_group_factory
+    )
 
     if quadrature_order < 0:
         quadrature_order = 2*order+1
@@ -55,8 +56,8 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     discr = EagerDGDiscretization(
         actx, mesh,
         discr_tag_to_group_factory={
-            DISCR_TAG_BASE: PolynomialRecursiveNodesGroupFactory(order,
-                                                                 family="lgl"),
+            DISCR_TAG_BASE: default_simplex_group_factory(base_dim=mesh.dim,
+                                                          order=order),
             DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(quadrature_order),
         },
         mpi_communicator=mpi_communicator

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -278,8 +278,8 @@ def check_range_local(discr: DiscretizationCollection, dd: str, field: DOFArray,
                       min_value: float, max_value: float) -> List[float]:
     """Return the values that are outside the range [min_value, max_value]."""
     actx = field.array_context
-    local_min = np.asscalar(actx.to_numpy(op.nodal_min_loc(discr, dd, field)))
-    local_max = np.asscalar(actx.to_numpy(op.nodal_max_loc(discr, dd, field)))
+    local_min = actx.to_numpy(op.nodal_min_loc(discr, dd, field)).item()
+    local_max = actx.to_numpy(op.nodal_max_loc(discr, dd, field)).item()
 
     failing_values = []
 


### PR DESCRIPTION
This is a follow-on to #687 and #688.  It moves the examples from `EagerDGDiscretization` --> `DiscretizationCollection`.

Plus a couple of out-of-band changes:
- `discretization.py`: Update discr coll util to use `default_node_factory` util from `meshmode` 
- `simutil.py`: Resolve deprecated `asscalar@numpy`, fixes #691 

 
**Questions for the review** @lukeolson:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
  - [x] The PR should have a guide if needed (e.g., an ordering).
- [ ] ~~Is every top-level method and class documented? Are things that should be documented actually so?~~
- [ ] ~~Does the implementation do what the docstring claims?~~
- [x] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [x] Is everything that is implemented covered by tests?
- [x] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
