### PR TITLE
Multiple volumes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,3 +91,8 @@ mathjax3_config = {
 rst_prolog = """
 .. |mirgecom| replace:: *MIRGE-Com*
 """
+
+# FIXME: Remove when grudge#280 gets merged
+nitpick_ignore_regex = [
+    ("py:class", r".*BoundaryDomainTag.*"),
+]

--- a/examples/autoignition-mpi.py
+++ b/examples/autoignition-mpi.py
@@ -170,8 +170,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                                                                     generate_mesh)
         local_nelements = local_mesh.nelements
 
-    dcoll = create_discretization_collection(actx, local_mesh, order=order,
-                                             mpi_communicator=comm)
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
     ones = dcoll.zeros(actx) + 1.0
 
@@ -320,8 +319,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         else:
             rst_cv = restart_data["cv"]
             old_dcoll = \
-                create_discretization_collection(actx, local_mesh, order=rst_order,
-                                                 mpi_communicator=comm)
+                create_discretization_collection(actx, local_mesh, order=rst_order)
             from meshmode.discretization.connection import make_same_mesh_connection
             connection = make_same_mesh_connection(actx, dcoll.discr_from_dd("vol"),
                                                    old_dcoll.discr_from_dd("vol"))

--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -30,7 +30,7 @@ import pyopencl as cl
 from functools import partial
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
-from grudge.dof_desc import DTAG_BOUNDARY
+from grudge.dof_desc import BoundaryDomainTag
 from grudge.shortcuts import make_visualizer
 
 
@@ -237,22 +237,22 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     eos = IdealSingleGas()
     gas_model = GasModel(eos=eos, transport=transport_model)
 
-    def _boundary_state(dcoll, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
 
     boundaries = {
-        DTAG_BOUNDARY("ic1"):
-        PrescribedFluidBoundary(boundary_state_func=_boundary_state),
-        DTAG_BOUNDARY("ic2"):
-        PrescribedFluidBoundary(boundary_state_func=_boundary_state),
-        DTAG_BOUNDARY("ic3"):
-        PrescribedFluidBoundary(boundary_state_func=_boundary_state),
-        DTAG_BOUNDARY("wall"): AdiabaticNoslipMovingBoundary(),
-        DTAG_BOUNDARY("out"): AdiabaticNoslipMovingBoundary(),
+        BoundaryDomainTag("ic1"):
+            PrescribedFluidBoundary(boundary_state_func=_boundary_state),
+        BoundaryDomainTag("ic2"):
+            PrescribedFluidBoundary(boundary_state_func=_boundary_state),
+        BoundaryDomainTag("ic3"):
+            PrescribedFluidBoundary(boundary_state_func=_boundary_state),
+        BoundaryDomainTag("wall"): AdiabaticNoslipMovingBoundary(),
+        BoundaryDomainTag("out"): AdiabaticNoslipMovingBoundary(),
     }
 
     if rst_filename:

--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -192,8 +192,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     from mirgecom.discretization import create_discretization_collection
     order = 3
-    dcoll = create_discretization_collection(actx, local_mesh, order=order,
-                                             mpi_communicator=comm)
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     from grudge.dof_desc import DISCR_TAG_QUAD

--- a/examples/heat-source-mpi.py
+++ b/examples/heat-source-mpi.py
@@ -111,8 +111,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     order = 3
 
-    dcoll = create_discretization_collection(actx, local_mesh, order=order,
-                    mpi_communicator=comm)
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
 
     if dim == 2:
         # no deep meaning here, just a fudge factor

--- a/examples/heat-source-mpi.py
+++ b/examples/heat-source-mpi.py
@@ -30,7 +30,7 @@ import pyopencl as cl
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 import grudge.op as op
 from grudge.shortcuts import make_visualizer
-from grudge.dof_desc import DTAG_BOUNDARY
+from grudge.dof_desc import BoundaryDomainTag
 from mirgecom.discretization import create_discretization_collection
 from mirgecom.integrators import rk4_step
 from mirgecom.diffusion import (
@@ -125,8 +125,8 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     nodes = actx.thaw(dcoll.nodes())
 
     boundaries = {
-        DTAG_BOUNDARY("dirichlet"): DirichletDiffusionBoundary(0.),
-        DTAG_BOUNDARY("neumann"): NeumannDiffusionBoundary(0.)
+        BoundaryDomainTag("dirichlet"): DirichletDiffusionBoundary(0.),
+        BoundaryDomainTag("neumann"): NeumannDiffusionBoundary(0.)
     }
 
     u = dcoll.zeros(actx)

--- a/examples/hotplate-mpi.py
+++ b/examples/hotplate-mpi.py
@@ -31,7 +31,7 @@ from functools import partial
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
 from grudge.shortcuts import make_visualizer
-from grudge.dof_desc import DTAG_BOUNDARY
+from grudge.dof_desc import BoundaryDomainTag
 
 from mirgecom.discretization import create_discretization_collection
 from mirgecom.fluid import make_conserved
@@ -221,21 +221,22 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     exact = initializer(x_vec=nodes, eos=gas_model.eos)
 
-    def _boundary_state(dcoll, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
 
-    boundaries = {DTAG_BOUNDARY("-1"):
-                  PrescribedFluidBoundary(boundary_state_func=_boundary_state),
-                  DTAG_BOUNDARY("+1"):
-                  PrescribedFluidBoundary(boundary_state_func=_boundary_state),
-                  DTAG_BOUNDARY("-2"): IsothermalNoSlipBoundary(
-                      wall_temperature=bottom_boundary_temperature),
-                  DTAG_BOUNDARY("+2"): IsothermalNoSlipBoundary(
-                      wall_temperature=top_boundary_temperature)}
+    boundaries = {
+        BoundaryDomainTag("-1"): PrescribedFluidBoundary(
+            boundary_state_func=_boundary_state),
+        BoundaryDomainTag("+1"): PrescribedFluidBoundary(
+            boundary_state_func=_boundary_state),
+        BoundaryDomainTag("-2"): IsothermalNoSlipBoundary(
+            wall_temperature=bottom_boundary_temperature),
+        BoundaryDomainTag("+2"): IsothermalNoSlipBoundary(
+            wall_temperature=top_boundary_temperature)}
 
     if rst_filename:
         current_t = restart_data["t"]

--- a/examples/hotplate-mpi.py
+++ b/examples/hotplate-mpi.py
@@ -168,9 +168,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     if logmgr:

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -180,9 +180,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     from mirgecom.gas_model import GasModel, make_fluid_state
     gas_model = GasModel(eos=eos)
 
-    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -146,9 +146,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -202,9 +202,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     initializer = MixtureInitializer(dim=dim, nspecies=nspecies,
                                      massfractions=y0s, velocity=velocity)
 
-    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model,

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -146,9 +146,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None

--- a/examples/multiple-volumes-mpi-lazy.py
+++ b/examples/multiple-volumes-mpi-lazy.py
@@ -1,0 +1,1 @@
+multiple-volumes-mpi.py

--- a/examples/multiple-volumes-mpi.py
+++ b/examples/multiple-volumes-mpi.py
@@ -1,0 +1,418 @@
+"""Demonstrate multiple independent volumes."""
+
+__copyright__ = """
+Copyright (C) 2020 University of Illinois Board of Trustees
+"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import logging
+from mirgecom.mpi import mpi_entry_point
+import numpy as np
+from functools import partial
+import pyopencl as cl
+from pytools.obj_array import make_obj_array
+
+from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
+from grudge.shortcuts import make_visualizer
+from grudge.dof_desc import VolumeDomainTag, DISCR_TAG_BASE, DISCR_TAG_QUAD, DOFDesc
+
+from mirgecom.discretization import create_discretization_collection
+from mirgecom.euler import euler_operator
+from mirgecom.simutil import (
+    get_sim_timestep,
+    generate_and_distribute_mesh
+)
+from mirgecom.io import make_init_message
+
+from mirgecom.integrators import rk4_step
+from mirgecom.steppers import advance_state
+from mirgecom.boundary import AdiabaticSlipBoundary
+from mirgecom.initializers import (
+    Lump,
+    AcousticPulse
+)
+from mirgecom.eos import IdealSingleGas
+from mirgecom.gas_model import (
+    GasModel,
+    make_fluid_state
+)
+from logpyle import IntervalTimer, set_dt
+from mirgecom.euler import extract_vars_for_logging
+from mirgecom.logging_quantities import (
+    initialize_logmgr,
+    logmgr_add_many_discretization_quantities,
+    logmgr_add_cl_device_info,
+    logmgr_add_device_memory_usage,
+    set_sim_state
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MyRuntimeError(RuntimeError):
+    """Simple exception to kill the simulation."""
+
+    pass
+
+
+@mpi_entry_point
+def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
+         use_overintegration=False, lazy=False, use_leap=False, use_profiling=False,
+         casename=None, rst_filename=None):
+    """Drive the example."""
+    cl_ctx = ctx_factory()
+
+    if casename is None:
+        casename = "mirgecom"
+
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    num_parts = comm.Get_size()
+
+    from mirgecom.simutil import global_reduce as _global_reduce
+    global_reduce = partial(_global_reduce, comm=comm)
+
+    logmgr = initialize_logmgr(use_logmgr,
+        filename=f"{casename}.sqlite", mode="wu", mpi_comm=comm)
+
+    if use_profiling:
+        queue = cl.CommandQueue(
+            cl_ctx, properties=cl.command_queue_properties.PROFILING_ENABLE)
+    else:
+        queue = cl.CommandQueue(cl_ctx)
+
+    from mirgecom.simutil import get_reasonable_memory_pool
+    alloc = get_reasonable_memory_pool(cl_ctx, queue)
+
+    if lazy:
+        actx = actx_class(comm, queue, mpi_base_tag=12000, allocator=alloc)
+    else:
+        actx = actx_class(comm, queue, allocator=alloc, force_device_scalars=True)
+
+    # timestepping control
+    current_step = 0
+    if use_leap:
+        from leap.rk import RK4MethodBuilder
+        timestepper = RK4MethodBuilder("state")
+    else:
+        timestepper = rk4_step
+    t_final = 0.1
+    current_cfl = 1.0
+    current_dt = .005
+    current_t = 0
+    constant_cfl = False
+
+    # some i/o frequencies
+    nstatus = 1
+    nrestart = 5
+    nviz = 10
+    nhealth = 1
+
+    dim = 2
+
+    # Run simulations with several different pulse amplitudes simultaneously
+    pulse_amplitudes = [0.01, 0.1, 1.0]
+    nvolumes = len(pulse_amplitudes)
+
+    rst_path = "restart_data/"
+    rst_pattern = (
+        rst_path + "{cname}-{step:04d}-{rank:04d}.pkl"
+    )
+    if rst_filename:  # read the grid from restart data
+        rst_filename = f"{rst_filename}-{rank:04d}.pkl"
+        from mirgecom.restart import read_restart_data
+        restart_data = read_restart_data(actx, rst_filename)
+        local_prototype_mesh = restart_data["local_prototype_mesh"]
+        global_prototype_nelements = restart_data["global_prototype_nelements"]
+        assert restart_data["num_parts"] == num_parts
+    else:  # generate the grids from scratch
+        from meshmode.mesh.generation import generate_regular_rect_mesh
+        generate_mesh = partial(generate_regular_rect_mesh,
+                a=(-1,)*dim, b=(1,)*dim, nelements_per_axis=(16,)*dim)
+        local_prototype_mesh, global_prototype_nelements = \
+            generate_and_distribute_mesh(comm, generate_mesh)
+
+    volume_to_local_mesh = {i: local_prototype_mesh for i in range(nvolumes)}
+
+    local_nelements = local_prototype_mesh.nelements * nvolumes
+    global_nelements = global_prototype_nelements * nvolumes
+
+    order = 3
+    dcoll = create_discretization_collection(actx, volume_to_local_mesh, order=order)
+
+    volume_dds = [
+        DOFDesc(VolumeDomainTag(i), DISCR_TAG_BASE)
+        for i in range(nvolumes)]
+
+    if use_overintegration:
+        quadrature_tag = DISCR_TAG_QUAD
+    else:
+        quadrature_tag = None
+
+    vis_timer = None
+
+    if logmgr:
+        logmgr_add_cl_device_info(logmgr, queue)
+        logmgr_add_device_memory_usage(logmgr, queue)
+
+        def extract_vars(i, dim, cvs, eos):
+            name_to_field = extract_vars_for_logging(dim, cvs[i], eos)
+            return {
+                name + f"_{i}": field
+                for name, field in name_to_field.items()}
+
+        def units(quantity):
+            return ""
+
+        for i in range(nvolumes):
+            logmgr_add_many_discretization_quantities(
+                logmgr, dcoll, dim, partial(extract_vars, i), units,
+                volume_dd=volume_dds[i])
+
+        vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
+        logmgr.add_quantity(vis_timer)
+
+        logmgr.add_watches([
+            ("step.max", "step = {value}, "),
+            ("t_sim.max", "sim time: {value:1.6e} s\n"),
+            ("t_step.max", "------- step walltime: {value:6g} s, "),
+            ("t_log.max", "log walltime: {value:6g} s\n")
+        ])
+
+        for i in range(nvolumes):
+            logmgr.add_watches([
+                (f"min_pressure_{i}", "------- P (vol. " + str(i)
+                    + ") (min, max) (Pa) = ({value:1.9e}, "),
+                (f"max_pressure_{i}",    "{value:1.9e})\n"),
+            ])
+
+    eos = IdealSingleGas()
+    gas_model = GasModel(eos=eos)
+    wall = AdiabaticSlipBoundary()
+    if rst_filename:
+        current_t = restart_data["t"]
+        current_step = restart_data["step"]
+        current_cvs = restart_data["cvs"]
+        if logmgr:
+            from mirgecom.logging_quantities import logmgr_set_time
+            logmgr_set_time(logmgr, current_step, current_t)
+    else:
+        # Set the current state from time 0
+        def init(nodes, pulse_amplitude):
+            vel = np.zeros(shape=(dim,))
+            orig = np.zeros(shape=(dim,))
+            background = Lump(
+                dim=dim, center=orig, velocity=vel, rhoamp=0.0)(nodes)
+            return AcousticPulse(
+                dim=dim,
+                amplitude=pulse_amplitude,
+                width=0.1,
+                center=orig)(x_vec=nodes, cv=background, eos=eos)
+        current_cvs = make_obj_array([
+            init(actx.thaw(dcoll.nodes(dd)), pulse_amplitude)
+            for dd, pulse_amplitude in zip(volume_dds, pulse_amplitudes)])
+
+    current_fluid_states = [make_fluid_state(cv, gas_model) for cv in current_cvs]
+
+    visualizers = [make_visualizer(dcoll, volume_dd=dd) for dd in volume_dds]
+
+    initname = "multiple-volumes"
+    eosname = eos.__class__.__name__
+    init_message = make_init_message(dim=dim, order=order,
+                                     nelements=local_nelements,
+                                     global_nelements=global_nelements,
+                                     dt=current_dt, t_final=t_final, nstatus=nstatus,
+                                     nviz=nviz, cfl=current_cfl,
+                                     constant_cfl=constant_cfl, initname=initname,
+                                     eosname=eosname, casename=casename)
+    if rank == 0:
+        logger.info(init_message)
+
+    def my_get_timestep(step, t, dt, fluid_states):
+        return min([
+            get_sim_timestep(
+                dcoll, fluid_state, t, dt, current_cfl, t_final, constant_cfl)
+            for fluid_state in fluid_states])
+
+    def my_write_viz(step, t, cvs, dvs=None):
+        if dvs is None:
+            dvs = [eos.dependent_vars(cv) for cv in cvs]
+        for i in range(nvolumes):
+            viz_fields = [
+                ("cv", cvs[i]),
+                ("dv", dvs[i])]
+            from mirgecom.simutil import write_visfile
+            write_visfile(
+                dcoll, viz_fields, visualizers[i], vizname=casename + f"-{i}",
+                step=step, t=t, overwrite=True, vis_timer=vis_timer, comm=comm)
+
+    def my_write_restart(step, t, cvs):
+        rst_fname = rst_pattern.format(cname=casename, step=step, rank=rank)
+        if rst_fname != rst_filename:
+            rst_data = {
+                "local_prototype_mesh": local_prototype_mesh,
+                "cvs": cvs,
+                "t": t,
+                "step": step,
+                "order": order,
+                "global_nelements": global_nelements,
+                "num_parts": num_parts
+            }
+            from mirgecom.restart import write_restart_file
+            write_restart_file(actx, rst_data, rst_fname, comm)
+
+    def my_health_check(pressures):
+        health_error = False
+        for dd, pressure in zip(volume_dds, pressures):
+            from mirgecom.simutil import check_naninf_local, check_range_local
+            if check_naninf_local(dcoll, dd, pressure) \
+               or check_range_local(dcoll, dd, pressure, 1e-2, 10):
+                health_error = True
+                logger.info(f"{rank=}: Invalid pressure data found.")
+                break
+        return health_error
+
+    def my_pre_step(step, t, dt, state):
+        cvs = state
+        fluid_states = [make_fluid_state(cv, gas_model) for cv in cvs]
+        dvs = [fluid_state.dv for fluid_state in fluid_states]
+
+        try:
+
+            if logmgr:
+                logmgr.tick_before()
+
+            from mirgecom.simutil import check_step
+            do_viz = check_step(step=step, interval=nviz)
+            do_restart = check_step(step=step, interval=nrestart)
+            do_health = check_step(step=step, interval=nhealth)
+
+            if do_health:
+                pressures = [dv.pressure for dv in dvs]
+                health_errors = global_reduce(my_health_check(pressures), op="lor")
+                if health_errors:
+                    if rank == 0:
+                        logger.info("Fluid solution failed health check.")
+                    raise MyRuntimeError("Failed simulation health check.")
+
+            if do_restart:
+                my_write_restart(step=step, t=t, cvs=cvs)
+
+            if do_viz:
+                my_write_viz(step=step, t=t, cvs=cvs, dvs=dvs)
+
+        except MyRuntimeError:
+            if rank == 0:
+                logger.info("Errors detected; attempting graceful exit.")
+            my_write_viz(step=step, t=t, cvs=cvs)
+            my_write_restart(step=step, t=t, cvs=cvs)
+            raise
+
+        dt = my_get_timestep(step=step, t=t, dt=dt, fluid_states=fluid_states)
+
+        return cvs, dt
+
+    def my_post_step(step, t, dt, state):
+        # Logmgr needs to know about EOS, dt, dim?
+        # imo this is a design/scope flaw
+        if logmgr:
+            set_dt(logmgr, dt)
+            set_sim_state(logmgr, dim, state, eos)
+            logmgr.tick_after()
+        return state, dt
+
+    def my_rhs(t, state):
+        cvs = state
+        fluid_states = [make_fluid_state(cv, gas_model) for cv in cvs]
+        return make_obj_array([
+            euler_operator(
+                dcoll, state=fluid_state, time=t,
+                boundaries={dd.trace(BTAG_ALL).domain_tag: wall},
+                gas_model=gas_model, quadrature_tag=quadrature_tag,
+                volume_dd=dd, comm_tag=dd)
+            for dd, fluid_state in zip(volume_dds, fluid_states)])
+
+    current_dt = my_get_timestep(
+        current_step, current_t, current_dt, current_fluid_states)
+
+    current_step, current_t, current_cvs = \
+        advance_state(rhs=my_rhs, timestepper=timestepper,
+                      pre_step_callback=my_pre_step,
+                      post_step_callback=my_post_step, dt=current_dt,
+                      state=current_cvs, t=current_t, t_final=t_final)
+
+    # Dump the final data
+    if rank == 0:
+        logger.info("Checkpointing final state ...")
+    final_fluid_states = [make_fluid_state(cv, gas_model) for cv in current_cvs]
+    final_dvs = [fluid_state.dv for fluid_state in final_fluid_states]
+
+    my_write_viz(step=current_step, t=current_t, cvs=current_cvs, dvs=final_dvs)
+    my_write_restart(step=current_step, t=current_t, cvs=current_cvs)
+
+    if logmgr:
+        logmgr.close()
+    elif use_profiling:
+        print(actx.tabulate_profiling_data())
+
+    finish_tol = 1e-16
+    assert np.abs(current_t - t_final) < finish_tol
+
+
+if __name__ == "__main__":
+    import argparse
+    casename = "multiple-volumes"
+    parser = argparse.ArgumentParser(description=f"MIRGE-Com Example: {casename}")
+    parser.add_argument("--overintegration", action="store_true",
+        help="use overintegration in the RHS computations")
+    parser.add_argument("--lazy", action="store_true",
+        help="switch to a lazy computation mode")
+    parser.add_argument("--profiling", action="store_true",
+        help="turn on detailed performance profiling")
+    parser.add_argument("--log", action="store_true", default=True,
+        help="turn on logging")
+    parser.add_argument("--leap", action="store_true",
+        help="use leap timestepper")
+    parser.add_argument("--restart_file", help="root name of restart file")
+    parser.add_argument("--casename", help="casename to use for i/o")
+    args = parser.parse_args()
+    lazy = args.lazy
+    if args.profiling:
+        if lazy:
+            raise ValueError("Can't use lazy and profiling together.")
+
+    from grudge.array_context import get_reasonable_array_context_class
+    actx_class = get_reasonable_array_context_class(lazy=lazy, distributed=True)
+
+    logging.basicConfig(format="%(message)s", level=logging.INFO)
+    if args.casename:
+        casename = args.casename
+    rst_filename = None
+    if args.restart_file:
+        rst_filename = args.restart_file
+
+    main(actx_class, use_logmgr=args.log, use_overintegration=args.overintegration,
+         use_leap=args.leap, use_profiling=args.profiling, lazy=lazy,
+         casename=casename, rst_filename=rst_filename)
+
+# vim: foldmethod=marker

--- a/examples/multiple-volumes-mpi.py
+++ b/examples/multiple-volumes-mpi.py
@@ -1,4 +1,9 @@
-"""Demonstrate multiple independent volumes."""
+"""
+Demonstrate multiple non-interacting volumes.
+
+Runs several acoustic pulse simulations with different pulse amplitudes
+simultaneously.
+"""
 
 __copyright__ = """
 Copyright (C) 2020 University of Illinois Board of Trustees

--- a/examples/multiple-volumes-mpi.py
+++ b/examples/multiple-volumes-mpi.py
@@ -41,7 +41,10 @@ from grudge.shortcuts import make_visualizer
 from grudge.dof_desc import VolumeDomainTag, DISCR_TAG_BASE, DISCR_TAG_QUAD, DOFDesc
 
 from mirgecom.discretization import create_discretization_collection
-from mirgecom.euler import euler_operator
+from mirgecom.euler import (
+    euler_operator,
+    extract_vars_for_logging
+)
 from mirgecom.simutil import (
     get_sim_timestep,
     generate_and_distribute_mesh
@@ -61,7 +64,6 @@ from mirgecom.gas_model import (
     make_fluid_state
 )
 from logpyle import IntervalTimer, set_dt
-from mirgecom.euler import extract_vars_for_logging
 from mirgecom.logging_quantities import (
     initialize_logmgr,
     logmgr_add_many_discretization_quantities,

--- a/examples/multiple-volumes-mpi.py
+++ b/examples/multiple-volumes-mpi.py
@@ -187,7 +187,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         for i in range(nvolumes):
             logmgr_add_many_discretization_quantities(
                 logmgr, dcoll, dim, partial(extract_vars, i), units,
-                volume_dd=volume_dds[i])
+                dd=volume_dds[i])
 
         vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
         logmgr.add_quantity(vis_timer)
@@ -349,7 +349,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                 dcoll, state=fluid_state, time=t,
                 boundaries={dd.trace(BTAG_ALL).domain_tag: wall},
                 gas_model=gas_model, quadrature_tag=quadrature_tag,
-                volume_dd=dd, comm_tag=dd)
+                dd=dd, comm_tag=dd)
             for dd, fluid_state in zip(volume_dds, fluid_states)])
 
     current_dt = my_get_timestep(

--- a/examples/nsmix-mpi.py
+++ b/examples/nsmix-mpi.py
@@ -153,9 +153,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
     ones = dcoll.zeros(actx) + 1.0
 

--- a/examples/poiseuille-mpi.py
+++ b/examples/poiseuille-mpi.py
@@ -167,9 +167,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 2
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     if use_overintegration:

--- a/examples/pulse-mpi.py
+++ b/examples/pulse-mpi.py
@@ -152,9 +152,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     if use_overintegration:

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -145,9 +145,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -185,9 +185,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                                      spec_y0s=spec_y0s,
                                      spec_amplitudes=spec_amplitudes)
 
