### PR TITLE
Add zero level option to thermochem interface.

### DIFF
--- a/mirgecom/thermochemistry.py
+++ b/mirgecom/thermochemistry.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 """
 
 
-def get_pyrometheus_wrapper_class(pyro_class, temperature_niter=5):
+def get_pyrometheus_wrapper_class(pyro_class, temperature_niter=5, zero_level=0.):
     """Return a MIRGE-compatible wrapper for a :mod:`pyrometheus` mechanism class.
 
     Dynamically creates a class that inherits from a
@@ -49,6 +49,8 @@ def get_pyrometheus_wrapper_class(pyro_class, temperature_niter=5):
         Pyro thermochemical mechanism to wrap
     temperature_niter: int
         Number of Newton iterations in `get_temperature` (default=5)
+    zero_level: float
+        Squash concentrations below this level to 0. (default=0.)
     """
 
     class PyroWrapper(pyro_class):
@@ -61,7 +63,7 @@ def get_pyrometheus_wrapper_class(pyro_class, temperature_niter=5):
             # ensure non-negative concentrations
             zero = self._pyro_zeros_like(concs[0])
             for i in range(self.num_species):
-                concs[i] = self.usr_np.where(self.usr_np.less(concs[i], 0),
+                concs[i] = self.usr_np.where(self.usr_np.less(concs[i], zero_level),
                                              zero, concs[i])
             return concs
 
@@ -108,7 +110,8 @@ def get_pyrometheus_wrapper_class(pyro_class, temperature_niter=5):
     return PyroWrapper
 
 
-def get_pyrometheus_wrapper_class_from_cantera(cantera_soln, temperature_niter=5):
+def get_pyrometheus_wrapper_class_from_cantera(cantera_soln, temperature_niter=5,
+                                               zero_level=0.):
     """Return a MIRGE-compatible wrapper for a :mod:`pyrometheus` mechanism class.
 
     Cantera-based interface that creates a Pyrometheus mechanism
