### PR TITLE
Switch to DiscretizationCollection@grudge

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ Here’s an example, to give you an impression:
    import numpy as np
    import pyopencl as cl
    from pytools.obj_array import flat_obj_array
-   from grudge.eager import EagerDGDiscretization
+   from grudge.discretization import DiscretizationCollection
    from grudge.shortcuts import make_visualizer
    from mirgecom.wave import wave_operator
    from mirgecom.integrators import rk4_step
@@ -36,7 +36,7 @@ Here’s an example, to give you an impression:
 
    print("%d elements" % mesh.nelements)
 
-   discr = EagerDGDiscretization(actx, mesh, order=order)
+   discr = DiscretizationCollection(actx, mesh, order=order)
    fields = flat_obj_array(
        [discr.zeros(actx)],
        [discr.zeros(actx) for i in range(discr.dim)]
@@ -54,7 +54,7 @@ Here’s an example, to give you an impression:
        fields = rk4_step(fields, t, dt, rhs)
        if istep % 10 == 0:
            print(istep, t, discr.norm(fields[0], np.inf))
-           vis.write_vtk_file("wave-eager-%04d.vtu" % istep,
+           vis.write_vtk_file("wave-%04d.vtu" % istep,
                    [("u", fields[0]), ("v", fields[1:]), ])
 
        t += dt

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -77,7 +77,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.eager.EagerDGDiscretization`
+        discr: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -119,7 +119,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.eager.EagerDGDiscretization`
+        discr: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -169,7 +169,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.eager.EagerDGDiscretization`
+        discr: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -204,7 +204,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.eager.EagerDGDiscretization`
+        discr: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -468,7 +468,7 @@ class PrescribedFluidBoundary(FluidBoundary):
 
     def av_flux(self, discr, btag, diffusion, **kwargs):
         """Get the diffusive fluxes for the AV operator API."""
-        grad_av_minus = discr.project("vol", btag, diffusion)
+        grad_av_minus = op.project(discr, "vol", btag, diffusion)
         actx = grad_av_minus.mass[0].array_context
         nhat = thaw(discr.normal(btag), actx)
         grad_av_plus = self._bnd_grad_av_func(
@@ -527,7 +527,7 @@ class AdiabaticSlipBoundary(PrescribedFluidBoundary):
         E_plus = E_minus
         """
         # Grab some boundary-relevant data
-        dim = discr.dim
+        dim = state_minus.dim
         actx = state_minus.array_context
 
         # Grab a unit normal to the boundary
@@ -553,7 +553,7 @@ class AdiabaticSlipBoundary(PrescribedFluidBoundary):
         # Grab some boundary-relevant data
         dim, = grad_av_minus.mass.shape
         actx = grad_av_minus.mass[0].array_context
-        nhat = thaw(discr.norm(btag), actx)
+        nhat = thaw(discr.normal(btag), actx)
 
         # Subtract 2*wall-normal component of q
         # to enforce q=0 on the wall

--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -235,7 +235,7 @@ def grad_operator(discr, boundaries, u, quadrature_tag=DISCR_TAG_BASE):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
         the discretization to use
     boundaries:
         dictionary (or list of dictionaries) mapping boundary tags to
@@ -338,7 +338,7 @@ def diffusion_operator(discr, *args, return_grad_u=False, **kwargs):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
         the discretization to use
     kappa: numbers.Number or meshmode.dof_array.DOFArray
         the conductivity value(s)

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -54,8 +54,8 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     return DiscretizationCollection(
         actx, mesh,
         discr_tag_to_group_factory={
-            DISCR_TAG_BASE: PolynomialRecursiveNodesGroupFactory(base_dim=mesh.dim,
-                                                                 order=order),
+            DISCR_TAG_BASE: PolynomialRecursiveNodesGroupFactory(order=order,
+                                                                 family="lgl"),
             DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(quadrature_order),
         },
         mpi_communicator=mpi_communicator

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -45,7 +45,7 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     from grudge.discretization import DiscretizationCollection
     from meshmode.discretization.poly_element import (
         QuadratureSimplexGroupFactory,
-        default_simplex_group_factory
+        PolynomialRecursiveNodesGroupFactory
     )
 
     if quadrature_order < 0:
@@ -54,8 +54,8 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     return DiscretizationCollection(
         actx, mesh,
         discr_tag_to_group_factory={
-            DISCR_TAG_BASE: default_simplex_group_factory(base_dim=mesh.dim,
-                                                          order=order),
+            DISCR_TAG_BASE: PolynomialRecursiveNodesGroupFactory(base_dim=mesh.dim,
+                                                                 order=order),
             DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(quadrature_order),
         },
         mpi_communicator=mpi_communicator

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -41,7 +41,6 @@ logger = logging.getLogger(__name__)
 def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None,
                                      quadrature_order=-1):
     """Create and return a grudge DG discretization collection."""
-
     from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
     from grudge.discretization import DiscretizationCollection
     from meshmode.discretization.poly_element import (

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -38,13 +38,12 @@ logger = logging.getLogger(__name__)
 # we can replace it more easily when we refactor the drivers and
 # examples to use discretization collections, and change it centrally
 # when we want to change it.
-# TODO: Make this return an actual grudge `DiscretizationCollection`
-#       when we are ready to change mirgecom to support that change.
 def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None,
                                      quadrature_order=-1):
-    """Create and return a grudge DG discretization object."""
+    """Create and return a grudge DG discretization collection."""
+
     from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
-    from grudge.eager import EagerDGDiscretization
+    from grudge.discretization import DiscretizationCollection
     from meshmode.discretization.poly_element import (
         QuadratureSimplexGroupFactory,
         default_simplex_group_factory
@@ -53,7 +52,7 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     if quadrature_order < 0:
         quadrature_order = 2*order+1
 
-    discr = EagerDGDiscretization(
+    return DiscretizationCollection(
         actx, mesh,
         discr_tag_to_group_factory={
             DISCR_TAG_BASE: default_simplex_group_factory(base_dim=mesh.dim,
@@ -62,4 +61,3 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
         },
         mpi_communicator=mpi_communicator
     )
-    return discr

--- a/mirgecom/gas_model.py
+++ b/mirgecom/gas_model.py
@@ -289,7 +289,7 @@ def project_fluid_state(discr, src, tgt, state, gas_model):
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
 
         A discretization collection encapsulating the DG elements
 
@@ -401,7 +401,7 @@ def make_operator_fluid_states(discr, volume_state, gas_model, boundaries,
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
 
         A discretization collection encapsulating the DG elements
 

--- a/mirgecom/inviscid.py
+++ b/mirgecom/inviscid.py
@@ -236,7 +236,7 @@ def inviscid_flux_on_element_boundary(
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
         A discretization collection encapsulating the DG elements
 
     gas_model: :class:`~mirgecom.gas_model.GasModel`
@@ -304,7 +304,7 @@ def get_inviscid_timestep(discr, state):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
 
         the discretization to use
 
@@ -330,7 +330,7 @@ def get_inviscid_cfl(discr, state, dt):
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
 
         the discretization to use
 

--- a/mirgecom/operators.py
+++ b/mirgecom/operators.py
@@ -36,7 +36,7 @@ def grad_operator(discr, dd_vol, dd_faces, u, flux):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
         the discretization to use
     dd_vol: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the volume discretization.
@@ -67,7 +67,7 @@ def div_operator(discr, dd_vol, dd_faces, v, flux):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
         the discretization to use
     dd_vol: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the volume discretization.

--- a/mirgecom/viscous.py
+++ b/mirgecom/viscous.py
@@ -293,7 +293,7 @@ def viscous_facial_flux_central(discr, state_pair, grad_cv_pair, grad_t_pair,
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
 
         The discretization to use
 
@@ -345,7 +345,7 @@ def viscous_flux_on_element_boundary(
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
         A discretization collection encapsulating the DG elements
 
     gas_model: :class:`~mirgecom.gas_model.GasModel`
@@ -442,7 +442,7 @@ def get_viscous_timestep(discr, state):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
 
         the discretization to use
 
@@ -481,7 +481,7 @@ def get_viscous_cfl(discr, dt, state):
 
     Parameters
     ----------
-    discr: :class:`~grudge.eager.EagerDGDiscretization`
+    discr: :class:`~grudge.discretization.DiscretizationCollection`
 
         the discretization to use
 

--- a/mirgecom/wave.py
+++ b/mirgecom/wave.py
@@ -32,8 +32,7 @@ import numpy.linalg as la  # noqa
 from pytools.obj_array import flat_obj_array
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from meshmode.dof_array import thaw
-from grudge.trace_pair import TracePair
-from grudge.eager import interior_trace_pair, cross_rank_trace_pairs
+from grudge.trace_pair import TracePair, interior_trace_pairs
 import grudge.op as op
 
 
@@ -68,7 +67,7 @@ def wave_operator(discr, c, w):
 
     Parameters
     ----------
-    discr: grudge.eager.EagerDGDiscretization
+    discr: grudge.discretization.DiscretizationCollection
         the discretization to use
     c: float
         the (constant) wave speed
@@ -96,12 +95,12 @@ def wave_operator(discr, c, w):
                 )
             +  # noqa: W504
             op.face_mass(discr,
-                _flux(discr, c=c, w_tpair=interior_trace_pair(discr, w))
-                + _flux(discr, c=c,
-                    w_tpair=TracePair(BTAG_ALL, interior=dir_bval, exterior=dir_bc))
+                _flux(discr, c=c,
+                      w_tpair=TracePair(BTAG_ALL, interior=dir_bval,
+                                        exterior=dir_bc))
                 + sum(
                     _flux(discr, c=c, w_tpair=tpair)
-                    for tpair in cross_rank_trace_pairs(discr, w, _WaveTag))
+                    for tpair in interior_trace_pairs(discr, w, comm_tag=_WaveTag))
                 )
             )
         )

--- a/test/test_av.py
+++ b/test/test_av.py
@@ -228,7 +228,7 @@ def test_artificial_viscosity(ctx_factory, dim, order):
                                       exterior=diffusion_plus)
             from mirgecom.flux import num_flux_central
             flux_weak = num_flux_central(bnd_grad_pair.int, bnd_grad_pair.ext)@nhat
-            return disc.project(btag, "all_faces", flux_weak)
+            return op.project(disc, btag, "all_faces", flux_weak)
 
     boundaries = {BTAG_ALL: TestBoundary()}
 


### PR DESCRIPTION
- Banish Eager 
- Switch all discretization to `DiscretizationCollection` (for real)
- Clean up lingering issues exposed by switch
- switches to `interior_trace_pairs` to address deprecation (@lukeolson)

**Questions for the review** @lukeolson:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
  - [x] The PR should have a guide if needed (e.g., an ordering).
- ~~[ ] Is every top-level method and class documented? Are things that should be documented actually so?~~
- [ ] ~~Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?~~
- [x] Does the implementation do what the docstring claims?
- [x] Is everything that is implemented covered by tests?
  - [x] The tests still use `interior_trace_pair` (see bc, lazy, operators).  If these need to be updated, then we should do that now. https://github.com/inducer/grudge/blob/main/grudge/trace_pair.py#L266 vvvvv
  - [x] @lukeolson update.  out of scope, these were limited to `grudge.eager` changes.  leave to another PR.
- [x] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