-    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -144,9 +144,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None

--- a/examples/sod-mpi.py
+++ b/examples/sod-mpi.py
@@ -173,9 +173,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     eos = IdealSingleGas()
     gas_model = GasModel(eos=eos)
 
-    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -190,9 +190,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     initializer = Vortex2D(center=orig, velocity=vel)
     gas_model = GasModel(eos=eos)
 
-    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -149,9 +149,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None

--- a/examples/wave-mpi.py
+++ b/examples/wave-mpi.py
@@ -130,9 +130,7 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
 
     order = 3
 
-    dcoll = create_discretization_collection(
-        actx, local_mesh, order=order, mpi_communicator=comm
-    )
+    dcoll = create_discretization_collection(actx, local_mesh, order=order)
     nodes = actx.thaw(dcoll.nodes())
 
     current_cfl = 0.485
@@ -161,8 +159,7 @@ def main(actx_class, snapshot_pattern="wave-mpi-{step:04d}-{rank:04d}.pkl",
         old_order = restart_data["order"]
         if old_order != order:
             old_dcoll = create_discretization_collection(
-                actx, local_mesh, order=old_order, mpi_communicator=comm
-            )
+                actx, local_mesh, order=old_order)
             from meshmode.discretization.connection import make_same_mesh_connection
             connection = make_same_mesh_connection(actx, dcoll.discr_from_dd("vol"),
                                                    old_dcoll.discr_from_dd("vol"))

--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -126,7 +126,6 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from dataclasses import replace
 
 from pytools import memoize_in, keyed_memoize_in
 from functools import partial