@@ -121,27 +124,32 @@ def get_pyrometheus_wrapper_class_from_cantera(cantera_soln, temperature_niter=5
         Cantera solution from which to create the thermochemical mechanism
     temperature_niter: int
         Number of Newton iterations in `get_temperature` (default=5)
+    zero_level: float
+        Squash concentrations below this level to 0. (default=0.)
     """
     import pyrometheus as pyro
     pyro_class = pyro.get_thermochem_class(cantera_soln)
     return get_pyrometheus_wrapper_class(pyro_class,
-                                         temperature_niter=temperature_niter)
+                                         temperature_niter=temperature_niter,
+                                         zero_level=zero_level)
 
 
 # backwards compat
-def make_pyrometheus_mechanism_class(cantera_soln, temperature_niter=5):
+def make_pyrometheus_mechanism_class(cantera_soln, temperature_niter=5,
+                                     zero_level=0.):
     """Deprecate this interface to get_pyrometheus_mechanism_class."""
     from warnings import warn
     warn("make_pyrometheus_mechanism_class is deprecated."
          " use get_pyrometheus_wrapper_class_from_cantera.")
     return get_pyrometheus_wrapper_class_from_cantera(
-        cantera_soln, temperature_niter=temperature_niter)
+        cantera_soln, temperature_niter=temperature_niter, zero_level=zero_level)
 
 
-def make_pyro_thermochem_wrapper_class(cantera_soln, temperature_niter=5):
+def make_pyro_thermochem_wrapper_class(cantera_soln, temperature_niter=5,
+                                       zero_level=0.):
     """Deprecate this interface to pyro_wrapper_class_from_cantera."""
     from warnings import warn
     warn("make_pyrometheus_mechanism is deprecated."
          " use get_pyrometheus_wrapper_class_from_cantera.")
     return get_pyrometheus_wrapper_class_from_cantera(
-        cantera_soln, temperature_niter=temperature_niter)
+        cantera_soln, temperature_niter=temperature_niter, zero_level=zero_level)

--- a/mirgecom/thermochemistry.py
+++ b/mirgecom/thermochemistry.py
@@ -1,7 +1,26 @@
 r""":mod:`mirgecom.thermochemistry` provides a wrapper class for :mod:`pyrometheus`..
 
+This module provides an interface to the
+`Pyrometheus Thermochemistry <https://github.com/pyrometheus>`_ package's
+:class:`pyrometheus.Thermochemistry` object which provides a thermal and chemical
+kinetics model for the the :class:`mirgecom.eos.MixtureEOS`, and some helper
+routines to create the wrapper class.
+
+   .. note::
+    The wrapper addresses a couple of issues with the default interface:
+
+    - Lazy eval is currently incapable of dealing with data-dependent
+      behavior (like that of an iterative Newton solve). This wrapper allows us to
+      hard-code the number of Newton iterations to *temperature_niter*.
+
+    - Small species mass fractions can trigger reaction rates which drive species
+      fractions significantly negative over a single timestep. The wrapper provides
+      the *zero_level* parameter to set concentrations falling below *zero_level*
+      to be pinned to zero.
+
 .. autofunction:: get_pyrometheus_wrapper_class
 .. autofunction:: get_pyrometheus_wrapper_class_from_cantera
+.. autofunction:: get_thermochemistry_class_by_mechanism_name
 """
 
 __copyright__ = """
@@ -37,11 +56,12 @@ def get_pyrometheus_wrapper_class(pyro_class, temperature_niter=5, zero_level=0.
     to adapt it to :mod:`mirgecom`'s needs.
 
     - get_concentrations: overrides :class:`pyrometheus.Thermochemistry` version
-      of  the same function, pinning any negative concentrations due to slightly
-      negative massfractions (which are OK) back to 0.
+      of  the same function, pinning any concentrations less than the *zero_level*
+      due to small or slightly negative massfractions (which are OK) back to 0.
 
     - get_temperature: MIRGE-specific interface to use a hard-coded Newton solver
-      to find a temperature from an input state.
+      to find a temperature from an input state. This routine hard-codes the number
+      of Newton solve iterations to *temperature_niter*.
 
     Parameters
     ----------
@@ -132,6 +152,20 @@ def get_pyrometheus_wrapper_class_from_cantera(cantera_soln, temperature_niter=5
     return get_pyrometheus_wrapper_class(pyro_class,
                                          temperature_niter=temperature_niter,
                                          zero_level=zero_level)
+
+
+def get_thermochemistry_class_by_mechanism_name(mechanism_name: str,
+                                                temperature_niter=5,
+                                                zero_level=0.):
+    """Grab a pyrometheus mechanism class from the mech name."""
+    from mirgecom.mechanisms import get_mechanism_input
+    mech_input_source = get_mechanism_input(mechanism_name)
+    from cantera import Solution
+    cantera_soln = Solution(name="gas", yaml=mech_input_source)
+    return \
+        get_pyrometheus_wrapper_class_from_cantera(
+            cantera_soln, temperature_niter=temperature_niter,
+            zero_level=zero_level)
 
 
 # backwards compat

--- a/test/test_eos.py
+++ b/test/test_eos.py
@@ -205,7 +205,10 @@ def test_pyrometheus_eos(ctx_factory, mechname, dim, y0, vel):
     # Pyrometheus initialization
     mech_input = get_mechanism_input(mechname)
     sol = cantera.Solution(name="gas", yaml=mech_input)
-    from mirgecom.thermochemistry import make_pyrometheus_mechanism_class
+    from mirgecom.thermochemistry import (
+        make_pyrometheus_mechanism_class,
+        get_pyrometheus_wrapper_class_from_cantera
+    )
     prometheus_mechanism = make_pyrometheus_mechanism_class(sol)(actx.np)
 
     nspecies = prometheus_mechanism.num_species
@@ -253,6 +256,7 @@ def test_pyrometheus_eos(ctx_factory, mechname, dim, y0, vel):
         internal_energy = eos.get_internal_energy(temperature=tin,
                                                   species_mass_fractions=yin)
         y = cv.species_mass_fractions
+        rho = cv.mass
 
         print(f"pyro_y = {y}")
         print(f"pyro_eos.p = {p}")
@@ -267,6 +271,25 @@ def test_pyrometheus_eos(ctx_factory, mechname, dim, y0, vel):
         assert inf_norm((temperature - pyro_t) / pyro_t) < tol
         assert inf_norm((internal_energy - pyro_e) / pyro_e) < tol
         assert inf_norm((p - pyro_p) / pyro_p) < tol
+
+        # Test the concetrations zero level
+        y = -1.0*y
+        print(f"{y=}")
+        conc = prometheus_mechanism.get_concentrations(rho, y)
+        print(f"{conc=}")
+        for spec in range(nspecies):
+            assert max(conc[spec]).all() >= 0
+
+        zlev = 1e-3
+        test_mech = \
+            get_pyrometheus_wrapper_class_from_cantera(sol, zero_level=zlev)(actx.np)
+
+        y = 0*y + zlev
+        print(f"{y=}")
+        conc = test_mech.get_concentrations(rho, y)
+        print(f"{conc=}")
+        for spec in range(nspecies):
+            assert max(conc[spec]).all() == 0
 
 
 @pytest.mark.parametrize(("mechname", "rate_tol"),


### PR DESCRIPTION
Squash concentrations below `zero_level` to zero, preventing spurious reaction rates for insignificant concentrations of reactants.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
