### PR TITLE
Use `actx.freeze_thaw` instead of `force_evaluation`

### DIFF
--- a/examples/heat-source-mpi.py
+++ b/examples/heat-source-mpi.py
@@ -38,7 +38,6 @@ from mirgecom.diffusion import (
     DirichletDiffusionBoundary,
     NeumannDiffusionBoundary)
 from mirgecom.mpi import mpi_entry_point
-from mirgecom.utils import force_evaluation
 import pyopencl.tools as cl_tools
 
 from mirgecom.logging_quantities import (initialize_logmgr,
@@ -172,7 +171,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                         ], overwrite=True)
 
         u = rk4_step(u, t, dt, compiled_rhs)
-        u = force_evaluation(actx, u)
+        u = actx.freeze_thaw(u)
 
         t += dt
         istep += 1

--- a/examples/wave-mpi.py
+++ b/examples/wave-mpi.py
@@ -38,7 +38,6 @@ from mirgecom.discretization import create_discretization_collection
 from mirgecom.mpi import mpi_entry_point
 from mirgecom.integrators import rk4_step
 from mirgecom.wave import wave_operator
-from mirgecom.utils import force_evaluation
 
 import pyopencl.tools as cl_tools
 
@@ -230,7 +229,7 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
             )
 
         fields = rk4_step(fields, t, dt, compiled_rhs)
-        fields = force_evaluation(actx, fields)
+        fields = actx.freeze_thaw(fields)
 
         t += dt
         istep += 1

--- a/examples/wave.py
+++ b/examples/wave.py
@@ -36,7 +36,6 @@ import grudge.op as op
 from mirgecom.discretization import create_discretization_collection
 from mirgecom.wave import wave_operator
 from mirgecom.integrators import rk4_step
-from mirgecom.utils import force_evaluation
 
 from meshmode.array_context import (PyOpenCLArrayContext,
     PytatoPyOpenCLArrayContext)
@@ -150,7 +149,7 @@ def main(use_profiling=False, use_logmgr=False, lazy: bool = False):
             logmgr.tick_before()
 
         fields = rk4_step(fields, t, dt, compiled_rhs)
-        fields = force_evaluation(actx, fields)
+        fields = actx.freeze_thaw(fields)
 
         if istep % 10 == 0:
             if use_profiling:

--- a/mirgecom/steppers.py
+++ b/mirgecom/steppers.py
@@ -31,7 +31,6 @@ THE SOFTWARE.
 import numpy as np
 from logpyle import set_dt
 from mirgecom.logging_quantities import set_sim_state
-from mirgecom.utils import force_evaluation
 from pytools import memoize_in
 from arraycontext import get_container_context_recursively_opt
 
@@ -129,7 +128,9 @@ def _advance_state_stepper_func(rhs, timestepper,
     actx = get_container_context_recursively_opt(state)
 
     t = np.float64(t)
-    state = force_evaluation(actx, state)
+
+    if actx is not None:
+        state = actx.freeze_thaw(state)
 
     if t_final <= t:
         return istep, t, state
@@ -157,8 +158,8 @@ def _advance_state_stepper_func(rhs, timestepper,
             else:
                 force_eval = False
 
-        if force_eval:
-            state = force_evaluation(actx, state)
+        if force_eval and actx is not None:
+            state = actx.freeze_thaw(state)
 
         t += dt
         istep += 1
@@ -229,7 +230,9 @@ def _advance_state_leap(rhs, timestepper, state,
     actx = get_container_context_recursively_opt(state)
 
     t = np.float64(t)
-    state = force_evaluation(actx, state)
+
+    if actx is not None:
+        state = actx.freeze_thaw(state)
 
     if t_final <= t:
         return istep, t, state
@@ -265,8 +268,8 @@ def _advance_state_leap(rhs, timestepper, state,
                     else:
                         force_eval = False
 
-                if force_eval:
-                    state = force_evaluation(actx, state)
+                if force_eval and actx is not None:
+                    state = actx.freeze_thaw(state)
                     stepper_cls.state = state
 
                 t += dt

--- a/mirgecom/utils.py
+++ b/mirgecom/utils.py
@@ -2,7 +2,6 @@
 
 .. autoclass:: StatisticsAccumulator
 .. autofunction:: asdict_shallow
-.. autofunction:: force_evaluation
 """
 
 __copyright__ = """
@@ -114,6 +113,11 @@ class StatisticsAccumulator:
 
 def force_evaluation(actx, x):
     """Force evaluation of a (possibly lazy) array."""
+    from warnings import warn
+    warn(
+        "force_evaluation is deprecated and will disappear in Q4 2022. "
+        "Use the array container's freeze_thaw method instead.",
+        DeprecationWarning, stacklevel=2)
     if actx is None:
         return x
-    return actx.thaw(actx.freeze(x))
+    return actx.freeze_thaw(x)


### PR DESCRIPTION
Now that `actx.freeze_thaw` exists, `force_evaluation` seems mostly redundant (except for the `None` handling for `advance_state`, but that can be worked around without too much trouble).

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?