@@ -265,8 +264,7 @@ def av_laplacian_operator(dcoll, boundaries, fluid_state, alpha, gas_model=None,
 
     def central_flux_div(utpair):
         dd_trace = utpair.dd
-        dd_allfaces = dd_trace.with_domain_tag(
-            replace(dd_trace.domain_tag, tag=FACE_RESTR_ALL))
+        dd_allfaces = dd_trace.with_boundary_tag(FACE_RESTR_ALL)
         normal = actx.thaw(dcoll.normal(dd_trace))
         return op.project(dcoll, dd_trace, dd_allfaces,
                           # This uses a central vector flux along nhat:

--- a/mirgecom/artificial_viscosity.py
+++ b/mirgecom/artificial_viscosity.py
@@ -145,8 +145,9 @@ from grudge.dof_desc import (
     VolumeDomainTag,
     DISCR_TAG_BASE,
     DISCR_TAG_MODAL,
-    as_dofdesc,
 )
+
+from mirgecom.utils import normalize_boundaries
 
 import grudge.op as op
 
@@ -213,9 +214,7 @@ def av_laplacian_operator(dcoll, boundaries, fluid_state, alpha, gas_model=None,
     :class:`mirgecom.fluid.ConservedVars`
         The artificial viscosity operator applied to *q*.
     """
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     cv = fluid_state.cv
     actx = cv.array_context

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -478,8 +478,7 @@ class PrescribedFluidBoundary(FluidBoundary):
     def av_flux(self, dcoll, dd_bdry, diffusion, **kwargs):
         """Get the diffusive fluxes for the AV operator API."""
         dd_bdry = as_dofdesc(dd_bdry)
-        dd_vol = dd_bdry.untrace()
-        grad_av_minus = op.project(dcoll, dd_vol, dd_bdry, diffusion)
+        grad_av_minus = op.project(dcoll, dd_bdry.untrace(), dd_bdry, diffusion)
         actx = grad_av_minus.mass[0].array_context
         nhat = actx.thaw(dcoll.normal(dd_bdry))
         grad_av_plus = self._bnd_grad_av_func(

--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -36,7 +36,6 @@ THE SOFTWARE.
 import abc
 import numpy as np
 import numpy.linalg as la  # noqa
-from dataclasses import replace
 from pytools.obj_array import make_obj_array, obj_array_vectorize_n_args
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from meshmode.discretization.connection import FACE_RESTR_ALL  # noqa
@@ -51,8 +50,7 @@ def grad_flux(dcoll, u_tpair, *, quadrature_tag=DISCR_TAG_BASE):
 
     dd_trace = u_tpair.dd
     dd_trace_quad = dd_trace.with_discr_tag(quadrature_tag)
-    dd_allfaces_quad = dd_trace_quad.with_domain_tag(
-        replace(dd_trace_quad.domain_tag, tag=FACE_RESTR_ALL))
+    dd_allfaces_quad = dd_trace_quad.with_boundary_tag(FACE_RESTR_ALL)
 
     normal_quad = actx.thaw(dcoll.normal(dd_trace_quad))
 
@@ -73,8 +71,7 @@ def diffusion_flux(
 
     dd_trace = grad_u_tpair.dd
     dd_trace_quad = dd_trace.with_discr_tag(quadrature_tag)
-    dd_allfaces_quad = dd_trace_quad.with_domain_tag(
-        replace(dd_trace_quad.domain_tag, tag=FACE_RESTR_ALL))
+    dd_allfaces_quad = dd_trace_quad.with_boundary_tag(FACE_RESTR_ALL)
 
     normal_quad = actx.thaw(dcoll.normal(dd_trace_quad))
 
@@ -210,8 +207,7 @@ class NeumannDiffusionBoundary(DiffusionBoundary):
             self, dcoll, dd_vol, dd_bdry, kappa, grad_u, *,
             quadrature_tag=DISCR_TAG_BASE):  # noqa: D102
         dd_bdry_quad = dd_bdry.with_discr_tag(quadrature_tag)
-        dd_allfaces_quad = dd_bdry_quad.with_domain_tag(
-            replace(dd_bdry_quad.domain_tag, tag=FACE_RESTR_ALL))
+        dd_allfaces_quad = dd_bdry_quad.with_boundary_tag(FACE_RESTR_ALL)
         # Compute the flux directly instead of constructing an external grad_u value
         # (and the associated TracePair); this approach is simpler in the
         # spatially-varying kappa case (the other approach would result in a

--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -44,7 +44,6 @@ from grudge.dof_desc import (
     DD_VOLUME_ALL,
     VolumeDomainTag,
     DISCR_TAG_BASE,
-    as_dofdesc,
 )
 from grudge.trace_pair import (
     TracePair,
@@ -52,6 +51,7 @@ from grudge.trace_pair import (
     tracepair_with_discr_tag,
 )
 import grudge.op as op
+from mirgecom.utils import normalize_boundaries
 
 
 def grad_facial_flux(u_tpair, normal):
@@ -255,9 +255,7 @@ def grad_operator(
 
     actx = u.array_context
 
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     for bdtag, bdry in boundaries.items():
         if not isinstance(bdry, DiffusionBoundary):
@@ -366,9 +364,7 @@ def diffusion_operator(
 
     actx = u.array_context
 
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     for bdtag, bdry in boundaries.items():
         if not isinstance(bdry, DiffusionBoundary):

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -41,6 +41,12 @@ logger = logging.getLogger(__name__)
 def create_discretization_collection(actx, volume_meshes, order, *,
         mpi_communicator=None, quadrature_order=-1):
     """Create and return a grudge DG discretization collection."""
+    if mpi_communicator is not None:
+        from warnings import warn
+        warn(
+            "mpi_communicator argument is deprecated and will disappear in Q4 2022.",
+            DeprecationWarning, stacklevel=2)
+
     from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
     from grudge.discretization import make_discretization_collection
     from meshmode.discretization.poly_element import (

--- a/mirgecom/discretization.py
+++ b/mirgecom/discretization.py
@@ -38,11 +38,11 @@ logger = logging.getLogger(__name__)
 # we can replace it more easily when we refactor the drivers and
 # examples to use discretization collections, and change it centrally
 # when we want to change it.
-def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None,
-                                     quadrature_order=-1):
+def create_discretization_collection(actx, volume_meshes, order, *,
+        mpi_communicator=None, quadrature_order=-1):
     """Create and return a grudge DG discretization collection."""
     from grudge.dof_desc import DISCR_TAG_BASE, DISCR_TAG_QUAD
-    from grudge.discretization import DiscretizationCollection
+    from grudge.discretization import make_discretization_collection
     from meshmode.discretization.poly_element import (
         QuadratureSimplexGroupFactory,
         PolynomialRecursiveNodesGroupFactory
@@ -51,12 +51,11 @@ def create_discretization_collection(actx, mesh, order, *, mpi_communicator=None
     if quadrature_order < 0:
         quadrature_order = 2*order+1
 
-    return DiscretizationCollection(
-        actx, mesh,
+    return make_discretization_collection(
+        actx, volume_meshes,
         discr_tag_to_group_factory={
             DISCR_TAG_BASE: PolynomialRecursiveNodesGroupFactory(order=order,
                                                                  family="lgl"),
             DISCR_TAG_QUAD: QuadratureSimplexGroupFactory(quadrature_order),
-        },
-        mpi_communicator=mpi_communicator
+        }
     )

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -54,7 +54,8 @@ THE SOFTWARE.
 
 import numpy as np  # noqa
 
-from grudge.dof_desc import DOFDesc
+from meshmode.discretization.connection import FACE_RESTR_ALL
+from grudge.dof_desc import DD_VOLUME_ALL, DISCR_TAG_BASE
 
 from mirgecom.gas_model import make_operator_fluid_states
 from mirgecom.inviscid import (
@@ -68,7 +69,8 @@ from mirgecom.operators import div_operator
 
 def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
                    inviscid_numerical_flux_func=inviscid_facial_flux_rusanov,
-                   quadrature_tag=None, operator_states_quad=None):
+                   quadrature_tag=DISCR_TAG_BASE, volume_dd=DD_VOLUME_ALL,
+                   operator_states_quad=None):
     r"""Compute RHS of the Euler flow equations.
 
     Returns
@@ -91,7 +93,8 @@ def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
 
     boundaries
 
-        Dictionary of boundary functions, one for each valid btag
+        Dictionary of boundary functions, one for each valid
+        :class:`~grudge.dof_desc.BoundaryDomainTag`
 
     time
 
@@ -106,14 +109,17 @@ def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
 
         An optional identifier denoting a particular quadrature
         discretization to use during operator evaluations.
-        The default value is *None*.
+
+    volume_dd: grudge.dof_desc.DOFDesc
+        The DOF descriptor of the volume on which to apply the operator.
     """
-    dd_quad_vol = DOFDesc("vol", quadrature_tag)
-    dd_quad_faces = DOFDesc("all_faces", quadrature_tag)
+    dd_quad_vol = volume_dd.with_discr_tag(quadrature_tag)
+    dd_quad_allfaces = dd_quad_vol.trace(FACE_RESTR_ALL)
 
     if operator_states_quad is None:
         operator_states_quad = make_operator_fluid_states(dcoll, state, gas_model,
-                                                          boundaries, quadrature_tag)
+                                                          boundaries, quadrature_tag,
+                                                          volume_dd=volume_dd)
 
     volume_state_quad, interior_state_pairs_quad, domain_boundary_states_quad = \
         operator_states_quad
@@ -125,9 +131,10 @@ def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
     inviscid_flux_bnd = inviscid_flux_on_element_boundary(
         dcoll, gas_model, boundaries, interior_state_pairs_quad,
         domain_boundary_states_quad, quadrature_tag=quadrature_tag,
-        numerical_flux_func=inviscid_numerical_flux_func, time=time)
+        numerical_flux_func=inviscid_numerical_flux_func, time=time,
+        volume_dd=volume_dd)
 
-    return -div_operator(dcoll, dd_quad_vol, dd_quad_faces,
+    return -div_operator(dcoll, dd_quad_vol, dd_quad_allfaces,
                          inviscid_flux_vol, inviscid_flux_bnd)
 
 

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -117,6 +117,10 @@ def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
     comm_tag: Hashable
         Tag for distributed communication
     """
+    boundaries = {
+        as_dofdesc(bdtag).domain_tag: bdry
+        for bdtag, bdry in boundaries.items()}
+
     dd_quad_vol = volume_dd.with_discr_tag(quadrature_tag)
     dd_quad_allfaces = dd_quad_vol.trace(FACE_RESTR_ALL)
 

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -59,7 +59,6 @@ from grudge.dof_desc import (
     DD_VOLUME_ALL,
     VolumeDomainTag,
     DISCR_TAG_BASE,
-    as_dofdesc,
 )
 
 from mirgecom.gas_model import make_operator_fluid_states
@@ -70,6 +69,7 @@ from mirgecom.inviscid import (
 )
 
 from mirgecom.operators import div_operator
+from mirgecom.utils import normalize_boundaries
 
 
 def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
@@ -125,9 +125,7 @@ def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
 
         Tag for distributed communication
     """
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")

--- a/mirgecom/filter.py
+++ b/mirgecom/filter.py
@@ -46,11 +46,11 @@ THE SOFTWARE.
 """
 
 import numpy as np
-import grudge.dof_desc as dof_desc
+from functools import partial
+
+from grudge.dof_desc import DISCR_TAG_MODAL, as_dofdesc
 
 from arraycontext import map_array_container
-
-from functools import partial
 
 from meshmode.dof_array import DOFArray
 
@@ -205,13 +205,15 @@ def filter_modally(dcoll, dd, cutoff, mode_resp_func, field):
             partial(filter_modally, dcoll, dd, cutoff, mode_resp_func), field
         )
 
-    actx = field.array_context
-    dd = dof_desc.as_dofdesc(dd)
-    dd_modal = dof_desc.DD_VOLUME_MODAL
-    discr = dcoll.discr_from_dd(dd)
+    dd_nodal = as_dofdesc(dd)
+    dd_modal = dd_nodal.with_discr_tag(DISCR_TAG_MODAL)
 
-    modal_map = dcoll.connection_from_dds(dd, dd_modal)
-    nodal_map = dcoll.connection_from_dds(dd_modal, dd)
+    discr = dcoll.discr_from_dd(dd_nodal)
+
+    actx = field.array_context
+
+    modal_map = dcoll.connection_from_dds(dd_nodal, dd_modal)
+    nodal_map = dcoll.connection_from_dds(dd_modal, dd_nodal)
     field = modal_map(field)
     field = apply_spectral_filter(actx, field, discr, cutoff,
                                   mode_resp_func)

--- a/mirgecom/gas_model.py
+++ b/mirgecom/gas_model.py
@@ -63,13 +63,13 @@ from grudge.dof_desc import (
     DD_VOLUME_ALL,
     VolumeDomainTag,
     DISCR_TAG_BASE,
-    as_dofdesc,
 )
 import grudge.op as op
 from grudge.trace_pair import (
     interior_trace_pairs,
     tracepair_with_discr_tag
 )
+from mirgecom.utils import normalize_boundaries
 
 
 @dataclass(frozen=True)
@@ -444,9 +444,7 @@ def make_operator_fluid_states(
         boundary domain tags in *boundaries*, all on the quadrature grid (if
         specified).
     """
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")

--- a/mirgecom/gas_model.py
+++ b/mirgecom/gas_model.py
@@ -63,6 +63,7 @@ from grudge.dof_desc import (
     DD_VOLUME_ALL,
     VolumeDomainTag,
     DISCR_TAG_BASE,
+    as_dofdesc,
 )
 import grudge.op as op
 from grudge.trace_pair import (
@@ -443,6 +444,10 @@ def make_operator_fluid_states(
         boundary domain tags in *boundaries*, all on the quadrature grid (if
         specified).
     """
+    boundaries = {
+        as_dofdesc(bdtag).domain_tag: bdry
+        for bdtag, bdry in boundaries.items()}
+
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")
     if dd.discretization_tag != DISCR_TAG_BASE:

--- a/mirgecom/inviscid.py
+++ b/mirgecom/inviscid.py
@@ -48,6 +48,7 @@ from grudge.dof_desc import (
 )
 import grudge.op as op
 from mirgecom.fluid import make_conserved
+from mirgecom.utils import normalize_boundaries
 
 
 def inviscid_flux(state):
@@ -273,6 +274,8 @@ def inviscid_flux_on_element_boundary(
         the DOF descriptor of the discretization on which the fluid lives. Must be
         a volume on the base discretization.
     """
+    boundaries = normalize_boundaries(boundaries)
+
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")
     if dd.discretization_tag != DISCR_TAG_BASE:

--- a/mirgecom/io.py
+++ b/mirgecom/io.py
@@ -32,6 +32,8 @@ from functools import partial
 import grudge.op as op
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 
+from grudge.dof_desc import DD_VOLUME_ALL
+
 
 def make_init_message(*, dim, order, dt, t_final,
                       nstatus, nviz, cfl, constant_cfl,
@@ -52,11 +54,12 @@ def make_init_message(*, dim, order, dt, t_final,
     )
 
 
-def make_status_message(*, dcoll, t, step, dt, cfl, dependent_vars):
+def make_status_message(
+        *, dcoll, t, step, dt, cfl, dependent_vars, fluid_volume_dd=DD_VOLUME_ALL):
     r"""Make simulation status and health message."""
     dv = dependent_vars
-    _min = partial(op.nodal_min, dcoll, "vol")
-    _max = partial(op.nodal_max, dcoll, "vol")
+    _min = partial(op.nodal_min, dcoll, fluid_volume_dd)
+    _max = partial(op.nodal_max, dcoll, fluid_volume_dd)
     statusmsg = (
         f"Status: {step=} {t=}\n"
         f"------- P({_min(dv.pressure):.3g}, {_max(dv.pressure):.3g})\n"

--- a/mirgecom/io.py
+++ b/mirgecom/io.py
@@ -55,11 +55,11 @@ def make_init_message(*, dim, order, dt, t_final,
 
 
 def make_status_message(
-        *, dcoll, t, step, dt, cfl, dependent_vars, fluid_volume_dd=DD_VOLUME_ALL):
+        *, dcoll, t, step, dt, cfl, dependent_vars, fluid_dd=DD_VOLUME_ALL):
     r"""Make simulation status and health message."""
     dv = dependent_vars
-    _min = partial(op.nodal_min, dcoll, fluid_volume_dd)
-    _max = partial(op.nodal_max, dcoll, fluid_volume_dd)
+    _min = partial(op.nodal_min, dcoll, fluid_dd)
+    _max = partial(op.nodal_max, dcoll, fluid_dd)
     statusmsg = (
         f"Status: {step=} {t=}\n"
         f"------- P({_min(dv.pressure):.3g}, {_max(dv.pressure):.3g})\n"

--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -50,6 +50,7 @@ import pyopencl as cl
 from typing import Optional, Callable
 import numpy as np
 
+from grudge.dof_desc import DD_VOLUME_ALL
 import grudge.op as oper
 
 
@@ -102,24 +103,23 @@ def logmgr_add_device_memory_usage(logmgr: LogManager, queue: cl.CommandQueue):
 
 
 def logmgr_add_many_discretization_quantities(logmgr: LogManager, dcoll, dim,
-      extract_vars_for_logging, units_for_logging):
+        extract_vars_for_logging, units_for_logging, volume_dd=DD_VOLUME_ALL):
     """Add default discretization quantities to the logmgr."""
     for reduction_op in ["min", "max", "L2_norm"]:
         for quantity in ["pressure", "temperature"]:
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, quantity, reduction_op, extract_vars_for_logging,
-                units_for_logging))
+                units_for_logging, volume_dd=volume_dd))
 
         for quantity in ["mass", "energy"]:
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, quantity, reduction_op, extract_vars_for_logging,
-                units_for_logging))
+                units_for_logging, volume_dd=volume_dd))
 
         for d in range(dim):
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, "momentum", reduction_op, extract_vars_for_logging,
-                units_for_logging,
-                axis=d))
+                units_for_logging, axis=d, volume_dd=volume_dd))
 
 
 # {{{ Package versions
@@ -245,7 +245,7 @@ class DiscretizationBasedQuantity(PostLogQuantity, StateConsumer):
 
     def __init__(self, dcoll: DiscretizationCollection, quantity: str, op: str,
                  extract_vars_for_logging, units_logging, name: str = None,
-                 axis: Optional[int] = None):
+                 axis: Optional[int] = None, volume_dd=DD_VOLUME_ALL):
         unit = units_logging(quantity)
 
         if name is None:
@@ -262,13 +262,13 @@ class DiscretizationBasedQuantity(PostLogQuantity, StateConsumer):
         from functools import partial
 
         if op == "min":
-            self._discr_reduction = partial(oper.nodal_min, self.dcoll, "vol")
+            self._discr_reduction = partial(oper.nodal_min, self.dcoll, volume_dd)
             self.rank_aggr = min
         elif op == "max":
-            self._discr_reduction = partial(oper.nodal_max, self.dcoll, "vol")
+            self._discr_reduction = partial(oper.nodal_max, self.dcoll, volume_dd)
             self.rank_aggr = max
         elif op == "L2_norm":
-            self._discr_reduction = partial(oper.norm, self.dcoll, p=2)
+            self._discr_reduction = partial(oper.norm, self.dcoll, p=2, dd=volume_dd)
             self.rank_aggr = max
         else:
             raise ValueError(f"unknown operation {op}")

--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -105,20 +105,25 @@ def logmgr_add_device_memory_usage(logmgr: LogManager, queue: cl.CommandQueue):
 def logmgr_add_many_discretization_quantities(logmgr: LogManager, dcoll, dim,
         extract_vars_for_logging, units_for_logging, volume_dd=DD_VOLUME_ALL):
     """Add default discretization quantities to the logmgr."""
+    if volume_dd != DD_VOLUME_ALL:
+        suffix = f"_{volume_dd.domain_tag.tag}"
+    else:
+        suffix = ""
+
     for reduction_op in ["min", "max", "L2_norm"]:
-        for quantity in ["pressure", "temperature"]:
+        for quantity in ["pressure"+suffix, "temperature"+suffix]:
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, quantity, reduction_op, extract_vars_for_logging,
                 units_for_logging, volume_dd=volume_dd))
 
-        for quantity in ["mass", "energy"]:
+        for quantity in ["mass"+suffix, "energy"+suffix]:
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, quantity, reduction_op, extract_vars_for_logging,
                 units_for_logging, volume_dd=volume_dd))
 
         for d in range(dim):
             logmgr.add_quantity(DiscretizationBasedQuantity(
-                dcoll, "momentum", reduction_op, extract_vars_for_logging,
+                dcoll, "momentum"+suffix, reduction_op, extract_vars_for_logging,
                 units_for_logging, axis=d, volume_dd=volume_dd))
 
 

--- a/mirgecom/logging_quantities.py
+++ b/mirgecom/logging_quantities.py
@@ -103,10 +103,10 @@ def logmgr_add_device_memory_usage(logmgr: LogManager, queue: cl.CommandQueue):
 
 
 def logmgr_add_many_discretization_quantities(logmgr: LogManager, dcoll, dim,
-        extract_vars_for_logging, units_for_logging, volume_dd=DD_VOLUME_ALL):
+        extract_vars_for_logging, units_for_logging, dd=DD_VOLUME_ALL):
     """Add default discretization quantities to the logmgr."""
-    if volume_dd != DD_VOLUME_ALL:
-        suffix = f"_{volume_dd.domain_tag.tag}"
+    if dd != DD_VOLUME_ALL:
+        suffix = f"_{dd.domain_tag.tag}"
     else:
         suffix = ""
 
@@ -114,17 +114,17 @@ def logmgr_add_many_discretization_quantities(logmgr: LogManager, dcoll, dim,
         for quantity in ["pressure"+suffix, "temperature"+suffix]:
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, quantity, reduction_op, extract_vars_for_logging,
-                units_for_logging, volume_dd=volume_dd))
+                units_for_logging, dd=dd))
 
         for quantity in ["mass"+suffix, "energy"+suffix]:
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, quantity, reduction_op, extract_vars_for_logging,
-                units_for_logging, volume_dd=volume_dd))
+                units_for_logging, dd=dd))
 
         for d in range(dim):
             logmgr.add_quantity(DiscretizationBasedQuantity(
                 dcoll, "momentum"+suffix, reduction_op, extract_vars_for_logging,
-                units_for_logging, axis=d, volume_dd=volume_dd))
+                units_for_logging, axis=d, dd=dd))
 
 
 # {{{ Package versions
@@ -250,7 +250,7 @@ class DiscretizationBasedQuantity(PostLogQuantity, StateConsumer):
 
     def __init__(self, dcoll: DiscretizationCollection, quantity: str, op: str,
                  extract_vars_for_logging, units_logging, name: str = None,
-                 axis: Optional[int] = None, volume_dd=DD_VOLUME_ALL):
+                 axis: Optional[int] = None, dd=DD_VOLUME_ALL):
         unit = units_logging(quantity)
 
         if name is None:
@@ -267,13 +267,13 @@ class DiscretizationBasedQuantity(PostLogQuantity, StateConsumer):
         from functools import partial
 
         if op == "min":
-            self._discr_reduction = partial(oper.nodal_min, self.dcoll, volume_dd)
+            self._discr_reduction = partial(oper.nodal_min, self.dcoll, dd)
             self.rank_aggr = min
         elif op == "max":
-            self._discr_reduction = partial(oper.nodal_max, self.dcoll, volume_dd)
+            self._discr_reduction = partial(oper.nodal_max, self.dcoll, dd)
             self.rank_aggr = max
         elif op == "L2_norm":
-            self._discr_reduction = partial(oper.norm, self.dcoll, p=2, dd=volume_dd)
+            self._discr_reduction = partial(oper.norm, self.dcoll, p=2, dd=dd)
             self.rank_aggr = max
         else:
             raise ValueError(f"unknown operation {op}")

--- a/mirgecom/navierstokes.py
+++ b/mirgecom/navierstokes.py
@@ -57,7 +57,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from dataclasses import replace
 from functools import partial
 
 from meshmode.discretization.connection import FACE_RESTR_ALL
@@ -106,8 +105,7 @@ def _gradient_flux_interior(dcoll, numerical_flux_func, tpair):
     from arraycontext import outer
     actx = tpair.int.array_context
     dd_trace = tpair.dd
-    dd_allfaces = dd_trace.with_domain_tag(
-        replace(dd_trace.domain_tag, tag=FACE_RESTR_ALL))
+    dd_allfaces = dd_trace.with_boundary_tag(FACE_RESTR_ALL)
     normal = actx.thaw(dcoll.normal(dd_trace))
     flux = outer(numerical_flux_func(tpair.int, tpair.ext), normal)
     return op.project(dcoll, dd_trace, dd_allfaces, flux)

--- a/mirgecom/navierstokes.py
+++ b/mirgecom/navierstokes.py
@@ -70,7 +70,6 @@ from grudge.dof_desc import (
     DD_VOLUME_ALL,
     VolumeDomainTag,
     DISCR_TAG_BASE,
-    as_dofdesc,
 )
 
 import grudge.op as op
@@ -91,6 +90,7 @@ from mirgecom.operators import (
     div_operator, grad_operator
 )
 from mirgecom.gas_model import make_operator_fluid_states
+from mirgecom.utils import normalize_boundaries
 
 
 class _NSGradCVTag:
@@ -163,9 +163,7 @@ def grad_cv_operator(
         CV object with vector components representing the gradient of the fluid
         conserved variables.
     """
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")
@@ -266,9 +264,7 @@ def grad_t_operator(
         Array of :class:`~meshmode.dof_array.DOFArray` representing the gradient of
         the fluid temperature.
     """
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")
@@ -414,9 +410,7 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
     if not state.is_viscous:
         raise ValueError("Navier-Stokes operator expects viscous gas model.")
 
-    boundaries = {
-        as_dofdesc(bdtag).domain_tag: bdry
-        for bdtag, bdry in boundaries.items()}
+    boundaries = normalize_boundaries(boundaries)
 
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")

--- a/mirgecom/navierstokes.py
+++ b/mirgecom/navierstokes.py
@@ -57,14 +57,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from dataclasses import replace
 from functools import partial
+
+from meshmode.discretization.connection import FACE_RESTR_ALL
 
 from grudge.trace_pair import (
     TracePair,
     interior_trace_pairs,
     tracepair_with_discr_tag
 )
-from grudge.dof_desc import DOFDesc, as_dofdesc, DISCR_TAG_BASE
+from grudge.dof_desc import (
+    DD_VOLUME_ALL,
+    DISCR_TAG_BASE,
+    as_dofdesc,
+)
 
 import grudge.op as op
 
@@ -98,16 +105,18 @@ def _gradient_flux_interior(dcoll, numerical_flux_func, tpair):
     """Compute interior face flux for gradient operator."""
     from arraycontext import outer
     actx = tpair.int.array_context
-    dd = tpair.dd
-    normal = actx.thaw(dcoll.normal(dd))
+    dd_trace = tpair.dd
+    dd_allfaces = dd_trace.with_domain_tag(
+        replace(dd_trace.domain_tag, tag=FACE_RESTR_ALL))
+    normal = actx.thaw(dcoll.normal(dd_trace))
     flux = outer(numerical_flux_func(tpair.int, tpair.ext), normal)
-    return op.project(dcoll, dd, dd.with_dtag("all_faces"), flux)
+    return op.project(dcoll, dd_trace, dd_allfaces, flux)
 
 
 def grad_cv_operator(
         dcoll, gas_model, boundaries, state, *, time=0.0,
         numerical_flux_func=num_flux_central,
-        quadrature_tag=DISCR_TAG_BASE,
+        quadrature_tag=DISCR_TAG_BASE, volume_dd=DD_VOLUME_ALL,
         # Added to avoid repeated computation
         # FIXME: See if there's a better way to do this
         operator_states_quad=None):
@@ -121,7 +130,8 @@ def grad_cv_operator(
         quantities.
 
     boundaries
-        Dictionary of boundary functions keyed by btags
+        Dictionary of boundary functions, one for each valid
+        :class:`~grudge.dof_desc.BoundaryDomainTag`
 
     time
         Time
@@ -140,6 +150,9 @@ def grad_cv_operator(
         An identifier denoting a particular quadrature discretization to use during
         operator evaluations.
 
+    volume_dd: grudge.dof_desc.DOFDesc
+        The DOF descriptor of the volume on which to apply the operator.
+
     Returns
     -------
     :class:`~mirgecom.fluid.ConservedVars`
@@ -147,12 +160,18 @@ def grad_cv_operator(
         CV object with vector components representing the gradient of the fluid
         conserved variables.
     """
-    dd_vol_quad = DOFDesc("vol", quadrature_tag)
-    dd_faces_quad = DOFDesc("all_faces", quadrature_tag)
+    boundaries = {
+        as_dofdesc(bdtag).domain_tag: bdry
+        for bdtag, bdry in boundaries.items()}
+
+    dd_vol_base = volume_dd
+    dd_vol_quad = dd_vol_base.with_discr_tag(quadrature_tag)
+    dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
 
     if operator_states_quad is None:
         operator_states_quad = make_operator_fluid_states(
-            dcoll, state, gas_model, boundaries, quadrature_tag)
+            dcoll, state, gas_model, boundaries, quadrature_tag,
+            volume_dd=dd_vol_base)
 
     vol_state_quad, inter_elem_bnd_states_quad, domain_bnd_states_quad = \
         operator_states_quad
@@ -169,18 +188,16 @@ def grad_cv_operator(
 
         # Domain boundaries
         sum(op.project(
-            dcoll, as_dofdesc(btag).with_discr_tag(quadrature_tag),
-            as_dofdesc(btag).with_discr_tag(quadrature_tag).with_dtag("all_faces"),
+            dcoll, dd_vol_quad.with_domain_tag(bdtag),
+            dd_allfaces_quad,
             bdry.cv_gradient_flux(
                 dcoll,
-                # Make sure we get the state on the quadrature grid
-                # restricted to the tag *btag*
-                as_dofdesc(btag).with_discr_tag(quadrature_tag),
+                dd_vol_quad.with_domain_tag(bdtag),
                 gas_model=gas_model,
-                state_minus=domain_bnd_states_quad[btag],
+                state_minus=domain_bnd_states_quad[bdtag],
                 time=time,
                 numerical_flux_func=numerical_flux_func))
-            for btag, bdry in boundaries.items())
+            for bdtag, bdry in boundaries.items())
 
         # Interior boundaries
         + sum(get_interior_flux(tpair) for tpair in cv_interior_pairs)
@@ -188,13 +205,13 @@ def grad_cv_operator(
 
     # [Bassi_1997]_ eqn 15 (s = grad_q)
     return grad_operator(
-        dcoll, dd_vol_quad, dd_faces_quad, vol_state_quad.cv, cv_flux_bnd)
+        dcoll, dd_vol_quad, dd_allfaces_quad, vol_state_quad.cv, cv_flux_bnd)
 
 
 def grad_t_operator(
         dcoll, gas_model, boundaries, state, *, time=0.0,
         numerical_flux_func=num_flux_central,
-        quadrature_tag=DISCR_TAG_BASE,
+        quadrature_tag=DISCR_TAG_BASE, volume_dd=DD_VOLUME_ALL,
         # Added to avoid repeated computation
         # FIXME: See if there's a better way to do this
         operator_states_quad=None):
@@ -227,6 +244,9 @@ def grad_t_operator(
         An identifier denoting a particular quadrature discretization to use during
         operator evaluations.
 
+    volume_dd: grudge.dof_desc.DOFDesc
+        The DOF descriptor of the volume on which to apply the operator.
+
     Returns
     -------
     :class:`numpy.ndarray`
@@ -234,12 +254,18 @@ def grad_t_operator(
         Array of :class:`~meshmode.dof_array.DOFArray` representing the gradient of
         the fluid temperature.
     """
-    dd_vol_quad = DOFDesc("vol", quadrature_tag)
-    dd_faces_quad = DOFDesc("all_faces", quadrature_tag)
+    boundaries = {
+        as_dofdesc(bdtag).domain_tag: bdry
+        for bdtag, bdry in boundaries.items()}
+
+    dd_vol_base = volume_dd
+    dd_vol_quad = dd_vol_base.with_discr_tag(quadrature_tag)
+    dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
 
     if operator_states_quad is None:
         operator_states_quad = make_operator_fluid_states(
-            dcoll, state, gas_model, boundaries, quadrature_tag)
+            dcoll, state, gas_model, boundaries, quadrature_tag,
+            volume_dd=dd_vol_base)
 
     vol_state_quad, inter_elem_bnd_states_quad, domain_bnd_states_quad = \
         operator_states_quad
@@ -260,18 +286,16 @@ def grad_t_operator(
 
         # Domain boundaries
         sum(op.project(
-            dcoll, as_dofdesc(btag).with_discr_tag(quadrature_tag),
-            as_dofdesc(btag).with_discr_tag(quadrature_tag).with_dtag("all_faces"),
+            dcoll, dd_vol_quad.with_domain_tag(bdtag),
+            dd_allfaces_quad,
             bdry.temperature_gradient_flux(
                 dcoll,
-                # Make sure we get the state on the quadrature grid
-                # restricted to the tag *btag*
-                as_dofdesc(btag).with_discr_tag(quadrature_tag),
+                dd_vol_quad.with_domain_tag(bdtag),
                 gas_model=gas_model,
-                state_minus=domain_bnd_states_quad[btag],
+                state_minus=domain_bnd_states_quad[bdtag],
                 time=time,
                 numerical_flux_func=numerical_flux_func))
-            for btag, bdry in boundaries.items())
+            for bdtag, bdry in boundaries.items())
 
         # Interior boundaries
         + sum(get_interior_flux(tpair) for tpair in t_interior_pairs)
@@ -279,14 +303,15 @@ def grad_t_operator(
 
     # Fluxes in-hand, compute the gradient of temperature
     return grad_operator(
-        dcoll, dd_vol_quad, dd_faces_quad, vol_state_quad.temperature, t_flux_bnd)
+        dcoll, dd_vol_quad, dd_allfaces_quad, vol_state_quad.temperature, t_flux_bnd)
 
 
 def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
                 inviscid_numerical_flux_func=inviscid_facial_flux_rusanov,
                 gradient_numerical_flux_func=num_flux_central,
                 viscous_numerical_flux_func=viscous_facial_flux_central,
-                quadrature_tag=DISCR_TAG_BASE, return_gradients=False,
+                return_gradients=False, quadrature_tag=DISCR_TAG_BASE,
+                volume_dd=DD_VOLUME_ALL,
                 # Added to avoid repeated computation
                 # FIXME: See if there's a better way to do this
                 operator_states_quad=None,
@@ -325,9 +350,17 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
        Optional callable function to return the numerical flux to be used when
        computing gradients in the Navier-Stokes operator.
 
+    return_gradients
+        Optional boolean (defaults to false) indicating whether to return
+        $\nabla(\text{CV})$ and $\nabla(T)$ along with the RHS for the Navier-Stokes
+        equations.  Useful for debugging and visualization.
+
     quadrature_tag
         An identifier denoting a particular quadrature discretization to use during
         operator evaluations.
+
+    volume_dd: grudge.dof_desc.DOFDesc
+        The DOF descriptor of the volume on which to apply the operator.
 
     operator_states_quad
         Optional iterable container providing the full fluid states
@@ -347,11 +380,6 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
         provided, the operator will calculate it with
         :func:`~mirgecom.navierstokes.grad_t_operator`.
 
-    return_gradients
-        Optional boolean (defaults to false) indicating whether to return
-        $\nabla(\text{CV})$ and $\nabla(T)$ along with the RHS for the Navier-Stokes
-        equations.  Useful for debugging and visualization.
-
     Returns
     -------
     :class:`mirgecom.fluid.ConservedVars`
@@ -365,9 +393,13 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
     if not state.is_viscous:
         raise ValueError("Navier-Stokes operator expects viscous gas model.")
 
-    dd_base = as_dofdesc("vol")
-    dd_vol_quad = DOFDesc("vol", quadrature_tag)
-    dd_faces_quad = DOFDesc("all_faces", quadrature_tag)
+    boundaries = {
+        as_dofdesc(bdtag).domain_tag: bdry
+        for bdtag, bdry in boundaries.items()}
+
+    dd_vol_base = volume_dd
+    dd_vol_quad = dd_vol_base.with_discr_tag(quadrature_tag)
+    dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
 
     # Make model-consistent fluid state data (i.e. CV *and* DV) for:
     # - Volume: vol_state_quad
@@ -378,7 +410,8 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
     # otherwise they stay on the interpolatory/base domain.
     if operator_states_quad is None:
         operator_states_quad = make_operator_fluid_states(
-            dcoll, state, gas_model, boundaries, quadrature_tag)
+            dcoll, state, gas_model, boundaries, quadrature_tag,
+            volume_dd=dd_vol_base)
 
     vol_state_quad, inter_elem_bnd_states_quad, domain_bnd_states_quad = \
         operator_states_quad
@@ -396,7 +429,7 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
         grad_cv = grad_cv_operator(
             dcoll, gas_model, boundaries, state, time=time,
             numerical_flux_func=gradient_numerical_flux_func,
-            quadrature_tag=quadrature_tag,
+            quadrature_tag=quadrature_tag, volume_dd=dd_vol_base,
             operator_states_quad=operator_states_quad)
 
     # Communicate grad(CV) and put it on the quadrature domain
@@ -404,7 +437,8 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
         # Get the interior trace pairs onto the surface quadrature
         # discretization (if any)
         interp_to_surf_quad(tpair=tpair)
-        for tpair in interior_trace_pairs(dcoll, grad_cv, tag=_NSGradCVTag)
+        for tpair in interior_trace_pairs(
+            dcoll, grad_cv, volume_dd=dd_vol_base, tag=_NSGradCVTag)
     ]
 
     # }}} Compute grad(CV)
@@ -415,7 +449,7 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
         grad_t = grad_t_operator(
             dcoll, gas_model, boundaries, state, time=time,
             numerical_flux_func=gradient_numerical_flux_func,
-            quadrature_tag=quadrature_tag,
+            quadrature_tag=quadrature_tag, volume_dd=dd_vol_base,
             operator_states_quad=operator_states_quad)
 
     # Create the interior face trace pairs, perform MPI exchange, interp to quad
@@ -423,7 +457,8 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
         # Get the interior trace pairs onto the surface quadrature
         # discretization (if any)
         interp_to_surf_quad(tpair=tpair)
-        for tpair in interior_trace_pairs(dcoll, grad_t, tag=_NSGradTemperatureTag)
+        for tpair in interior_trace_pairs(
+            dcoll, grad_t, volume_dd=dd_vol_base, tag=_NSGradTemperatureTag)
     ]
 
     # }}} compute grad(temperature)
@@ -437,8 +472,8 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
         # using field values on the quadrature grid
         viscous_flux(state=vol_state_quad,
                      # Interpolate gradients to the quadrature grid
-                     grad_cv=op.project(dcoll, dd_base, dd_vol_quad, grad_cv),
-                     grad_t=op.project(dcoll, dd_base, dd_vol_quad, grad_t))
+                     grad_cv=op.project(dcoll, dd_vol_base, dd_vol_quad, grad_cv),
+                     grad_t=op.project(dcoll, dd_vol_base, dd_vol_quad, grad_t))
 
         # Compute the volume contribution of the inviscid flux terms
         # using field values on the quadrature grid
@@ -453,16 +488,18 @@ def ns_operator(dcoll, gas_model, state, boundaries, *, time=0.0,
             dcoll, gas_model, boundaries, inter_elem_bnd_states_quad,
             domain_bnd_states_quad, grad_cv, grad_cv_interior_pairs,
             grad_t, grad_t_interior_pairs, quadrature_tag=quadrature_tag,
-            numerical_flux_func=viscous_numerical_flux_func, time=time)
+            numerical_flux_func=viscous_numerical_flux_func, time=time,
+            volume_dd=dd_vol_base)
 
         # All surface contributions from the inviscid fluxes
         - inviscid_flux_on_element_boundary(
             dcoll, gas_model, boundaries, inter_elem_bnd_states_quad,
             domain_bnd_states_quad, quadrature_tag=quadrature_tag,
-            numerical_flux_func=inviscid_numerical_flux_func, time=time)
+            numerical_flux_func=inviscid_numerical_flux_func, time=time,
+            volume_dd=dd_vol_base)
 
     )
-    ns_rhs = div_operator(dcoll, dd_vol_quad, dd_faces_quad, vol_term, bnd_term)
+    ns_rhs = div_operator(dcoll, dd_vol_quad, dd_allfaces_quad, vol_term, bnd_term)
     if return_gradients:
         return ns_rhs, grad_cv, grad_t
     return ns_rhs

--- a/mirgecom/operators.py
+++ b/mirgecom/operators.py
@@ -30,6 +30,8 @@ THE SOFTWARE.
 
 import grudge.op as op
 
+from grudge.dof_desc import DISCR_TAG_BASE
+
 
 def grad_operator(dcoll, dd_vol, dd_faces, u, flux):
     r"""Compute a DG gradient for the input *u* with flux given by *flux*.
@@ -57,7 +59,8 @@ def grad_operator(dcoll, dd_vol, dd_faces, u, flux):
         the dg gradient operator applied to *u*
     """
     # pylint: disable=invalid-unary-operand-type
-    return - op.inverse_mass(dcoll,
+    return -op.inverse_mass(
+        dcoll, dd_vol.with_discr_tag(DISCR_TAG_BASE),
         op.weak_local_grad(dcoll, dd_vol, u)
         - op.face_mass(dcoll, dd_faces, flux))
 
@@ -88,6 +91,7 @@ def div_operator(dcoll, dd_vol, dd_faces, v, flux):
         the dg divergence operator applied to vector-valued function(s) *v*.
     """
     # pylint: disable=invalid-unary-operand-type
-    return - op.inverse_mass(dcoll,
+    return -op.inverse_mass(
+        dcoll, dd_vol.with_discr_tag(DISCR_TAG_BASE),
         op.weak_local_div(dcoll, dd_vol, v)
         - op.face_mass(dcoll, dd_faces, flux))

--- a/mirgecom/operators.py
+++ b/mirgecom/operators.py
@@ -33,7 +33,7 @@ import grudge.op as op
 from grudge.dof_desc import DISCR_TAG_BASE
 
 
-def grad_operator(dcoll, dd_vol, dd_faces, u, flux):
+def grad_operator(dcoll, dd_vol, dd_allfaces, u, flux):
     r"""Compute a DG gradient for the input *u* with flux given by *flux*.
 
     Parameters
@@ -43,7 +43,7 @@ def grad_operator(dcoll, dd_vol, dd_faces, u, flux):
     dd_vol: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the volume discretization.
         This determines the type of quadrature to be used.
-    dd_faces: grudge.dof_desc.DOFDesc
+    dd_allfaces: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the surface discretization.
         This determines the type of quadrature to be used.
     u: meshmode.dof_array.DOFArray or numpy.ndarray
@@ -62,10 +62,10 @@ def grad_operator(dcoll, dd_vol, dd_faces, u, flux):
     return -op.inverse_mass(
         dcoll, dd_vol.with_discr_tag(DISCR_TAG_BASE),
         op.weak_local_grad(dcoll, dd_vol, u)
-        - op.face_mass(dcoll, dd_faces, flux))
+        - op.face_mass(dcoll, dd_allfaces, flux))
 
 
-def div_operator(dcoll, dd_vol, dd_faces, v, flux):
+def div_operator(dcoll, dd_vol, dd_allfaces, v, flux):
     r"""Compute DG divergence of vector-valued func *v* with flux given by *flux*.
 
     Parameters
@@ -75,7 +75,7 @@ def div_operator(dcoll, dd_vol, dd_faces, v, flux):
     dd_vol: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the volume discretization.
         This determines the type of quadrature to be used.
-    dd_faces: grudge.dof_desc.DOFDesc
+    dd_allfaces: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the surface discretization.
         This determines the type of quadrature to be used.
     v: numpy.ndarray
@@ -94,4 +94,4 @@ def div_operator(dcoll, dd_vol, dd_faces, v, flux):
     return -op.inverse_mass(
         dcoll, dd_vol.with_discr_tag(DISCR_TAG_BASE),
         op.weak_local_div(dcoll, dd_vol, v)
-        - op.face_mass(dcoll, dd_faces, flux))
+        - op.face_mass(dcoll, dd_allfaces, flux))

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -94,7 +94,7 @@ def check_step(step, interval):
 
 def get_sim_timestep(
         dcoll, state, t, dt, cfl, t_final, constant_cfl=False,
-        fluid_volume_dd=DD_VOLUME_ALL):
+        fluid_dd=DD_VOLUME_ALL):
     """Return the maximum stable timestep for a typical fluid simulation.
 
     This routine returns *dt*, the users defined constant timestep, or *max_dt*, the
@@ -125,6 +125,9 @@ def get_sim_timestep(
         The current CFL number
     constant_cfl: bool
         True if running constant CFL mode
+    fluid_dd: grudge.dof_desc.DOFDesc
+        the DOF descriptor of the discretization on which *state* lives. Must be a
+        volume on the base discretization.
 
     Returns
     -------
@@ -138,7 +141,7 @@ def get_sim_timestep(
         from grudge.op import nodal_min
         mydt = state.array_context.to_numpy(
             cfl * nodal_min(
-                dcoll, fluid_volume_dd,
+                dcoll, fluid_dd,
                 get_viscous_timestep(dcoll=dcoll, state=state)))[()]
     return min(t_remaining, mydt)
 

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -66,6 +66,7 @@ from meshmode.dof_array import DOFArray
 
 from typing import List, Dict
 from grudge.discretization import DiscretizationCollection
+from grudge.dof_desc import DD_VOLUME_ALL
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +92,9 @@ def check_step(step, interval):
     return False
 
 
-def get_sim_timestep(dcoll, state, t, dt, cfl, t_final, constant_cfl=False):
+def get_sim_timestep(
+        dcoll, state, t, dt, cfl, t_final, constant_cfl=False,
+        fluid_volume_dd=DD_VOLUME_ALL):
     """Return the maximum stable timestep for a typical fluid simulation.
 
     This routine returns *dt*, the users defined constant timestep, or *max_dt*, the
@@ -135,7 +138,7 @@ def get_sim_timestep(dcoll, state, t, dt, cfl, t_final, constant_cfl=False):
         from grudge.op import nodal_min
         mydt = state.array_context.to_numpy(
             cfl * nodal_min(
-                dcoll, "vol",
+                dcoll, fluid_volume_dd,
                 get_viscous_timestep(dcoll=dcoll, state=state)))[()]
     return min(t_remaining, mydt)
 
@@ -335,7 +338,7 @@ def check_naninf_local(dcoll: DiscretizationCollection, dd: str,
     return not np.isfinite(s)
 
 
-def compare_fluid_solutions(dcoll, red_state, blue_state):
+def compare_fluid_solutions(dcoll, red_state, blue_state, *, dd=DD_VOLUME_ALL):
     """Return inf norm of (*red_state* - *blue_state*) for each component.
 
     .. note::
@@ -344,12 +347,12 @@ def compare_fluid_solutions(dcoll, red_state, blue_state):
     actx = red_state.array_context
     resid = red_state - blue_state
     resid_errs = actx.to_numpy(
-        flatten(componentwise_norms(dcoll, resid, order=np.inf), actx))
+        flatten(componentwise_norms(dcoll, resid, order=np.inf, dd=dd), actx))
 
     return resid_errs.tolist()
 
 
-def componentwise_norms(dcoll, fields, order=np.inf):
+def componentwise_norms(dcoll, fields, order=np.inf, *, dd=DD_VOLUME_ALL):
     """Return the *order*-norm for each component of *fields*.
 
     .. note::
@@ -357,15 +360,15 @@ def componentwise_norms(dcoll, fields, order=np.inf):
     """
     if not isinstance(fields, DOFArray):
         return map_array_container(
-            partial(componentwise_norms, dcoll, order=order), fields)
+            partial(componentwise_norms, dcoll, order=order, dd=dd), fields)
     if len(fields) > 0:
-        return op.norm(dcoll, fields, order)
+        return op.norm(dcoll, fields, order, dd=dd)
     else:
         # FIXME: This work-around for #575 can go away after #569
         return 0
 
 
-def max_component_norm(dcoll, fields, order=np.inf):
+def max_component_norm(dcoll, fields, order=np.inf, *, dd=DD_VOLUME_ALL):
     """Return the max *order*-norm over the components of *fields*.
 
     .. note::
@@ -373,7 +376,7 @@ def max_component_norm(dcoll, fields, order=np.inf):
     """
     actx = fields.array_context
     return max(actx.to_numpy(flatten(
-        componentwise_norms(dcoll, fields, order), actx)))
+        componentwise_norms(dcoll, fields, order, dd=dd), actx)))
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/mirgecom/utils.py
+++ b/mirgecom/utils.py
@@ -3,6 +3,7 @@
 .. autoclass:: StatisticsAccumulator
 .. autofunction:: asdict_shallow
 .. autofunction:: force_evaluation
+.. autofunction:: normalize_boundaries
 """
 
 __copyright__ = """
@@ -117,3 +118,15 @@ def force_evaluation(actx, x):
     if actx is None:
         return x
     return actx.freeze_thaw(x)
+
+
+def normalize_boundaries(boundaries):
+    """
+    Normalize the keys of *boundaries*.
+
+    Promotes boundary tags to :class:`grudge.dof_desc.BoundaryDomainTag`.
+    """
+    from grudge.dof_desc import as_dofdesc
+    return {
+        as_dofdesc(key).domain_tag: bdry
+        for key, bdry in boundaries.items()}

--- a/mirgecom/viscous.py
+++ b/mirgecom/viscous.py
@@ -60,6 +60,8 @@ from mirgecom.fluid import (
     make_conserved
 )
 
+from mirgecom.utils import normalize_boundaries
+
 
 # low level routine works with numpy arrays and can be tested without
 # a full grid + fluid state, etc
@@ -395,6 +397,8 @@ def viscous_flux_on_element_boundary(
         the DOF descriptor of the discretization on which the fluid lives. Must be
         a volume on the base discretization.
     """
+    boundaries = normalize_boundaries(boundaries)
+
     if not isinstance(dd.domain_tag, VolumeDomainTag):
         raise TypeError("dd must represent a volume")
     if dd.discretization_tag != DISCR_TAG_BASE:

--- a/mirgecom/wave.py
+++ b/mirgecom/wave.py
@@ -88,8 +88,8 @@ def wave_operator(dcoll, c, w):
     return (
         op.inverse_mass(dcoll,
             flat_obj_array(
-                -c*op.weak_local_div(dcoll, "vol", v),
-                -c*op.weak_local_grad(dcoll, "vol", u)
+                -c*op.weak_local_div(dcoll, v),
+                -c*op.weak_local_grad(dcoll, u)
                 )
             +  # noqa: W504
             op.face_mass(dcoll,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ pyyaml
 --editable git+https://github.com/inducer/dagrt.git#egg=dagrt
 --editable git+https://github.com/inducer/leap.git#egg=leap
 --editable git+https://github.com/inducer/modepy.git#egg=modepy
---editable git+https://github.com/kaushikcfd/arraycontext.git#egg=arraycontext
---editable git+https://github.com/majosm/meshmode.git@production#egg=meshmode
---editable git+https://github.com/majosm/grudge.git@multi-volume-misc#egg=grudge
---editable git+https://github.com/kaushikcfd/pytato.git#egg=pytato
+--editable git+https://github.com/inducer/arraycontext.git#egg=arraycontext
+--editable git+https://github.com/inducer/meshmode.git#egg=meshmode
+--editable git+https://github.com/majosm/grudge.git@multiple-independent-volumes#egg=grudge
+--editable git+https://github.com/inducer/pytato.git#egg=pytato
 --editable git+https://github.com/ecisneros8/pyrometheus.git#egg=pyrometheus
 --editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyyaml
 --editable git+https://github.com/inducer/modepy.git#egg=modepy
 --editable git+https://github.com/inducer/arraycontext.git#egg=arraycontext
 --editable git+https://github.com/inducer/meshmode.git#egg=meshmode
---editable git+https://github.com/majosm/grudge.git@multiple-independent-volumes#egg=grudge
+--editable git+https://github.com/majosm/grudge.git@dof-desc-helpers#egg=grudge
 --editable git+https://github.com/inducer/pytato.git#egg=pytato
 --editable git+https://github.com/ecisneros8/pyrometheus.git#egg=pyrometheus
 --editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pyyaml
 --editable git+https://github.com/inducer/modepy.git#egg=modepy
 --editable git+https://github.com/inducer/arraycontext.git#egg=arraycontext
 --editable git+https://github.com/inducer/meshmode.git#egg=meshmode
---editable git+https://github.com/majosm/grudge.git@dof-desc-helpers#egg=grudge
+--editable git+https://github.com/majosm/grudge.git@multi-main#egg=grudge
 --editable git+https://github.com/inducer/pytato.git#egg=pytato
 --editable git+https://github.com/ecisneros8/pyrometheus.git#egg=pyrometheus
 --editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ pyyaml
 --editable git+https://github.com/inducer/dagrt.git#egg=dagrt
 --editable git+https://github.com/inducer/leap.git#egg=leap
 --editable git+https://github.com/inducer/modepy.git#egg=modepy
---editable git+https://github.com/inducer/arraycontext.git#egg=arraycontext
---editable git+https://github.com/inducer/meshmode.git#egg=meshmode
---editable git+https://github.com/inducer/grudge.git#egg=grudge
---editable git+https://github.com/inducer/pytato.git#egg=pytato
+--editable git+https://github.com/kaushikcfd/arraycontext.git#egg=arraycontext
+--editable git+https://github.com/majosm/meshmode.git@production#egg=meshmode
+--editable git+https://github.com/majosm/grudge.git@multi-volume-misc#egg=grudge
+--editable git+https://github.com/kaushikcfd/pytato.git#egg=pytato
 --editable git+https://github.com/ecisneros8/pyrometheus.git#egg=pyrometheus
 --editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle

--- a/test/test_av.py
+++ b/test/test_av.py
@@ -35,6 +35,7 @@ from meshmode.array_context import (  # noqa
     as pytest_generate_tests
 )
 from meshmode.mesh import BTAG_ALL
+from meshmode.discretization.connection import FACE_RESTR_ALL
 import grudge.op as op
 from mirgecom.artificial_viscosity import (
     av_laplacian_operator,
@@ -443,11 +444,11 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
     # Prescribed boundaries are used for inflow/outflow-type boundaries
     # where we expect to _preserve_ the soln gradient
     from grudge.dof_desc import as_dofdesc
-    dd_bnd = as_dofdesc(BTAG_ALL)
-    all_faces_dd = dd_bnd.with_dtag("all_faces")
+    dd_bdry = as_dofdesc(BTAG_ALL)
+    dd_allfaces = dd_bdry.with_boundary_tag(FACE_RESTR_ALL)
     expected_av_flux_prescribed_boundary = av_diffusion_boundary@boundary_nhat
     print(f"{expected_av_flux_prescribed_boundary=}")
-    exp_av_flux = op.project(dcoll, dd_bnd, all_faces_dd,
+    exp_av_flux = op.project(dcoll, dd_bdry, dd_allfaces,
                                 expected_av_flux_prescribed_boundary)
     print(f"{exp_av_flux=}")
 

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -103,11 +103,14 @@ def test_slipwall_identity(actx_factory, dim):
                 return actx.to_numpy(op.norm(dcoll, vec, p=np.inf, dd=BTAG_ALL))
 
             state_plus = \
-                wall.adiabatic_slip_state(dcoll, btag=BTAG_ALL, gas_model=gas_model,
-                                          state_minus=state_minus)
+                wall.adiabatic_slip_state(
+                    dcoll, dd_bdry=BTAG_ALL, gas_model=gas_model,
+                    state_minus=state_minus)
 
-            bnd_pair = TracePair(BTAG_ALL, interior=state_minus.cv,
-                                 exterior=state_plus.cv)
+            bnd_pair = TracePair(
+                as_dofdesc(BTAG_ALL),
+                interior=state_minus.cv,
+                exterior=state_plus.cv)
 
             # check that mass and energy are preserved
             mass_resid = bnd_pair.int.mass - bnd_pair.ext.mass
@@ -178,14 +181,18 @@ def test_slipwall_flux(actx_factory, dim, order, flux_func):
                                                     state=fluid_state,
                                                     gas_model=gas_model)
 
-                bnd_soln = wall.adiabatic_slip_state(dcoll, btag=BTAG_ALL,
+                bnd_soln = wall.adiabatic_slip_state(dcoll, dd_bdry=BTAG_ALL,
                                                      gas_model=gas_model,
                                                      state_minus=interior_soln)
 
-                bnd_pair = TracePair(BTAG_ALL, interior=interior_soln.cv,
-                                     exterior=bnd_soln.cv)
-                state_pair = TracePair(BTAG_ALL, interior=interior_soln,
-                                       exterior=bnd_soln)
+                bnd_pair = TracePair(
+                    as_dofdesc(BTAG_ALL),
+                    interior=interior_soln.cv,
+                    exterior=bnd_soln.cv)
+                state_pair = TracePair(
+                    as_dofdesc(BTAG_ALL),
+                    interior=interior_soln,
+                    exterior=bnd_soln)
 
                 # Check the total velocity component normal
                 # to each surface.  It should be zero.  The
@@ -309,10 +316,11 @@ def test_noslip(actx_factory, dim, flux_func):
             print(f"{cv_flux_int=}")
 
             wall_state = wall.isothermal_noslip_state(
-                dcoll, btag=BTAG_ALL, gas_model=gas_model, state_minus=state_minus)
+                dcoll, dd_bdry=BTAG_ALL, gas_model=gas_model,
+                state_minus=state_minus)
             print(f"{wall_state=}")
 
-            cv_grad_flux_wall = wall.cv_gradient_flux(dcoll, btag=BTAG_ALL,
+            cv_grad_flux_wall = wall.cv_gradient_flux(dcoll, dd_bdry=BTAG_ALL,
                                                  gas_model=gas_model,
                                                  state_minus=state_minus)
 
@@ -330,7 +338,7 @@ def test_noslip(actx_factory, dim, flux_func):
 
             t_int_tpair = interior_trace_pair(dcoll, temper)
             t_flux_int = scalar_flux_interior(t_int_tpair)
-            t_flux_bc = wall.temperature_gradient_flux(dcoll, btag=BTAG_ALL,
+            t_flux_bc = wall.temperature_gradient_flux(dcoll, dd_bdry=BTAG_ALL,
                                                        gas_model=gas_model,
                                                        state_minus=state_minus)
 
@@ -340,7 +348,7 @@ def test_noslip(actx_factory, dim, flux_func):
 
             t_flux_bnd = t_flux_bc + t_flux_int
 
-            i_flux_bc = wall.inviscid_divergence_flux(dcoll, btag=BTAG_ALL,
+            i_flux_bc = wall.inviscid_divergence_flux(dcoll, dd_bdry=BTAG_ALL,
                                                       gas_model=gas_model,
                                                       state_minus=state_minus)
 
@@ -372,7 +380,7 @@ def test_noslip(actx_factory, dim, flux_func):
             print(f"{grad_cv_minus=}")
             print(f"{grad_t_minus=}")
 
-            v_flux_bc = wall.viscous_divergence_flux(dcoll, btag=BTAG_ALL,
+            v_flux_bc = wall.viscous_divergence_flux(dcoll, dd_bdry=BTAG_ALL,
                                                      gas_model=gas_model,
                                                      state_minus=state_minus,
                                                      grad_cv_minus=grad_cv_minus,
@@ -461,9 +469,9 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
     # (*note): Most people will never change these as they are used internally
     #          to compute a DG gradient of Q and temperature.
 
-    def _boundary_state_func(dcoll, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state_func(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(prescribed_soln(r=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -521,7 +529,7 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
 
             cv_int_tpair = interior_trace_pair(dcoll, cv)
             cv_flux_int = scalar_flux_interior(cv_int_tpair)
-            cv_flux_bc = domain_boundary.cv_gradient_flux(dcoll, btag=BTAG_ALL,
+            cv_flux_bc = domain_boundary.cv_gradient_flux(dcoll, dd_bdry=BTAG_ALL,
                                                gas_model=gas_model,
                                                state_minus=state_minus)
 
@@ -534,7 +542,7 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             t_int_tpair = interior_trace_pair(dcoll, temper)
             t_flux_int = scalar_flux_interior(t_int_tpair)
             t_flux_bc = \
-                domain_boundary.temperature_gradient_flux(dcoll, btag=BTAG_ALL,
+                domain_boundary.temperature_gradient_flux(dcoll, dd_bdry=BTAG_ALL,
                                                           gas_model=gas_model,
                                                           state_minus=state_minus)
 
@@ -545,7 +553,7 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             t_flux_bnd = t_flux_bc + t_flux_int
 
             i_flux_bc = \
-                domain_boundary.inviscid_divergence_flux(dcoll, btag=BTAG_ALL,
+                domain_boundary.inviscid_divergence_flux(dcoll, dd_bdry=BTAG_ALL,
                                                          gas_model=gas_model,
                                                          state_minus=state_minus)
 
@@ -579,11 +587,10 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             print(f"{grad_t_minus=}")
 
             v_flux_bc = \
-                domain_boundary.viscous_divergence_flux(dcoll=dcoll, btag=BTAG_ALL,
-                                                        gas_model=gas_model,
-                                                        state_minus=state_minus,
-                                                        grad_cv_minus=grad_cv_minus,
-                                                        grad_t_minus=grad_t_minus)
+                domain_boundary.viscous_divergence_flux(
+                    dcoll=dcoll, dd_bdry=BTAG_ALL, gas_model=gas_model,
+                    state_minus=state_minus, grad_cv_minus=grad_cv_minus,
+                    grad_t_minus=grad_t_minus)
             print(f"{v_flux_bc=}")
             bc_soln = \
                 domain_boundary._boundary_state_pair(dcoll, BTAG_ALL, gas_model,

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -30,6 +30,7 @@ import logging
 import pytest
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
+from meshmode.discretization.connection import FACE_RESTR_ALL
 from mirgecom.initializers import Lump
 from mirgecom.boundary import AdiabaticSlipBoundary
 from mirgecom.eos import IdealSingleGas
@@ -355,7 +356,7 @@ def test_noslip(actx_factory, dim, flux_func):
             nhat = actx.thaw(dcoll.normal(state_pair.dd))
             bnd_flux = flux_func(state_pair, gas_model, nhat)
             dd = state_pair.dd
-            dd_allfaces = dd.with_dtag("all_faces")
+            dd_allfaces = dd.with_boundary_tag(FACE_RESTR_ALL)
             i_flux_int = op.project(dcoll, dd, dd_allfaces, bnd_flux)
             bc_dd = as_dofdesc(BTAG_ALL)
             i_flux_bc = op.project(dcoll, bc_dd, dd_allfaces, i_flux_bc)
@@ -368,13 +369,13 @@ def test_noslip(actx_factory, dim, flux_func):
 
             from mirgecom.operators import grad_operator
             dd_vol = as_dofdesc("vol")
-            dd_faces = as_dofdesc("all_faces")
+            dd_allfaces = as_dofdesc("all_faces")
             grad_cv_minus = \
                 op.project(dcoll, "vol", BTAG_ALL,
-                              grad_operator(dcoll, dd_vol, dd_faces,
+                              grad_operator(dcoll, dd_vol, dd_allfaces,
                                             uniform_state.cv, cv_flux_bnd))
             grad_t_minus = op.project(dcoll, "vol", BTAG_ALL,
-                                         grad_operator(dcoll, dd_vol, dd_faces,
+                                         grad_operator(dcoll, dd_vol, dd_allfaces,
                                                        temper, t_flux_bnd))
 
             print(f"{grad_cv_minus=}")
@@ -564,9 +565,9 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             nhat = actx.thaw(dcoll.normal(state_pair.dd))
             bnd_flux = flux_func(state_pair, gas_model, nhat)
             dd = state_pair.dd
-            dd_allfaces = dd.with_dtag("all_faces")
-            bc_dd = as_dofdesc(BTAG_ALL)
-            i_flux_bc = op.project(dcoll, bc_dd, dd_allfaces, i_flux_bc)
+            dd_allfaces = dd.with_boundary_tag(FACE_RESTR_ALL)
+            dd_bdry = as_dofdesc(BTAG_ALL)
+            i_flux_bc = op.project(dcoll, dd_bdry, dd_allfaces, i_flux_bc)
             i_flux_int = op.project(dcoll, dd, dd_allfaces, bnd_flux)
 
             i_flux_bnd = i_flux_bc + i_flux_int
@@ -577,9 +578,9 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
 
             from mirgecom.operators import grad_operator
             dd_vol = as_dofdesc("vol")
-            dd_faces = as_dofdesc("all_faces")
-            grad_cv = grad_operator(dcoll, dd_vol, dd_faces, cv, cv_flux_bnd)
-            grad_t = grad_operator(dcoll, dd_vol, dd_faces, temper, t_flux_bnd)
+            dd_allfaces = as_dofdesc("all_faces")
+            grad_cv = grad_operator(dcoll, dd_vol, dd_allfaces, cv, cv_flux_bnd)
+            grad_t = grad_operator(dcoll, dd_vol, dd_allfaces, temper, t_flux_bnd)
             grad_cv_minus = op.project(dcoll, "vol", BTAG_ALL, grad_cv)
             grad_t_minus = op.project(dcoll, "vol", BTAG_ALL, grad_t)
 

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -38,7 +38,7 @@ from mirgecom.diffusion import (
     DirichletDiffusionBoundary,
     NeumannDiffusionBoundary)
 from meshmode.dof_array import DOFArray
-from grudge.dof_desc import DTAG_BOUNDARY, DISCR_TAG_BASE, DISCR_TAG_QUAD
+from grudge.dof_desc import BoundaryDomainTag, DISCR_TAG_BASE, DISCR_TAG_QUAD
 from mirgecom.discretization import create_discretization_collection
 from meshmode.array_context import (  # noqa
     pytest_generate_tests_for_pyopencl_array_context
@@ -133,14 +133,14 @@ class DecayingTrig(HeatProblem):
         boundaries = {}
 
         for i in range(self.dim-1):
-            lower_btag = DTAG_BOUNDARY("-"+str(i))
-            upper_btag = DTAG_BOUNDARY("+"+str(i))
-            boundaries[lower_btag] = NeumannDiffusionBoundary(0.)
-            boundaries[upper_btag] = NeumannDiffusionBoundary(0.)
-        lower_btag = DTAG_BOUNDARY("-"+str(self.dim-1))
-        upper_btag = DTAG_BOUNDARY("+"+str(self.dim-1))
-        boundaries[lower_btag] = DirichletDiffusionBoundary(0.)
-        boundaries[upper_btag] = DirichletDiffusionBoundary(0.)
+            lower_bdtag = BoundaryDomainTag("-"+str(i))
+            upper_bdtag = BoundaryDomainTag("+"+str(i))
+            boundaries[lower_bdtag] = NeumannDiffusionBoundary(0.)
+            boundaries[upper_bdtag] = NeumannDiffusionBoundary(0.)
+        lower_bdtag = BoundaryDomainTag("-"+str(self.dim-1))
+        upper_bdtag = BoundaryDomainTag("+"+str(self.dim-1))
+        boundaries[lower_bdtag] = DirichletDiffusionBoundary(0.)
+        boundaries[upper_bdtag] = DirichletDiffusionBoundary(0.)
 
         return boundaries
 
@@ -179,18 +179,18 @@ class DecayingTrigTruncatedDomain(HeatProblem):
         boundaries = {}
 
         for i in range(self.dim-1):
-            lower_btag = DTAG_BOUNDARY("-"+str(i))
-            upper_btag = DTAG_BOUNDARY("+"+str(i))
-            upper_grad_u = op.project(dcoll, "vol", upper_btag, exact_grad_u)
-            normal = actx.thaw(dcoll.normal(upper_btag))
+            lower_bdtag = BoundaryDomainTag("-"+str(i))
+            upper_bdtag = BoundaryDomainTag("+"+str(i))
+            upper_grad_u = op.project(dcoll, "vol", upper_bdtag, exact_grad_u)
+            normal = actx.thaw(dcoll.normal(upper_bdtag))
             upper_grad_u_dot_n = np.dot(upper_grad_u, normal)
-            boundaries[lower_btag] = NeumannDiffusionBoundary(0.)
-            boundaries[upper_btag] = NeumannDiffusionBoundary(upper_grad_u_dot_n)
-        lower_btag = DTAG_BOUNDARY("-"+str(self.dim-1))
-        upper_btag = DTAG_BOUNDARY("+"+str(self.dim-1))
-        upper_u = op.project(dcoll, "vol", upper_btag, exact_u)
-        boundaries[lower_btag] = DirichletDiffusionBoundary(0.)
-        boundaries[upper_btag] = DirichletDiffusionBoundary(upper_u)
+            boundaries[lower_bdtag] = NeumannDiffusionBoundary(0.)
+            boundaries[upper_bdtag] = NeumannDiffusionBoundary(upper_grad_u_dot_n)
+        lower_bdtag = BoundaryDomainTag("-"+str(self.dim-1))
+        upper_bdtag = BoundaryDomainTag("+"+str(self.dim-1))
+        upper_u = op.project(dcoll, "vol", upper_bdtag, exact_u)
+        boundaries[lower_bdtag] = DirichletDiffusionBoundary(0.)
+        boundaries[upper_bdtag] = DirichletDiffusionBoundary(upper_u)
 
         return boundaries
 
@@ -227,14 +227,14 @@ class OscillatingTrigVarDiff(HeatProblem):
         boundaries = {}
 
         for i in range(self.dim-1):
-            lower_btag = DTAG_BOUNDARY("-"+str(i))
-            upper_btag = DTAG_BOUNDARY("+"+str(i))
-            boundaries[lower_btag] = NeumannDiffusionBoundary(0.)
-            boundaries[upper_btag] = NeumannDiffusionBoundary(0.)
-        lower_btag = DTAG_BOUNDARY("-"+str(self.dim-1))
-        upper_btag = DTAG_BOUNDARY("+"+str(self.dim-1))
-        boundaries[lower_btag] = DirichletDiffusionBoundary(0.)
-        boundaries[upper_btag] = DirichletDiffusionBoundary(0.)
+            lower_bdtag = BoundaryDomainTag("-"+str(i))
+            upper_bdtag = BoundaryDomainTag("+"+str(i))
+            boundaries[lower_bdtag] = NeumannDiffusionBoundary(0.)
+            boundaries[upper_bdtag] = NeumannDiffusionBoundary(0.)
+        lower_bdtag = BoundaryDomainTag("-"+str(self.dim-1))
+        upper_bdtag = BoundaryDomainTag("+"+str(self.dim-1))
+        boundaries[lower_bdtag] = DirichletDiffusionBoundary(0.)
+        boundaries[upper_bdtag] = DirichletDiffusionBoundary(0.)
 
         return boundaries
 
@@ -265,14 +265,14 @@ class OscillatingTrigNonlinearDiff(HeatProblem):
         boundaries = {}
 
         for i in range(self.dim-1):
-            lower_btag = DTAG_BOUNDARY("-"+str(i))
-            upper_btag = DTAG_BOUNDARY("+"+str(i))
-            boundaries[lower_btag] = NeumannDiffusionBoundary(0.)
-            boundaries[upper_btag] = NeumannDiffusionBoundary(0.)
-        lower_btag = DTAG_BOUNDARY("-"+str(self.dim-1))
-        upper_btag = DTAG_BOUNDARY("+"+str(self.dim-1))
-        boundaries[lower_btag] = DirichletDiffusionBoundary(0.)
-        boundaries[upper_btag] = DirichletDiffusionBoundary(0.)
+            lower_bdtag = BoundaryDomainTag("-"+str(i))
+            upper_bdtag = BoundaryDomainTag("+"+str(i))
+            boundaries[lower_bdtag] = NeumannDiffusionBoundary(0.)
+            boundaries[upper_bdtag] = NeumannDiffusionBoundary(0.)
+        lower_bdtag = BoundaryDomainTag("-"+str(self.dim-1))
+        upper_bdtag = BoundaryDomainTag("+"+str(self.dim-1))
+        boundaries[lower_bdtag] = DirichletDiffusionBoundary(0.)
+        boundaries[upper_bdtag] = DirichletDiffusionBoundary(0.)
 
         return boundaries
 
@@ -411,8 +411,8 @@ def test_diffusion_discontinuous_kappa(actx_factory, order, visualize=False):
     kappa = kappa_lower * lower_mask + kappa_upper * upper_mask
 
     boundaries = {
-        DTAG_BOUNDARY("-0"): DirichletDiffusionBoundary(0.),
-        DTAG_BOUNDARY("+0"): DirichletDiffusionBoundary(1.),
+        BoundaryDomainTag("-0"): DirichletDiffusionBoundary(0.),
+        BoundaryDomainTag("+0"): DirichletDiffusionBoundary(1.),
     }
 
     flux = -kappa_lower*kappa_upper/(kappa_lower + kappa_upper)

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -603,7 +603,7 @@ def _euler_flow_stepper(actx, parameters):
                 write_soln(state=cv)
 
         cv = rk4_step(cv, t, dt, rhs)
-        cv = filter_modally(dcoll, "vol", cutoff, frfunc, cv)
+        cv = filter_modally(dcoll, cutoff, frfunc, cv)
         fluid_state = make_fluid_state(cv, gas_model)
 
         t += dt

--- a/test/test_euler.py
+++ b/test/test_euler.py
@@ -270,9 +270,9 @@ def test_vortex_rhs(actx_factory, order, use_overintegration, numerical_flux_fun
         gas_model = GasModel(eos=IdealSingleGas())
         fluid_state = make_fluid_state(vortex_soln, gas_model)
 
-        def _vortex_boundary(dcoll, btag, gas_model, state_minus, **kwargs):
+        def _vortex_boundary(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
             actx = state_minus.array_context
-            bnd_discr = dcoll.discr_from_dd(btag)
+            bnd_discr = dcoll.discr_from_dd(dd_bdry)
             nodes = actx.thaw(bnd_discr.nodes())
             return make_fluid_state(vortex(x_vec=nodes, **kwargs), gas_model)
 
@@ -350,9 +350,9 @@ def test_lump_rhs(actx_factory, dim, order, use_overintegration,
         gas_model = GasModel(eos=IdealSingleGas())
         fluid_state = make_fluid_state(lump_soln, gas_model)
 
-        def _lump_boundary(dcoll, btag, gas_model, state_minus, **kwargs):
+        def _lump_boundary(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
             actx = state_minus.array_context
-            bnd_discr = dcoll.discr_from_dd(btag)
+            bnd_discr = dcoll.discr_from_dd(dd_bdry)
             nodes = actx.thaw(bnd_discr.nodes())
             return make_fluid_state(lump(x_vec=nodes, cv=state_minus, **kwargs),
                                     gas_model)
@@ -445,9 +445,9 @@ def test_multilump_rhs(actx_factory, dim, order, v0, use_overintegration,
         gas_model = GasModel(eos=IdealSingleGas())
         fluid_state = make_fluid_state(lump_soln, gas_model)
 
-        def _my_boundary(dcoll, btag, gas_model, state_minus, **kwargs):
+        def _my_boundary(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
             actx = state_minus.array_context
-            bnd_discr = dcoll.discr_from_dd(btag)
+            bnd_discr = dcoll.discr_from_dd(dd_bdry)
             nodes = actx.thaw(bnd_discr.nodes())
             return make_fluid_state(lump(x_vec=nodes, **kwargs), gas_model)
 
@@ -664,9 +664,9 @@ def test_isentropic_vortex(actx_factory, order, use_overintegration,
         initializer = Vortex2D(center=orig, velocity=vel)
         casename = "Vortex"
 
-        def _vortex_boundary(dcoll, btag, state_minus, gas_model, **kwargs):
+        def _vortex_boundary(dcoll, dd_bdry, state_minus, gas_model, **kwargs):
             actx = state_minus.array_context
-            bnd_discr = dcoll.discr_from_dd(btag)
+            bnd_discr = dcoll.discr_from_dd(dd_bdry)
             nodes = actx.thaw(bnd_discr.nodes())
             return make_fluid_state(initializer(x_vec=nodes, **kwargs), gas_model)
 

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -205,7 +205,7 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
         r = nodes[0]
         result = 0
         for n, a in enumerate(coeff):
-            result += a * r ** n
+            result = result + a * r ** n
         return make_obj_array([result])
 
     # Any order {cutoff} and below fields should be unharmed

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -188,8 +188,7 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
     uniform_soln = initr(t=0, x_vec=nodes)
 
     from mirgecom.filter import filter_modally
-    filtered_soln = filter_modally(dcoll, "vol", cutoff,
-                                   frfunc, uniform_soln)
+    filtered_soln = filter_modally(dcoll, cutoff, frfunc, uniform_soln)
     soln_resid = uniform_soln - filtered_soln
     from mirgecom.simutil import componentwise_norms
     max_errors = componentwise_norms(dcoll, soln_resid, np.inf)
@@ -214,8 +213,7 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
     field_order = int(cutoff)
     coeff = [1.0 / (i + 1) for i in range(field_order + 1)]
     field = polyfn(coeff=coeff)
-    filtered_field = filter_modally(dcoll, "vol", cutoff,
-                                    frfunc, field)
+    filtered_field = filter_modally(dcoll, cutoff, frfunc, field)
     soln_resid = field - filtered_field
     max_errors = [actx.to_numpy(op.norm(dcoll, v, np.inf)) for v in soln_resid]
     logger.info(f"Field = {field}")
@@ -237,8 +235,7 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
     for field_order in range(cutoff+1, cutoff+4):
         coeff = [1.0 / (i + 1) for i in range(field_order+1)]
         field = polyfn(coeff=coeff)
-        filtered_field = filter_modally(dcoll, "vol", cutoff,
-                                        frfunc, field)
+        filtered_field = filter_modally(dcoll, cutoff, frfunc, field)
 
         unfiltered_spectrum = modal_map(field)
         filtered_spectrum = modal_map(filtered_field)

--- a/test/test_filter.py
+++ b/test/test_filter.py
@@ -230,9 +230,9 @@ def test_filter_function(actx_factory, dim, order, do_viz=False):
         from grudge.shortcuts import make_visualizer
         vis = make_visualizer(dcoll, order)
 
-    from grudge.dof_desc import DD_VOLUME_MODAL, DD_VOLUME
+    from grudge.dof_desc import DD_VOLUME_ALL, DD_VOLUME_ALL_MODAL
 
-    modal_map = dcoll.connection_from_dds(DD_VOLUME, DD_VOLUME_MODAL)
+    modal_map = dcoll.connection_from_dds(DD_VOLUME_ALL, DD_VOLUME_ALL_MODAL)
 
     for field_order in range(cutoff+1, cutoff+4):
         coeff = [1.0 / (i + 1) for i in range(field_order+1)]

--- a/test/test_flux.py
+++ b/test/test_flux.py
@@ -34,6 +34,7 @@ import pytest
 from pytools.obj_array import make_obj_array
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
 from meshmode.dof_array import DOFArray
+from grudge.dof_desc import as_dofdesc
 from grudge.trace_pair import TracePair
 from mirgecom.fluid import make_conserved
 from mirgecom.eos import IdealSingleGas
@@ -129,7 +130,10 @@ def test_lfr_flux(actx_factory, nspecies, dim, norm_dir, vel_mag):
     mag = np.linalg.norm(normal)
     normal = norm_dir*normal/mag
 
-    state_pair = TracePair("vol", interior=fluid_state_int, exterior=fluid_state_ext)
+    state_pair = TracePair(
+        as_dofdesc("vol"),
+        interior=fluid_state_int,
+        exterior=fluid_state_ext)
 
     # code passes in fluxes in the direction of the surface normal,
     # so we will too
@@ -275,7 +279,10 @@ def test_hll_flux(actx_factory, nspecies, dim, norm_dir, vel_mag):
     mag = np.linalg.norm(normal)
     normal = norm_dir*normal/mag
 
-    state_pair = TracePair("vol", interior=fluid_state_int, exterior=fluid_state_ext)
+    state_pair = TracePair(
+        as_dofdesc("vol"),
+        interior=fluid_state_int,
+        exterior=fluid_state_ext)
 
     from mirgecom.inviscid import inviscid_facial_flux_hll
     flux_bnd = inviscid_facial_flux_hll(state_pair, gas_model, normal)

--- a/test/test_inviscid.py
+++ b/test/test_inviscid.py
@@ -37,6 +37,7 @@ from pytools.obj_array import (
 )
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
+from grudge.dof_desc import as_dofdesc
 from grudge.trace_pair import TracePair
 from mirgecom.fluid import make_conserved
 from mirgecom.eos import IdealSingleGas
@@ -375,7 +376,7 @@ def test_facial_flux(actx_factory, nspecies, order, dim, num_flux):
                                 momentum=dir_mom, species_mass=dir_mf)
         dir_bval = make_conserved(dim, mass=dir_mass, energy=dir_e,
                                   momentum=dir_mom, species_mass=dir_mf)
-        state_tpair = TracePair(BTAG_ALL,
+        state_tpair = TracePair(as_dofdesc(BTAG_ALL),
                                 interior=make_fluid_state(dir_bval, gas_model),
                                 exterior=make_fluid_state(dir_bc, gas_model))
 

--- a/test/test_inviscid.py
+++ b/test/test_inviscid.py
@@ -37,6 +37,7 @@ from pytools.obj_array import (
 )
 
 from meshmode.mesh import BTAG_ALL, BTAG_NONE  # noqa
+from meshmode.discretization.connection import FACE_RESTR_ALL
 from grudge.dof_desc import as_dofdesc
 from grudge.trace_pair import TracePair
 from mirgecom.fluid import make_conserved
@@ -334,7 +335,7 @@ def test_facial_flux(actx_factory, nspecies, order, dim, num_flux):
         nhat = actx.thaw(dcoll.normal(interior_state_pair.dd))
         bnd_flux = num_flux(interior_state_pair, gas_model, nhat)
         dd = interior_state_pair.dd
-        dd_allfaces = dd.with_dtag("all_faces")
+        dd_allfaces = dd.with_boundary_tag(FACE_RESTR_ALL)
         interior_face_flux = op.project(dcoll, dd, dd_allfaces, bnd_flux)
 
         def inf_norm(data):
@@ -383,7 +384,7 @@ def test_facial_flux(actx_factory, nspecies, order, dim, num_flux):
         nhat = actx.thaw(dcoll.normal(state_tpair.dd))
         bnd_flux = num_flux(state_tpair, gas_model, nhat)
         dd = state_tpair.dd
-        dd_allfaces = dd.with_dtag("all_faces")
+        dd_allfaces = dd.with_boundary_tag(FACE_RESTR_ALL)
         boundary_flux = op.project(dcoll, dd, dd_allfaces, bnd_flux)
 
         assert inf_norm(boundary_flux.mass) < tolerance

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -33,6 +33,7 @@ from meshmode.array_context import (  # noqa
     PyOpenCLArrayContext,
     PytatoPyOpenCLArrayContext
 )
+from meshmode.discretization.connection import FACE_RESTR_ALL
 from mirgecom.discretization import create_discretization_collection
 import grudge.op as op
 from meshmode.array_context import (  # noqa
@@ -132,11 +133,11 @@ def test_lazy_op_divergence(op_test_data, order):
     from mirgecom.operators import div_operator
 
     dd_vol = as_dofdesc("vol")
-    dd_faces = as_dofdesc("all_faces")
+    dd_allfaces = as_dofdesc("all_faces")
 
     def get_flux(u_tpair):
         dd = u_tpair.dd
-        dd_allfaces = dd.with_dtag("all_faces")
+        dd_allfaces = dd.with_boundary_tag(FACE_RESTR_ALL)
         normal = dcoll.normal(dd)
         actx = u_tpair.int[0].array_context
         normal = actx.thaw(normal)
@@ -144,7 +145,7 @@ def test_lazy_op_divergence(op_test_data, order):
         return op.project(dcoll, dd, dd_allfaces, flux)
 
     def div_op(u):
-        return div_operator(dcoll, dd_vol, dd_faces,
+        return div_operator(dcoll, dd_vol, dd_allfaces,
                             u, get_flux(interior_trace_pair(dcoll, u)))
 
     lazy_op = lazy_actx.compile(div_op)

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -102,15 +102,15 @@ def _isclose(dcoll, x, y, rel_tol=1e-9, abs_tol=0, return_operands=False):
 #     cl_ctx = ctx_factory()
 #     actx, dcoll = _op_test_fixture(cl_ctx)
 #
-#     from grudge.dof_desc import DTAG_BOUNDARY
+#     from grudge.dof_desc import BoundaryDomainTag
 #     from mirgecom.diffusion import (
 #         _gradient_operator,
 #         DirichletDiffusionBoundary,
 #         NeumannDiffusionBoundary)
 #
 #     boundaries = {
-#         DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0),
-#         DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0)
+#         BoundaryDomainTag("x"): DirichletDiffusionBoundary(0),
+#         BoundaryDomainTag("y"): NeumannDiffusionBoundary(0)
 #     }
 #
 #     def op(u):
@@ -173,15 +173,15 @@ def test_lazy_op_diffusion(op_test_data, order):
     eager_actx, lazy_actx, get_dcoll = op_test_data
     dcoll = get_dcoll(order)
 
-    from grudge.dof_desc import DTAG_BOUNDARY
+    from grudge.dof_desc import BoundaryDomainTag
     from mirgecom.diffusion import (
         diffusion_operator,
         DirichletDiffusionBoundary,
         NeumannDiffusionBoundary)
 
     boundaries = {
-        DTAG_BOUNDARY("x"): DirichletDiffusionBoundary(0),
-        DTAG_BOUNDARY("y"): NeumannDiffusionBoundary(0)
+        BoundaryDomainTag("x"): DirichletDiffusionBoundary(0),
+        BoundaryDomainTag("y"): NeumannDiffusionBoundary(0)
     }
 
     def diffusion_op(kappa, u):
@@ -239,9 +239,9 @@ def _get_scalar_lump():
         dim=2, nspecies=3, velocity=np.ones(2), spec_y0s=np.ones(3),
         spec_amplitudes=np.ones(3))
 
-    def _my_boundary(dcoll, btag, gas_model, state_minus, **kwargs):
+    def _my_boundary(dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(init(x_vec=nodes, eos=gas_model.eos,
                                      **kwargs), gas_model)

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -96,11 +96,9 @@ def test_independent_volumes(actx_factory, order, visualize=False):
     def get_rhs(t, u):
         return make_obj_array([
             diffusion_operator(
-                dcoll, kappa=1, boundaries=boundaries1, u=u[0],
-                volume_dd=dd_vol1),
+                dcoll, kappa=1, boundaries=boundaries1, u=u[0], dd=dd_vol1),
             diffusion_operator(
-                dcoll, kappa=1, boundaries=boundaries2, u=u[1],
-                volume_dd=dd_vol2)])
+                dcoll, kappa=1, boundaries=boundaries2, u=u[1], dd=dd_vol2)])
 
     rhs = get_rhs(0, u)
 

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -1,0 +1,142 @@
+__copyright__ = """Copyright (C) 2022 University of Illinois Board of Trustees"""
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+import pyopencl.array as cla  # noqa
+import pyopencl.clmath as clmath # noqa
+from pytools.obj_array import make_obj_array
+import grudge.op as op
+from mirgecom.diffusion import (
+    diffusion_operator,
+    DirichletDiffusionBoundary,
+    NeumannDiffusionBoundary)
+from meshmode.mesh import BTAG_PARTITION
+from grudge.dof_desc import DOFDesc, VolumeDomainTag, DISCR_TAG_BASE
+from grudge.discretization import PartID
+from mirgecom.discretization import create_discretization_collection
+from meshmode.array_context import (  # noqa
+    pytest_generate_tests_for_pyopencl_array_context
+    as pytest_generate_tests)
+import pytest
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def get_box_mesh(dim, a, b, n):
+    dim_names = ["x", "y", "z"]
+    boundary_tag_to_face = {}
+    for i in range(dim):
+        boundary_tag_to_face["-"+str(i)] = ["-"+dim_names[i]]
+        boundary_tag_to_face["+"+str(i)] = ["+"+dim_names[i]]
+    from meshmode.mesh.generation import generate_regular_rect_mesh
+    return generate_regular_rect_mesh(a=(a,)*dim, b=(b,)*dim,
+        nelements_per_axis=(n,)*dim, boundary_tag_to_face=boundary_tag_to_face)
+
+
+@pytest.mark.parametrize("order", [1, 2, 3, 4])
+def test_independent_volumes(actx_factory, order, visualize=False):
+    """Check multi-volume machinery by setting up two independent volumes."""
+    actx = actx_factory()
+
+    n = 8
+    global_mesh = get_box_mesh(2, -1, 1, n)
+
+    mgrp, = global_mesh.groups
+    y = global_mesh.vertices[1, mgrp.vertex_indices]
+    y_elem_avg = np.sum(y, axis=1)/y.shape[1]
+    volume_to_elements = {
+        "Lower": np.where(y_elem_avg < 0)[0],
+        "Upper": np.where(y_elem_avg > 0)[0]}
+
+    from meshmode.mesh.processing import partition_mesh
+    volume_meshes = partition_mesh(global_mesh, volume_to_elements)
+
+    dcoll = create_discretization_collection(actx, volume_meshes, order)
+
+    dd_vol_lower = DOFDesc(VolumeDomainTag("Lower"), DISCR_TAG_BASE)
+    dd_vol_upper = DOFDesc(VolumeDomainTag("Upper"), DISCR_TAG_BASE)
+
+    lower_nodes = actx.thaw(dcoll.nodes(dd=dd_vol_lower))
+    upper_nodes = actx.thaw(dcoll.nodes(dd=dd_vol_upper))
+
+    lower_boundaries = {
+        dd_vol_lower.trace("-0").domain_tag: NeumannDiffusionBoundary(0.),
+        dd_vol_lower.trace("+0").domain_tag: NeumannDiffusionBoundary(0.),
+        dd_vol_lower.trace("-1").domain_tag: DirichletDiffusionBoundary(0.),
+        dd_vol_lower.trace(BTAG_PARTITION(PartID("Upper"))).domain_tag:
+            DirichletDiffusionBoundary(1.),
+    }
+
+    upper_boundaries = {
+        dd_vol_upper.trace("-0").domain_tag: NeumannDiffusionBoundary(0.),
+        dd_vol_upper.trace("+0").domain_tag: NeumannDiffusionBoundary(0.),
+        dd_vol_upper.trace(BTAG_PARTITION(PartID("Lower"))).domain_tag:
+            DirichletDiffusionBoundary(0.),
+        dd_vol_upper.trace("+1"): DirichletDiffusionBoundary(1.),
+    }
+
+    lower_u = lower_nodes[1] + 1
+    upper_u = upper_nodes[1]
+
+    u = make_obj_array([lower_u, upper_u])
+
+    def get_rhs(t, u):
+        return make_obj_array([
+            diffusion_operator(
+                dcoll, kappa=1, boundaries=lower_boundaries, u=u[0],
+                volume_dd=dd_vol_lower),
+            diffusion_operator(
+                dcoll, kappa=1, boundaries=upper_boundaries, u=u[1],
+                volume_dd=dd_vol_upper)])
+
+    rhs = get_rhs(0, u)
+
+    if visualize:
+        from grudge.shortcuts import make_visualizer
+        viz_lower = make_visualizer(dcoll, order+3, volume_dd=dd_vol_lower)
+        viz_upper = make_visualizer(dcoll, order+3, volume_dd=dd_vol_upper)
+        viz_lower.write_vtk_file(
+            f"multiphysics_independent_volumes_{order}_lower.vtu", [
+                ("u", u[0]),
+                ("rhs", rhs[0]),
+                ])
+        viz_upper.write_vtk_file(
+            f"multiphysics_independent_volumes_{order}_upper.vtu", [
+                ("u", u[1]),
+                ("rhs", rhs[1]),
+                ])
+
+    linf_err_lower = actx.to_numpy(op.norm(dcoll, rhs[0], np.inf, dd=dd_vol_lower))
+    linf_err_upper = actx.to_numpy(op.norm(dcoll, rhs[1], np.inf, dd=dd_vol_upper))
+
+    assert linf_err_lower < 1e-9
+    assert linf_err_upper < 1e-9
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -74,6 +74,9 @@ def test_independent_volumes(actx_factory, order, visualize=False):
     nodes1 = actx.thaw(dcoll.nodes(dd=dd_vol1))
     nodes2 = actx.thaw(dcoll.nodes(dd=dd_vol2))
 
+    # Set solution to x for volume 1
+    # Set solution to y for volume 2
+
     boundaries1 = {
         dd_vol1.trace("-0").domain_tag: DirichletDiffusionBoundary(-1.),
         dd_vol1.trace("+0").domain_tag: DirichletDiffusionBoundary(1.),

--- a/test/test_navierstokes.py
+++ b/test/test_navierstokes.py
@@ -294,10 +294,10 @@ class FluidManufacturedSolution(FluidCase):
         """Get the boundary condition dictionary: prescribed exact by default."""
         from mirgecom.gas_model import make_fluid_state
 
-        def _boundary_state_func(dcoll, btag, gas_model, state_minus, time=0,
+        def _boundary_state_func(dcoll, dd_bdry, gas_model, state_minus, time=0,
                                  **kwargs):
             actx = state_minus.array_context
-            bnd_discr = dcoll.discr_from_dd(btag)
+            bnd_discr = dcoll.discr_from_dd(dd_bdry)
             nodes = actx.thaw(bnd_discr.nodes())
             return make_fluid_state(self.get_solution(x=nodes, t=time), gas_model)
 
@@ -676,10 +676,10 @@ def test_shear_flow(actx_factory, dim, flow_direction, order):
     from pytools.convergence import EOCRecorder
     eoc_energy = EOCRecorder()
 
-    def _boundary_state_func(dcoll, btag, gas_model, state_minus, time=0,
+    def _boundary_state_func(dcoll, dd_bdry, gas_model, state_minus, time=0,
                              **kwargs):
         actx = state_minus.array_context
-        bnd_discr = dcoll.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(dd_bdry)
         nodes = actx.thaw(bnd_discr.nodes())
         boundary_cv = exact_soln(x=nodes)
         return make_fluid_state(boundary_cv, gas_model)
@@ -932,10 +932,10 @@ def test_roy_mms(actx_factory, order, dim, u_0, v_0, w_0, a_r, a_p, a_u,
         logger.info(f"{source_norms=}")
         logger.info(f"{source_eval=}")
 
-        def _boundary_state_func(dcoll, btag, gas_model, state_minus, time=0,
+        def _boundary_state_func(dcoll, dd_bdry, gas_model, state_minus, time=0,
                                  **kwargs):
             actx = state_minus.array_context
-            bnd_discr = dcoll.discr_from_dd(btag)
+            bnd_discr = dcoll.discr_from_dd(dd_bdry)
             nodes = actx.thaw(bnd_discr.nodes())
             boundary_cv = evaluate(sym_cv, x=nodes, t=time)
             return make_fluid_state(boundary_cv, gas_model)

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -126,8 +126,8 @@ def central_flux_interior(actx, dcoll, int_tpair):
     normal = actx.thaw(dcoll.normal(int_tpair.dd))
     from arraycontext import outer
     flux_weak = outer(num_flux_central(int_tpair.int, int_tpair.ext), normal)
-    dd_all_faces = int_tpair.dd.with_dtag("all_faces")
-    return op.project(dcoll, int_tpair.dd, dd_all_faces, flux_weak)
+    dd_allfaces = int_tpair.dd.with_dtag("all_faces")
+    return op.project(dcoll, int_tpair.dd, dd_allfaces, flux_weak)
 
 
 def central_flux_boundary(actx, dcoll, soln_func, dd_bdry):
@@ -140,8 +140,8 @@ def central_flux_boundary(actx, dcoll, soln_func, dd_bdry):
     bnd_tpair = TracePair(dd_bdry, interior=soln_bnd, exterior=soln_bnd)
     from arraycontext import outer
     flux_weak = outer(num_flux_central(bnd_tpair.int, bnd_tpair.ext), bnd_nhat)
-    dd_all_faces = bnd_tpair.dd.with_dtag("all_faces")
-    return op.project(dcoll, bnd_tpair.dd, dd_all_faces, flux_weak)
+    dd_allfaces = bnd_tpair.dd.with_dtag("all_faces")
+    return op.project(dcoll, bnd_tpair.dd, dd_allfaces, flux_weak)
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
@@ -228,8 +228,8 @@ def test_grad_operator(actx_factory, dim, order, sym_test_func_factory):
 
         from mirgecom.operators import grad_operator
         dd_vol = as_dofdesc("vol")
-        dd_faces = as_dofdesc("all_faces")
-        test_grad = grad_operator(dcoll, dd_vol, dd_faces,
+        dd_allfaces = as_dofdesc("all_faces")
+        test_grad = grad_operator(dcoll, dd_vol, dd_allfaces,
                                   test_data, test_data_flux_bnd)
 
         print(f"{test_grad=}")

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -173,8 +173,8 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         normal = actx.thaw(dcoll.normal(int_tpair.dd))
         from arraycontext import outer
         flux_weak = outer(num_flux_central(int_tpair.int, int_tpair.ext), normal)
-        dd_all_faces = int_tpair.dd.with_dtag("all_faces")
-        return op.project(dcoll, int_tpair.dd, dd_all_faces, flux_weak)
+        dd_allfaces = int_tpair.dd.with_boundary_tag(FACE_RESTR_ALL)
+        return op.project(dcoll, int_tpair.dd, dd_allfaces, flux_weak)
 
     def cv_flux_boundary(dd_bdry):
         boundary_discr = dcoll.discr_from_dd(dd_bdry)
@@ -185,8 +185,8 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         bnd_tpair = TracePair(dd_bdry, interior=cv_bnd, exterior=cv_bnd)
         from arraycontext import outer
         flux_weak = outer(num_flux_central(bnd_tpair.int, bnd_tpair.ext), bnd_nhat)
-        dd_all_faces = dd_bdry.with_boundary_tag(FACE_RESTR_ALL)
-        return op.project(dcoll, dd_bdry, dd_all_faces, flux_weak)
+        dd_allfaces = dd_bdry.with_boundary_tag(FACE_RESTR_ALL)
+        return op.project(dcoll, dd_bdry, dd_allfaces, flux_weak)
 
     for nfac in [1, 2, 4]:
 
@@ -217,8 +217,8 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
                                   cv_int_tpairs, boundaries)
         from mirgecom.operators import grad_operator
         dd_vol = as_dofdesc("vol")
-        dd_faces = as_dofdesc("all_faces")
-        grad_cv = grad_operator(dcoll, dd_vol, dd_faces, cv, cv_flux_bnd)
+        dd_allfaces = as_dofdesc("all_faces")
+        grad_cv = grad_operator(dcoll, dd_vol, dd_allfaces, cv, cv_flux_bnd)
 
         xp_grad_cv = initializer.exact_grad(x_vec=nodes, eos=eos, cv_exact=cv)
         xp_grad_v = 1/cv.mass * xp_grad_cv.momentum

--- a/test/test_viscous.py
+++ b/test/test_viscous.py
@@ -30,7 +30,6 @@ import numpy.linalg as la  # noqa
 import pyopencl.clmath  # noqa
 import logging
 import pytest  # noqa
-from dataclasses import replace
 
 from pytools.obj_array import make_obj_array
 from meshmode.discretization.connection import FACE_RESTR_ALL
@@ -186,8 +185,7 @@ def test_poiseuille_fluxes(actx_factory, order, kappa):
         bnd_tpair = TracePair(dd_bdry, interior=cv_bnd, exterior=cv_bnd)
         from arraycontext import outer
         flux_weak = outer(num_flux_central(bnd_tpair.int, bnd_tpair.ext), bnd_nhat)
-        dd_all_faces = dd_bdry.with_domain_tag(
-            replace(dd_bdry.domain_tag, tag=FACE_RESTR_ALL))
+        dd_all_faces = dd_bdry.with_boundary_tag(FACE_RESTR_ALL)
         return op.project(dcoll, dd_bdry, dd_all_faces, flux_weak)
 
     for nfac in [1, 2, 4]:


### PR DESCRIPTION
Extracted out of #630. Depends on inducer/grudge#246 and inducer/meshmode#342.

**Questions for the review** @lukeolson:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
    - Common updates include updating `dcoll`, `BoundaryDomainTag` (from grudge multi-volume), adding a dof descriptor `dd`, promoting the boundary tags.
  - [x] The PR should have a guide if needed (e.g., an ordering).
- [x] Is every top-level method and class documented? Are things that should be documented actually so?
  - [x] add a more complete description in the docstring of `multiple-volumes-mpi.py` to check this off.
- [x] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [x] Does the implementation do what the docstring claims?
- [x] Is everything that is implemented covered by tests?
  - [x] yes, although tests are only covering independent volumes.  There is no coupling.
  - [x] Add a note that `u=x` and `u=y` on vol 1 and 2, resp, to close this box: https://github.com/illinois-ceesd/mirgecom/pull/726/files#diff-a711e4a672e5ea17608d8536895c9a666557a0872b0b23b2e3f3809874898dfbR91
- [x] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
