### PR TITLE
Avoid uncaught NaNs in some tests

### DIFF
--- a/test/test_eos.py
+++ b/test/test_eos.py
@@ -159,7 +159,7 @@ def test_pyrometheus_mechanisms(ctx_factory, mechname, rate_tol, y0):
         def inf_norm(x):
             return actx.to_numpy(op.norm(discr, x, np.inf))
 
-        assert inf_norm((prom_c - can_c) / can_c) < 1e-14
+        assert inf_norm((prom_c - can_c)) < 1e-14
         assert inf_norm((prom_t - can_t) / can_t) < 1e-14
         assert inf_norm((prom_rho - can_rho) / can_rho) < 1e-14
         assert inf_norm((prom_p - can_p) / can_p) < 1e-14

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -81,7 +81,7 @@ def test_viscous_stress_tensor(actx_factory, transport_model):
     velocity = make_obj_array([velocity_x, velocity_y, velocity_z])
 
     mass = 2*ones
-    energy = zeros + 2.5
+    energy = zeros + 2.5 + .5*mass*np.dot(velocity, velocity)
     mom = mass * velocity
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)


### PR DESCRIPTION
Fixes the NaNs indicated by @majosm and appearing in this [CI run](https://github.com/illinois-ceesd/mirgecom/runs/7344124579) when order 2 norms are used for errors.

The ones appearing like the link below occur because the expected/cantera species concentrations can be 0, so relative errors NaN.  Switched this test to the more severe absolute difference comparison.
https://github.com/illinois-ceesd/mirgecom/runs/7344124579?check_suite_focus=true#step:4:57

The ones appearing at the next link occur because the kinetic energy was not added to the total energy in the power-law transport test.  This made the thermal state unphysical, and the power law test rightly failed.  Fixed by adding the kinetic energy.
https://github.com/illinois-ceesd/mirgecom/runs/7344124579?check_suite_focus=true#step:4:2177

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
