### PR TITLE
Rename `discr` to `dcoll`

### DIFF
--- a/examples/doublemach-mpi.py
+++ b/examples/doublemach-mpi.py
@@ -192,9 +192,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     from mirgecom.discretization import create_discretization_collection
     order = 3
-    discr = create_discretization_collection(actx, local_mesh, order=order,
+    dcoll = create_discretization_collection(actx, local_mesh, order=order,
                                              mpi_communicator=comm)
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     from grudge.dof_desc import DISCR_TAG_QUAD
     if use_overintegration:
@@ -206,7 +206,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
         logmgr_add_device_memory_usage(logmgr, queue)
-        logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+        logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                              extract_vars_for_logging, units_for_logging)
 
         logmgr.add_watches([
@@ -237,9 +237,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     eos = IdealSingleGas()
     gas_model = GasModel(eos=eos, transport=transport_model)
 
-    def _boundary_state(discr, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -267,7 +267,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         current_cv = initializer(nodes)
     current_state = make_fluid_state(cv=current_cv, gas_model=gas_model)
 
-    visualizer = make_visualizer(discr)
+    visualizer = make_visualizer(dcoll)
 
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
@@ -294,7 +294,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                       ("dv", dv),
                       ("tagged_cells", tagged_cells)]
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True,
                       comm=comm)
 
@@ -320,29 +320,29 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         #       be changed accordingly.
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", dv.pressure):
+        if check_naninf_local(dcoll, "vol", dv.pressure):
             health_error = True
             logger.info(f"{rank=}: NANs/Infs in pressure data.")
 
-        if global_reduce(check_range_local(discr, "vol", dv.pressure, .9, 18.6),
+        if global_reduce(check_range_local(dcoll, "vol", dv.pressure, .9, 18.6),
                          op="lor"):
             health_error = True
             from grudge.op import nodal_max, nodal_min
-            p_min = actx.to_numpy(nodal_min(discr, "vol", dv.pressure))
-            p_max = actx.to_numpy(nodal_max(discr, "vol", dv.pressure))
+            p_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.pressure))
+            p_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.pressure))
             logger.info(f"Pressure range violation ({p_min=}, {p_max=})")
 
-        if check_naninf_local(discr, "vol", dv.temperature):
+        if check_naninf_local(dcoll, "vol", dv.temperature):
             health_error = True
             logger.info(f"{rank=}: NANs/INFs in temperature data.")
 
         if global_reduce(
-                check_range_local(discr, "vol", dv.temperature, 2.48e-3, 1.071e-2),
+                check_range_local(dcoll, "vol", dv.temperature, 2.48e-3, 1.071e-2),
                 op="lor"):
             health_error = True
             from grudge.op import nodal_max, nodal_min
-            t_min = actx.to_numpy(nodal_min(discr, "vol", dv.temperature))
-            t_max = actx.to_numpy(nodal_max(discr, "vol", dv.temperature))
+            t_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.temperature))
+            t_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.temperature))
             logger.info(f"Temperature range violation ({t_min=}, {t_max=})")
 
         return health_error
@@ -373,7 +373,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                 my_write_restart(step=step, t=t, state=state)
 
             if do_viz:
-                tagged_cells = smoothness_indicator(discr, state.mass, s0=s0,
+                tagged_cells = smoothness_indicator(dcoll, state.mass, s0=s0,
                                                     kappa=kappa)
                 my_write_viz(step=step, t=t, state=state, dv=dv,
                              tagged_cells=tagged_cells)
@@ -381,14 +381,14 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         except MyRuntimeError:
             if rank == 0:
                 logger.info("Errors detected; attempting graceful exit.")
-            tagged_cells = smoothness_indicator(discr, state.mass, s0=s0,
+            tagged_cells = smoothness_indicator(dcoll, state.mass, s0=s0,
                                                 kappa=kappa)
             my_write_viz(step=step, t=t, state=state,
                          tagged_cells=tagged_cells, dv=dv)
             my_write_restart(step=step, t=t, state=state)
             raise
 
-        dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+        dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                               current_cfl, t_final, constant_cfl)
 
         return state, dt
@@ -405,17 +405,17 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
         return (
-            euler_operator(discr, state=fluid_state, time=t,
+            euler_operator(dcoll, state=fluid_state, time=t,
                            boundaries=boundaries,
                            gas_model=gas_model, quadrature_tag=quadrature_tag)
-            + av_laplacian_operator(discr, fluid_state=fluid_state,
+            + av_laplacian_operator(dcoll, fluid_state=fluid_state,
                                     boundaries=boundaries,
                                     time=t, gas_model=gas_model,
                                     alpha=alpha, s0=s0, kappa=kappa,
                                     quadrature_tag=quadrature_tag)
         )
 
-    current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
 
     current_step, current_t, current_cv = \
@@ -429,7 +429,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         logger.info("Checkpointing final state ...")
     current_state = make_fluid_state(current_cv, gas_model)
     final_dv = current_state.dv
-    tagged_cells = smoothness_indicator(discr, current_cv.mass, s0=s0, kappa=kappa)
+    tagged_cells = smoothness_indicator(dcoll, current_cv.mass, s0=s0, kappa=kappa)
     my_write_viz(step=current_step, t=current_t, state=current_cv, dv=final_dv,
                  tagged_cells=tagged_cells)
     my_write_restart(step=current_step, t=current_t, state=current_cv)

--- a/examples/lump-mpi.py
+++ b/examples/lump-mpi.py
@@ -146,17 +146,17 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = create_discretization_collection(
+    dcoll = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None
 
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
         logmgr_add_device_memory_usage(logmgr, queue)
-        logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+        logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                              extract_vars_for_logging, units_for_logging)
 
         vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
@@ -180,9 +180,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     from mirgecom.gas_model import GasModel, make_fluid_state
     gas_model = GasModel(eos=eos)
 
-    def boundary_solution(discr, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -203,7 +203,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         current_cv = initializer(nodes)
     current_state = make_fluid_state(current_cv, gas_model)
 
-    visualizer = make_visualizer(discr)
+    visualizer = make_visualizer(dcoll)
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,
@@ -228,7 +228,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                       ("exact", exact),
                       ("residual", resid)]
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,
                       comm=comm)
 
@@ -250,13 +250,13 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_health_check(dv, state, exact):
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", dv.pressure) \
-           or check_range_local(discr, "vol", dv.pressure, .9999999999, 1.00000001):
+        if check_naninf_local(dcoll, "vol", dv.pressure) \
+           or check_range_local(dcoll, "vol", dv.pressure, .9999999999, 1.00000001):
             health_error = True
             logger.info(f"{rank=}: Invalid pressure data found.")
 
         from mirgecom.simutil import compare_fluid_solutions
-        component_errors = compare_fluid_solutions(discr, state, exact)
+        component_errors = compare_fluid_solutions(dcoll, state, exact)
         exittol = .09
         if max(component_errors) > exittol:
             health_error = True
@@ -303,7 +303,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                 if exact is None:
                     exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
-                component_errors = compare_fluid_solutions(discr, state, exact)
+                component_errors = compare_fluid_solutions(dcoll, state, exact)
                 status_msg = (
                     "------- errors="
                     + ", ".join("%.3g" % en for en in component_errors))
@@ -317,7 +317,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             my_write_restart(step=step, t=t, state=state)
             raise
 
-        dt = get_sim_timestep(discr, fluid_state, t, dt, current_cfl, t_final,
+        dt = get_sim_timestep(dcoll, fluid_state, t, dt, current_cfl, t_final,
                               constant_cfl)
         return state, dt
 
@@ -332,10 +332,10 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
-        return euler_operator(discr, state=fluid_state, time=t,
+        return euler_operator(dcoll, state=fluid_state, time=t,
                               boundaries=boundaries, gas_model=gas_model)
 
-    current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
 
     current_step, current_t, current_cv = \

--- a/examples/mixture-mpi.py
+++ b/examples/mixture-mpi.py
@@ -146,10 +146,10 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = create_discretization_collection(
+    dcoll = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None
 
@@ -168,7 +168,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         ])
 
         if log_dependent:
-            logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+            logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                                                       extract_vars_for_logging,
                                                       units_for_logging)
             logmgr.add_watches([
@@ -202,9 +202,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     initializer = MixtureInitializer(dim=dim, nspecies=nspecies,
                                      massfractions=y0s, velocity=velocity)
 
-    def boundary_solution(discr, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model,
@@ -229,7 +229,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     current_state = make_fluid_state(current_cv, gas_model, temperature_seed=tseed)
 
-    visualizer = make_visualizer(discr)
+    visualizer = make_visualizer(dcoll)
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,
@@ -251,13 +251,13 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             press = dv.pressure
 
             from grudge.op import nodal_min_loc, nodal_max_loc
-            tmin = global_reduce(actx.to_numpy(nodal_min_loc(discr, "vol", temp)),
+            tmin = global_reduce(actx.to_numpy(nodal_min_loc(dcoll, "vol", temp)),
                                  op="min")
-            tmax = global_reduce(actx.to_numpy(nodal_max_loc(discr, "vol", temp)),
+            tmax = global_reduce(actx.to_numpy(nodal_max_loc(dcoll, "vol", temp)),
                                  op="max")
-            pmin = global_reduce(actx.to_numpy(nodal_min_loc(discr, "vol", press)),
+            pmin = global_reduce(actx.to_numpy(nodal_min_loc(dcoll, "vol", press)),
                                  op="min")
-            pmax = global_reduce(actx.to_numpy(nodal_max_loc(discr, "vol", press)),
+            pmax = global_reduce(actx.to_numpy(nodal_max_loc(dcoll, "vol", press)),
                                  op="max")
             dv_status_msg = f"\nP({pmin}, {pmax}), T({tmin}, {tmax})"
             status_msg = status_msg + dv_status_msg
@@ -274,7 +274,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             resid = state - exact
         viz_fields = [("cv", state), ("dv", dv)]
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,
                       comm=comm)
 
@@ -297,8 +297,8 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_health_check(dv, component_errors):
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", dv.pressure) \
-           or check_range_local(discr, "vol", dv.pressure, 1e5, 1.1e5):
+        if check_naninf_local(dcoll, "vol", dv.pressure) \
+           or check_range_local(dcoll, "vol", dv.pressure, 1e5, 1.1e5):
             health_error = True
             logger.info(f"{rank=}: Invalid pressure data found.")
 
@@ -331,7 +331,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             if do_health:
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
-                component_errors = compare_fluid_solutions(discr, cv, exact)
+                component_errors = compare_fluid_solutions(dcoll, cv, exact)
                 health_errors = global_reduce(
                     my_health_check(dv, component_errors), op="lor")
                 if health_errors:
@@ -354,7 +354,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                     if exact is None:
                         exact = initializer(x_vec=nodes, eos=eos, time=t)
                     from mirgecom.simutil import compare_fluid_solutions
-                    component_errors = compare_fluid_solutions(discr, cv, exact)
+                    component_errors = compare_fluid_solutions(dcoll, cv, exact)
                 my_write_status(component_errors, dv=dv)
 
         except MyRuntimeError:
@@ -364,7 +364,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             my_write_restart(step=step, t=t, state=cv, tseed=tseed)
             raise
 
-        dt = get_sim_timestep(discr, fluid_state, t, dt, current_cfl, t_final,
+        dt = get_sim_timestep(dcoll, fluid_state, t, dt, current_cfl, t_final,
                               constant_cfl)
         return state, dt
 
@@ -384,11 +384,11 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         cv, tseed = state
         fluid_state = make_fluid_state(cv, gas_model, temperature_seed=tseed)
         return make_obj_array(
-            [euler_operator(discr, state=fluid_state, time=t,
+            [euler_operator(dcoll, state=fluid_state, time=t,
                             boundaries=boundaries, gas_model=gas_model),
              0*tseed])
 
-    current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
 
     current_step, current_t, advanced_state = \

--- a/examples/nsmix-mpi.py
+++ b/examples/nsmix-mpi.py
@@ -153,11 +153,11 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 1
-    discr = create_discretization_collection(
+    dcoll = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
-    nodes = actx.thaw(discr.nodes())
-    ones = discr.zeros(actx) + 1.0
+    nodes = actx.thaw(dcoll.nodes())
+    ones = dcoll.zeros(actx) + 1.0
 
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
@@ -174,7 +174,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         ])
 
         if log_dependent:
-            logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+            logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                                                       extract_vars_for_logging,
                                                       units_for_logging)
             logmgr.add_watches([
@@ -308,7 +308,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     # }}}
 
-    visualizer = make_visualizer(discr, order + 3 if dim == 2 else order)
+    visualizer = make_visualizer(dcoll, order + 3 if dim == 2 else order)
     initname = initializer.__class__.__name__
     eosname = gas_model.eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,
@@ -337,9 +337,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
             cfl = current_cfl
         else:
             from mirgecom.viscous import get_viscous_cfl
-            cfl_field = get_viscous_cfl(discr, dt, state=state)
+            cfl_field = get_viscous_cfl(dcoll, dt, state=state)
             from grudge.op import nodal_max
-            cfl = actx.to_numpy(nodal_max(discr, "vol", cfl_field))
+            cfl = actx.to_numpy(nodal_max(dcoll, "vol", cfl_field))
         status_msg = f"Step: {step}, T: {t}, DT: {dt}, CFL: {cfl}"
 
         if ((dv is not None) and (not log_dependent)):
@@ -347,13 +347,13 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
             press = dv.pressure
 
             from grudge.op import nodal_min_loc, nodal_max_loc
-            tmin = global_reduce(actx.to_numpy(nodal_min_loc(discr, "vol", temp)),
+            tmin = global_reduce(actx.to_numpy(nodal_min_loc(dcoll, "vol", temp)),
                                  op="min")
-            tmax = global_reduce(actx.to_numpy(nodal_max_loc(discr, "vol", temp)),
+            tmax = global_reduce(actx.to_numpy(nodal_max_loc(dcoll, "vol", temp)),
                                  op="max")
-            pmin = global_reduce(actx.to_numpy(nodal_min_loc(discr, "vol", press)),
+            pmin = global_reduce(actx.to_numpy(nodal_min_loc(dcoll, "vol", press)),
                                  op="min")
-            pmax = global_reduce(actx.to_numpy(nodal_max_loc(discr, "vol", press)),
+            pmax = global_reduce(actx.to_numpy(nodal_max_loc(dcoll, "vol", press)),
                                  op="max")
             dv_status_msg = f"\nP({pmin}, {pmax}), T({tmin}, {tmax})"
             status_msg = status_msg + dv_status_msg
@@ -365,7 +365,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         viz_fields = [("cv", state),
                       ("dv", dv)]
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, comm=comm)
 
     def my_write_restart(step, t, state, tseed):
@@ -392,28 +392,28 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         #       be changed accordingly.
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", dv.pressure):
+        if check_naninf_local(dcoll, "vol", dv.pressure):
             health_error = True
             logger.info(f"{rank=}: NANs/Infs in pressure data.")
 
-        if global_reduce(check_range_local(discr, "vol", dv.pressure, 9.9e4, 1.06e5),
+        if global_reduce(check_range_local(dcoll, "vol", dv.pressure, 9.9e4, 1.06e5),
                          op="lor"):
             health_error = True
             from grudge.op import nodal_max, nodal_min
-            p_min = actx.to_numpy(nodal_min(discr, "vol", dv.pressure))
-            p_max = actx.to_numpy(nodal_max(discr, "vol", dv.pressure))
+            p_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.pressure))
+            p_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.pressure))
             logger.info(f"Pressure range violation ({p_min=}, {p_max=})")
 
-        if check_naninf_local(discr, "vol", dv.temperature):
+        if check_naninf_local(dcoll, "vol", dv.temperature):
             health_error = True
             logger.info(f"{rank=}: NANs/INFs in temperature data.")
 
-        if global_reduce(check_range_local(discr, "vol", dv.temperature, 1450, 1570),
+        if global_reduce(check_range_local(dcoll, "vol", dv.temperature, 1450, 1570),
                          op="lor"):
             health_error = True
             from grudge.op import nodal_max, nodal_min
-            t_min = actx.to_numpy(nodal_min(discr, "vol", dv.temperature))
-            t_max = actx.to_numpy(nodal_max(discr, "vol", dv.temperature))
+            t_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.temperature))
+            t_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.temperature))
             logger.info(f"Temperature range violation ({t_min=}, {t_max=})")
 
         # This check is the temperature convergence check
@@ -421,7 +421,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         # in lazy mode.
         from grudge import op
         temp_resid = get_temperature_update(cv, dv.temperature) / dv.temperature
-        temp_err = (actx.to_numpy(op.nodal_max_loc(discr, "vol", temp_resid)))
+        temp_err = (actx.to_numpy(op.nodal_max_loc(dcoll, "vol", temp_resid)))
         if temp_err > 1e-8:
             health_error = True
             logger.info(f"{rank=}: Temperature is not converged {temp_resid=}.")
@@ -456,7 +456,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
             if do_viz:
                 my_write_viz(step=step, t=t, state=cv, dv=dv)
 
-            dt = get_sim_timestep(discr, fluid_state, t, dt, current_cfl,
+            dt = get_sim_timestep(dcoll, fluid_state, t, dt, current_cfl,
                                   t_final, constant_cfl)
             if do_status:
                 my_write_status(step, t, dt, dv=dv, state=fluid_state)
@@ -487,12 +487,12 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         cv, tseed = state
         fluid_state = make_fluid_state(cv=cv, gas_model=gas_model,
                                        temperature_seed=tseed)
-        ns_rhs = ns_operator(discr, state=fluid_state, time=t,
+        ns_rhs = ns_operator(dcoll, state=fluid_state, time=t,
                              boundaries=visc_bnds, gas_model=gas_model)
         cv_rhs = ns_rhs + eos.get_species_source_terms(cv, fluid_state.temperature)
         return make_obj_array([cv_rhs, 0*tseed])
 
-    current_dt = get_sim_timestep(discr, current_state, current_t,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t,
                                   current_dt, current_cfl, t_final, constant_cfl)
 
     current_step, current_t, current_stepper_state = \
@@ -510,7 +510,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     current_cv, tseed = current_stepper_state
     current_state = get_fluid_state(current_cv, tseed)
     final_dv = current_state.dv
-    final_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    final_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                 current_cfl, t_final, constant_cfl)
     my_write_viz(step=current_step, t=current_t, state=current_state.cv, dv=final_dv)
     my_write_restart(step=current_step, t=current_t, state=current_state.cv,

--- a/examples/poiseuille-mpi.py
+++ b/examples/poiseuille-mpi.py
@@ -168,10 +168,10 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 2
-    discr = create_discretization_collection(
+    dcoll = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     if use_overintegration:
         quadrature_tag = DISCR_TAG_QUAD
@@ -181,7 +181,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
         logmgr_add_device_memory_usage(logmgr, queue)
-        logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+        logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                              extract_vars_for_logging, units_for_logging)
 
         logmgr.add_watches([
@@ -235,9 +235,9 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                          transport=SimpleTransport(viscosity=mu))
     exact = initializer(x_vec=nodes, eos=gas_model.eos)
 
-    def _boundary_solution(discr, btag, gas_model, state_minus, **kwargs):
+    def _boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             cv=state_minus.cv, **kwargs), gas_model)
@@ -264,7 +264,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     vis_timer = None
 
-    visualizer = make_visualizer(discr, order)
+    visualizer = make_visualizer(dcoll, order)
 
     eosname = gas_model.eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,
@@ -280,16 +280,16 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_write_status(step, t, dt, state, component_errors):
         dv = state.dv
         from grudge.op import nodal_min, nodal_max
-        p_min = actx.to_numpy(nodal_min(discr, "vol", dv.pressure))
-        p_max = actx.to_numpy(nodal_max(discr, "vol", dv.pressure))
-        t_min = actx.to_numpy(nodal_min(discr, "vol", dv.temperature))
-        t_max = actx.to_numpy(nodal_max(discr, "vol", dv.temperature))
+        p_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.pressure))
+        p_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.pressure))
+        t_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.temperature))
+        t_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.temperature))
         if constant_cfl:
             cfl = current_cfl
         else:
             from mirgecom.viscous import get_viscous_cfl
-            cfl = actx.to_numpy(nodal_max(discr, "vol",
-                                          get_viscous_cfl(discr, dt, state)))
+            cfl = actx.to_numpy(nodal_max(dcoll, "vol",
+                                          get_viscous_cfl(dcoll, dt, state)))
         if rank == 0:
             logger.info(f"Step: {step}, T: {t}, DT: {dt}, CFL: {cfl}\n"
                         f"----- Pressure({p_min}, {p_max})\n"
@@ -305,7 +305,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
                       ("resid", resid)]
 
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, comm=comm)
 
     def my_write_restart(step, t, state):
@@ -326,28 +326,28 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_health_check(state, dv, component_errors):
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", dv.pressure):
+        if check_naninf_local(dcoll, "vol", dv.pressure):
             health_error = True
             logger.info(f"{rank=}: NANs/Infs in pressure data.")
 
-        if global_reduce(check_range_local(discr, "vol", dv.pressure, 9.999e4,
+        if global_reduce(check_range_local(dcoll, "vol", dv.pressure, 9.999e4,
                                            1.00101e5), op="lor"):
             health_error = True
             from grudge.op import nodal_max, nodal_min
-            p_min = actx.to_numpy(nodal_min(discr, "vol", dv.pressure))
-            p_max = actx.to_numpy(nodal_max(discr, "vol", dv.pressure))
+            p_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.pressure))
+            p_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.pressure))
             logger.info(f"Pressure range violation ({p_min=}, {p_max=})")
 
-        if check_naninf_local(discr, "vol", dv.temperature):
+        if check_naninf_local(dcoll, "vol", dv.temperature):
             health_error = True
             logger.info(f"{rank=}: NANs/INFs in temperature data.")
 
-        if global_reduce(check_range_local(discr, "vol", dv.temperature, 348, 350),
+        if global_reduce(check_range_local(dcoll, "vol", dv.temperature, 348, 350),
                          op="lor"):
             health_error = True
             from grudge.op import nodal_max, nodal_min
-            t_min = actx.to_numpy(nodal_min(discr, "vol", dv.temperature))
-            t_max = actx.to_numpy(nodal_max(discr, "vol", dv.temperature))
+            t_min = actx.to_numpy(nodal_min(dcoll, "vol", dv.temperature))
+            t_max = actx.to_numpy(nodal_max(dcoll, "vol", dv.temperature))
             logger.info(f"Temperature range violation ({t_min=}, {t_max=})")
 
         exittol = .1
@@ -375,7 +375,7 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
             if do_health:
                 from mirgecom.simutil import compare_fluid_solutions
-                component_errors = compare_fluid_solutions(discr, state, exact)
+                component_errors = compare_fluid_solutions(dcoll, state, exact)
                 health_errors = global_reduce(
                     my_health_check(state, dv, component_errors), op="lor")
                 if health_errors:
@@ -389,13 +389,13 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
             if do_viz:
                 my_write_viz(step=step, t=t, state=state, dv=dv)
 
-            dt = get_sim_timestep(discr, fluid_state, t, dt, current_cfl,
+            dt = get_sim_timestep(dcoll, fluid_state, t, dt, current_cfl,
                                   t_final, constant_cfl)
 
             if do_status:  # needed because logging fails to make output
                 if component_errors is None:
                     from mirgecom.simutil import compare_fluid_solutions
-                    component_errors = compare_fluid_solutions(discr, state, exact)
+                    component_errors = compare_fluid_solutions(dcoll, state, exact)
                 my_write_status(step=step, t=t, dt=dt, state=fluid_state,
                                 component_errors=component_errors)
 
@@ -419,11 +419,11 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
 
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
-        return ns_operator(discr, gas_model=gas_model, boundaries=boundaries,
+        return ns_operator(dcoll, gas_model=gas_model, boundaries=boundaries,
                            state=fluid_state, time=t,
                            quadrature_tag=quadrature_tag)
 
-    current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
 
     current_step, current_t, current_cv = \
@@ -438,10 +438,10 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     if rank == 0:
         logger.info("Checkpointing final state ...")
     final_dv = current_state.dv
-    final_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    final_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                 current_cfl, t_final, constant_cfl)
     from mirgecom.simutil import compare_fluid_solutions
-    component_errors = compare_fluid_solutions(discr, current_state.cv, exact)
+    component_errors = compare_fluid_solutions(dcoll, current_state.cv, exact)
 
     my_write_viz(step=current_step, t=current_t, state=current_state.cv, dv=final_dv)
     my_write_restart(step=current_step, t=current_t, state=current_state)

--- a/examples/scalar-lump-mpi.py
+++ b/examples/scalar-lump-mpi.py
@@ -145,17 +145,17 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = create_discretization_collection(
+    dcoll = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None
 
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
         logmgr_add_device_memory_usage(logmgr, queue)
-        logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+        logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                              extract_vars_for_logging, units_for_logging)
 
         vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
@@ -185,9 +185,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                                      spec_y0s=spec_y0s,
                                      spec_amplitudes=spec_amplitudes)
 
-    def boundary_solution(discr, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -208,7 +208,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         current_cv = initializer(nodes)
     current_state = make_fluid_state(current_cv, gas_model)
 
-    visualizer = make_visualizer(discr)
+    visualizer = make_visualizer(dcoll)
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
     init_message = make_init_message(dim=dim, order=order,
@@ -239,7 +239,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                       ("exact", exact),
                       ("resid", resid)]
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,
                       comm=comm)
 
@@ -261,8 +261,8 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_health_check(pressure, component_errors):
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", pressure) \
-           or check_range_local(discr, "vol", pressure, .99999999, 1.00000001):
+        if check_naninf_local(dcoll, "vol", pressure) \
+           or check_range_local(dcoll, "vol", pressure, .99999999, 1.00000001):
             health_error = True
             logger.info(f"{rank=}: Invalid pressure data found.")
 
@@ -295,7 +295,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             if do_health:
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
-                component_errors = compare_fluid_solutions(discr, cv, exact)
+                component_errors = compare_fluid_solutions(dcoll, cv, exact)
                 health_errors = global_reduce(
                     my_health_check(dv.pressure, component_errors), op="lor")
                 if health_errors:
@@ -318,7 +318,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                     if exact is None:
                         exact = initializer(x_vec=nodes, eos=eos, time=t)
                     from mirgecom.simutil import compare_fluid_solutions
-                    component_errors = compare_fluid_solutions(discr, cv, exact)
+                    component_errors = compare_fluid_solutions(dcoll, cv, exact)
                 my_write_status(component_errors)
 
         except MyRuntimeError:
@@ -328,7 +328,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             my_write_restart(step=step, t=t, state=cv)
             raise
 
-        dt = get_sim_timestep(discr, fluid_state, t, dt, current_cfl, t_final,
+        dt = get_sim_timestep(dcoll, fluid_state, t, dt, current_cfl, t_final,
                               constant_cfl)
         return state, dt
 
@@ -343,10 +343,10 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
-        return euler_operator(discr, state=fluid_state, time=t,
+        return euler_operator(dcoll, state=fluid_state, time=t,
                               boundaries=boundaries, gas_model=gas_model)
 
-    current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
 
     current_step, current_t, current_cv = \

--- a/examples/vortex-mpi.py
+++ b/examples/vortex-mpi.py
@@ -149,17 +149,17 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
         local_nelements = local_mesh.nelements
 
     order = 3
-    discr = create_discretization_collection(
+    dcoll = create_discretization_collection(
         actx, local_mesh, order=order, mpi_communicator=comm
     )
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     vis_timer = None
 
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
         logmgr_add_device_memory_usage(logmgr, queue)
-        logmgr_add_many_discretization_quantities(logmgr, discr, dim,
+        logmgr_add_many_discretization_quantities(logmgr, dcoll, dim,
                              extract_vars_for_logging, units_for_logging)
 
         vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
@@ -190,9 +190,9 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     initializer = Vortex2D(center=orig, velocity=vel)
     gas_model = GasModel(eos=eos)
 
-    def boundary_solution(discr, btag, gas_model, state_minus, **kwargs):
+    def boundary_solution(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(initializer(x_vec=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -214,7 +214,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     current_state = make_fluid_state(current_cv, gas_model)
 
-    visualizer = make_visualizer(discr)
+    visualizer = make_visualizer(dcoll)
 
     initname = initializer.__class__.__name__
     eosname = eos.__class__.__name__
@@ -237,8 +237,8 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                 from mirgecom.inviscid import get_inviscid_cfl
                 cfl = actx.to_numpy(
                     nodal_max(
-                        discr, "vol",
-                        get_inviscid_cfl(discr, state, current_dt)))[()]
+                        dcoll, "vol",
+                        get_inviscid_cfl(dcoll, state, current_dt)))[()]
         if rank == 0:
             logger.info(
                 f"------ {cfl=}\n"
@@ -255,7 +255,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                       ("exact", exact),
                       ("residual", resid)]
         from mirgecom.simutil import write_visfile
-        write_visfile(discr, viz_fields, visualizer, vizname=casename,
+        write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,
                       comm=comm)
 
@@ -277,8 +277,8 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
     def my_health_check(pressure, component_errors):
         health_error = False
         from mirgecom.simutil import check_naninf_local, check_range_local
-        if check_naninf_local(discr, "vol", pressure) \
-           or check_range_local(discr, "vol", pressure, .2, 1.02):
+        if check_naninf_local(dcoll, "vol", pressure) \
+           or check_range_local(dcoll, "vol", pressure, .2, 1.02):
             health_error = True
             logger.info(f"{rank=}: Invalid pressure data found.")
 
@@ -310,7 +310,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             if do_health:
                 exact = initializer(x_vec=nodes, eos=eos, time=t)
                 from mirgecom.simutil import compare_fluid_solutions
-                component_errors = compare_fluid_solutions(discr, cv, exact)
+                component_errors = compare_fluid_solutions(dcoll, cv, exact)
                 health_errors = global_reduce(
                     my_health_check(dv.pressure, component_errors), op="lor")
                 if health_errors:
@@ -326,7 +326,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
                     if exact is None:
                         exact = initializer(x_vec=nodes, eos=eos, time=t)
                     from mirgecom.simutil import compare_fluid_solutions
-                    component_errors = compare_fluid_solutions(discr, cv, exact)
+                    component_errors = compare_fluid_solutions(dcoll, cv, exact)
                 my_write_status(fluid_state, component_errors)
 
             if do_viz:
@@ -343,7 +343,7 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
             my_write_restart(step=step, t=t, state=cv)
             raise
 
-        dt = get_sim_timestep(discr, fluid_state, t, dt, current_cfl, t_final,
+        dt = get_sim_timestep(dcoll, fluid_state, t, dt, current_cfl, t_final,
                               constant_cfl)
         return state, dt
 
@@ -358,10 +358,10 @@ def main(actx_class, ctx_factory=cl.create_some_context, use_logmgr=True,
 
     def my_rhs(t, state):
         fluid_state = make_fluid_state(state, gas_model)
-        return euler_operator(discr, state=fluid_state, time=t,
+        return euler_operator(dcoll, state=fluid_state, time=t,
                               boundaries=boundaries, gas_model=gas_model)
 
-    current_dt = get_sim_timestep(discr, current_state, current_t, current_dt,
+    current_dt = get_sim_timestep(dcoll, current_state, current_t, current_dt,
                                   current_cfl, t_final, constant_cfl)
 
     current_step, current_t, current_cv = \

--- a/examples/wave.py
+++ b/examples/wave.py
@@ -106,20 +106,20 @@ def main(use_profiling=False, use_logmgr=False, lazy: bool = False):
 
     order = 3
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     current_cfl = 0.485
     wave_speed = 1.0
     from grudge.dt_utils import characteristic_lengthscales
-    nodal_dt = characteristic_lengthscales(actx, discr) / wave_speed
-    dt = actx.to_numpy(current_cfl * op.nodal_min(discr, "vol",
+    nodal_dt = characteristic_lengthscales(actx, dcoll) / wave_speed
+    dt = actx.to_numpy(current_cfl * op.nodal_min(dcoll, "vol",
                                                   nodal_dt))[()]
 
     print("%d elements" % mesh.nelements)
 
     fields = flat_obj_array(bump(actx, nodes),
-                            [discr.zeros(actx) for i in range(dim)])
+                            [dcoll.zeros(actx) for i in range(dim)])
 
     if logmgr:
         logmgr_add_cl_device_info(logmgr, queue)
@@ -138,10 +138,10 @@ def main(use_profiling=False, use_logmgr=False, lazy: bool = False):
         vis_timer = IntervalTimer("t_vis", "Time spent visualizing")
         logmgr.add_quantity(vis_timer)
 
-    vis = make_visualizer(discr)
+    vis = make_visualizer(dcoll)
 
     def rhs(t, w):
-        return wave_operator(discr, c=wave_speed, w=w)
+        return wave_operator(dcoll, c=wave_speed, w=w)
 
     compiled_rhs = actx.compile(rhs)
     fields = force_evaluation(actx, fields)
@@ -159,7 +159,7 @@ def main(use_profiling=False, use_logmgr=False, lazy: bool = False):
         if istep % 10 == 0:
             if use_profiling:
                 print(actx.tabulate_profiling_data())
-            print(istep, t, actx.to_numpy(op.norm(discr, fields[0], 2)))
+            print(istep, t, actx.to_numpy(op.norm(dcoll, fields[0], 2)))
             vis.write_vtk_file("fld-wave-%04d.vtu" % istep,
                     [
                         ("u", fields[0]),

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -67,7 +67,7 @@ class FluidBoundary(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def inviscid_divergence_flux(self, discr, btag, gas_model, state_minus,
+    def inviscid_divergence_flux(self, dcoll, btag, gas_model, state_minus,
                                  numerical_flux_func, **kwargs):
         """Get the inviscid boundary flux for the divergence operator.
 
@@ -76,7 +76,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.discretization.DiscretizationCollection`
+        dcoll: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -108,7 +108,7 @@ class FluidBoundary(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def viscous_divergence_flux(self, discr, btag, gas_model, state_minus,
+    def viscous_divergence_flux(self, dcoll, btag, gas_model, state_minus,
                                 grad_cv_minus, grad_t_minus,
                                 numerical_flux_func, **kwargs):
         """Get the viscous boundary flux for the divergence operator.
@@ -118,7 +118,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.discretization.DiscretizationCollection`
+        dcoll: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -160,7 +160,7 @@ class FluidBoundary(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def cv_gradient_flux(self, discr, btag, gas_model, state_minus, **kwargs):
+    def cv_gradient_flux(self, dcoll, btag, gas_model, state_minus, **kwargs):
         """Get the boundary flux for the gradient of the fluid conserved variables.
 
         This routine returns the facial flux used by the gradient operator to
@@ -168,7 +168,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.discretization.DiscretizationCollection`
+        dcoll: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -193,7 +193,7 @@ class FluidBoundary(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def temperature_gradient_flux(self, discr, btag, gas_model, state_minus,
+    def temperature_gradient_flux(self, dcoll, btag, gas_model, state_minus,
                                   **kwargs):
         """Get the boundary flux for the gradient of the fluid temperature.
 
@@ -203,7 +203,7 @@ class FluidBoundary(metaclass=ABCMeta):
 
         Parameters
         ----------
-        discr: :class:`~grudge.discretization.DiscretizationCollection`
+        dcoll: :class:`~grudge.discretization.DiscretizationCollection`
 
             A discretization collection encapsulating the DG elements
 
@@ -310,17 +310,17 @@ class PrescribedFluidBoundary(FluidBoundary):
         if not self._bnd_grad_temperature_func:
             self._bnd_grad_temperature_func = self._identical_grad_temperature
 
-    def _boundary_quantity(self, discr, btag, quantity, local=False, **kwargs):
+    def _boundary_quantity(self, dcoll, btag, quantity, local=False, **kwargs):
         """Get a boundary quantity on local boundary, or projected to "all_faces"."""
         from grudge.dof_desc import as_dofdesc
         btag = as_dofdesc(btag)
-        return quantity if local else op.project(discr,
+        return quantity if local else op.project(dcoll,
             btag, btag.with_dtag("all_faces"), quantity)
 
-    def _boundary_state_pair(self, discr, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state_pair(self, dcoll, btag, gas_model, state_minus, **kwargs):
         return TracePair(btag,
                          interior=state_minus,
-                         exterior=self._bnd_state_func(discr=discr, btag=btag,
+                         exterior=self._bnd_state_func(dcoll=dcoll, btag=btag,
                                                        gas_model=gas_model,
                                                        state_minus=state_minus,
                                                        **kwargs))
@@ -332,9 +332,9 @@ class PrescribedFluidBoundary(FluidBoundary):
     # {{{ Default boundary helpers
 
     # Returns temperature(+) for boundaries that prescribe CV(+)
-    def _temperature_for_prescribed_state(self, discr, btag,
+    def _temperature_for_prescribed_state(self, dcoll, btag,
                                           gas_model, state_minus, **kwargs):
-        boundary_state = self._bnd_state_func(discr=discr, btag=btag,
+        boundary_state = self._bnd_state_func(dcoll=dcoll, btag=btag,
                                               gas_model=gas_model,
                                               state_minus=state_minus,
                                               **kwargs)
@@ -351,10 +351,10 @@ class PrescribedFluidBoundary(FluidBoundary):
 
     # Returns the flux to be used by the gradient operator when computing the
     # gradient of the fluid solution on boundaries that prescribe CV(+).
-    def _gradient_flux_for_prescribed_cv(self, discr, btag, gas_model, state_minus,
+    def _gradient_flux_for_prescribed_cv(self, dcoll, btag, gas_model, state_minus,
                                          **kwargs):
         # Use prescribed external state and gradient numerical flux function
-        boundary_state = self._bnd_state_func(discr=discr, btag=btag,
+        boundary_state = self._bnd_state_func(dcoll=dcoll, btag=btag,
                                               gas_model=gas_model,
                                               state_minus=state_minus,
                                               **kwargs)
@@ -363,21 +363,21 @@ class PrescribedFluidBoundary(FluidBoundary):
                             exterior=boundary_state.cv)
 
         actx = state_minus.array_context
-        nhat = actx.thaw(discr.normal(btag))
+        nhat = actx.thaw(dcoll.normal(btag))
         from arraycontext import outer
         return outer(self._grad_num_flux_func(cv_pair.int, cv_pair.ext), nhat)
 
     # Returns the flux to be used by the gradient operator when computing the
     # gradient of fluid temperature using prescribed fluid temperature(+).
-    def _gradient_flux_for_prescribed_temperature(self, discr, btag, gas_model,
+    def _gradient_flux_for_prescribed_temperature(self, dcoll, btag, gas_model,
                                                   state_minus, **kwargs):
         # Feed a boundary temperature to numerical flux for grad op
         actx = state_minus.array_context
-        nhat = actx.thaw(discr.normal(btag))
+        nhat = actx.thaw(dcoll.normal(btag))
         bnd_tpair = TracePair(btag,
                               interior=state_minus.temperature,
                               exterior=self._bnd_temperature_func(
-                                  discr=discr, btag=btag, gas_model=gas_model,
+                                  dcoll=dcoll, btag=btag, gas_model=gas_model,
                                   state_minus=state_minus, **kwargs))
         from arraycontext import outer
         return outer(self._grad_num_flux_func(bnd_tpair.int, bnd_tpair.ext), nhat)
@@ -386,31 +386,31 @@ class PrescribedFluidBoundary(FluidBoundary):
     # divergence of inviscid fluid transport flux using the boundary's
     # prescribed CV(+).
     def _inviscid_flux_for_prescribed_state(
-            self, discr, btag, gas_model, state_minus,
+            self, dcoll, btag, gas_model, state_minus,
             numerical_flux_func=inviscid_facial_flux_rusanov, **kwargs):
         # Use a prescribed boundary state and the numerical flux function
-        boundary_state_pair = self._boundary_state_pair(discr=discr, btag=btag,
+        boundary_state_pair = self._boundary_state_pair(dcoll=dcoll, btag=btag,
                                                         gas_model=gas_model,
                                                         state_minus=state_minus,
                                                         **kwargs)
-        normal = state_minus.array_context.thaw(discr.normal(btag))
+        normal = state_minus.array_context.thaw(dcoll.normal(btag))
         return numerical_flux_func(boundary_state_pair, gas_model, normal)
 
     # Returns the flux to be used by the divergence operator when computing the
     # divergence of viscous fluid transport flux using the boundary's
     # prescribed CV(+).
     def _viscous_flux_for_prescribed_state(
-            self, discr, btag, gas_model, state_minus, grad_cv_minus, grad_t_minus,
+            self, dcoll, btag, gas_model, state_minus, grad_cv_minus, grad_t_minus,
             numerical_flux_func=viscous_facial_flux_central, **kwargs):
 
         state_pair = self._boundary_state_pair(
-            discr=discr, btag=btag, gas_model=gas_model, state_minus=state_minus,
+            dcoll=dcoll, btag=btag, gas_model=gas_model, state_minus=state_minus,
             **kwargs)
 
         grad_cv_pair = \
             TracePair(btag, interior=grad_cv_minus,
                       exterior=self._bnd_grad_cv_func(
-                          discr=discr, btag=btag, gas_model=gas_model,
+                          dcoll=dcoll, btag=btag, gas_model=gas_model,
                           state_minus=state_minus, grad_cv_minus=grad_cv_minus,
                           grad_t_minus=grad_t_minus))
 
@@ -418,42 +418,42 @@ class PrescribedFluidBoundary(FluidBoundary):
             TracePair(
                 btag, interior=grad_t_minus,
                 exterior=self._bnd_grad_temperature_func(
-                    discr=discr, btag=btag, gas_model=gas_model,
+                    dcoll=dcoll, btag=btag, gas_model=gas_model,
                     state_minus=state_minus, grad_cv_minus=grad_cv_minus,
                     grad_t_minus=grad_t_minus))
 
         return numerical_flux_func(
-            discr=discr, gas_model=gas_model, state_pair=state_pair,
+            dcoll=dcoll, gas_model=gas_model, state_pair=state_pair,
             grad_cv_pair=grad_cv_pair, grad_t_pair=grad_t_pair)
 
     # }}} Default boundary helpers
 
-    def inviscid_divergence_flux(self, discr, btag, gas_model, state_minus,
+    def inviscid_divergence_flux(self, dcoll, btag, gas_model, state_minus,
                                  numerical_flux_func=inviscid_facial_flux_rusanov,
                                  **kwargs):
         """Get the inviscid boundary flux for the divergence operator."""
-        return self._inviscid_flux_func(discr, btag, gas_model, state_minus,
+        return self._inviscid_flux_func(dcoll, btag, gas_model, state_minus,
                                         numerical_flux_func=numerical_flux_func,
                                         **kwargs)
 
-    def cv_gradient_flux(self, discr, btag, gas_model, state_minus, **kwargs):
+    def cv_gradient_flux(self, dcoll, btag, gas_model, state_minus, **kwargs):
         """Get the cv flux for *btag* for use in the gradient operator."""
         return self._cv_gradient_flux_func(
-            discr=discr, btag=btag, gas_model=gas_model, state_minus=state_minus,
+            dcoll=dcoll, btag=btag, gas_model=gas_model, state_minus=state_minus,
             **kwargs)
 
-    def temperature_gradient_flux(self, discr, btag, gas_model, state_minus,
+    def temperature_gradient_flux(self, dcoll, btag, gas_model, state_minus,
                                   **kwargs):
         """Get the "temperature flux" for *btag* for use in the gradient operator."""
-        return self._temperature_grad_flux_func(discr, btag, gas_model, state_minus,
+        return self._temperature_grad_flux_func(dcoll, btag, gas_model, state_minus,
                                                 **kwargs)
 
-    def viscous_divergence_flux(self, discr, btag, gas_model, state_minus,
+    def viscous_divergence_flux(self, dcoll, btag, gas_model, state_minus,
                                 grad_cv_minus, grad_t_minus,
                                 numerical_flux_func=viscous_facial_flux_central,
                                 **kwargs):
         """Get the viscous flux for *btag* for use in the divergence operator."""
-        return self._viscous_flux_func(discr=discr, btag=btag, gas_model=gas_model,
+        return self._viscous_flux_func(dcoll=dcoll, btag=btag, gas_model=gas_model,
                                        state_minus=state_minus,
                                        grad_cv_minus=grad_cv_minus,
                                        grad_t_minus=grad_t_minus,
@@ -465,17 +465,17 @@ class PrescribedFluidBoundary(FluidBoundary):
     def _identical_grad_av(self, grad_av_minus, **kwargs):
         return grad_av_minus
 
-    def av_flux(self, discr, btag, diffusion, **kwargs):
+    def av_flux(self, dcoll, btag, diffusion, **kwargs):
         """Get the diffusive fluxes for the AV operator API."""
-        grad_av_minus = op.project(discr, "vol", btag, diffusion)
+        grad_av_minus = op.project(dcoll, "vol", btag, diffusion)
         actx = grad_av_minus.mass[0].array_context
-        nhat = actx.thaw(discr.normal(btag))
+        nhat = actx.thaw(dcoll.normal(btag))
         grad_av_plus = self._bnd_grad_av_func(
-            discr=discr, btag=btag, grad_av_minus=grad_av_minus, **kwargs)
+            dcoll=dcoll, btag=btag, grad_av_minus=grad_av_minus, **kwargs)
         bnd_grad_pair = TracePair(btag, interior=grad_av_minus,
                                   exterior=grad_av_plus)
         num_flux = self._av_num_flux_func(bnd_grad_pair.int, bnd_grad_pair.ext)@nhat
-        return self._boundary_quantity(discr, btag, num_flux, **kwargs)
+        return self._boundary_quantity(dcoll, btag, num_flux, **kwargs)
 
     # }}}
 
@@ -514,7 +514,7 @@ class AdiabaticSlipBoundary(PrescribedFluidBoundary):
             boundary_grad_av_func=self.adiabatic_slip_grad_av
         )
 
-    def adiabatic_slip_state(self, discr, btag, gas_model, state_minus, **kwargs):
+    def adiabatic_slip_state(self, dcoll, btag, gas_model, state_minus, **kwargs):
         """Get the exterior solution on the boundary.
 
         The exterior solution is set such that there will be vanishing
@@ -530,7 +530,7 @@ class AdiabaticSlipBoundary(PrescribedFluidBoundary):
         actx = state_minus.array_context
 
         # Grab a unit normal to the boundary
-        nhat = actx.thaw(discr.normal(btag))
+        nhat = actx.thaw(dcoll.normal(btag))
 
         # Subtract out the 2*wall-normal component
         # of velocity from the velocity at the wall to
@@ -547,12 +547,12 @@ class AdiabaticSlipBoundary(PrescribedFluidBoundary):
         return make_fluid_state(cv=ext_cv, gas_model=gas_model,
                                 temperature_seed=t_seed)
 
-    def adiabatic_slip_grad_av(self, discr, btag, grad_av_minus, **kwargs):
+    def adiabatic_slip_grad_av(self, dcoll, btag, grad_av_minus, **kwargs):
         """Get the exterior grad(Q) on the boundary."""
         # Grab some boundary-relevant data
         dim, = grad_av_minus.mass.shape
         actx = grad_av_minus.mass[0].array_context
-        nhat = actx.thaw(discr.normal(btag))
+        nhat = actx.thaw(dcoll.normal(btag))
 
         # Subtract 2*wall-normal component of q
         # to enforce q=0 on the wall
@@ -587,7 +587,7 @@ class AdiabaticNoslipMovingBoundary(PrescribedFluidBoundary):
             raise ValueError(f"Specified wall velocity must be {dim}-vector.")
         self._wall_velocity = wall_velocity
 
-    def adiabatic_noslip_state(self, discr, btag, gas_model, state_minus, **kwargs):
+    def adiabatic_noslip_state(self, dcoll, btag, gas_model, state_minus, **kwargs):
         """Get the exterior solution on the boundary.
 
         Sets the external state s.t. $v^+ = -v^-$, giving vanishing contact velocity
@@ -624,7 +624,7 @@ class IsothermalNoSlipBoundary(PrescribedFluidBoundary):
             boundary_temperature_func=self.temperature_bc
         )
 
-    def isothermal_noslip_state(self, discr, btag, gas_model, state_minus, **kwargs):
+    def isothermal_noslip_state(self, dcoll, btag, gas_model, state_minus, **kwargs):
         r"""Get the interior and exterior solution (*state_minus*) on the boundary.
 
         Sets the external state s.t. $v^+ = -v^-$, giving vanishing contact velocity

--- a/mirgecom/euler.py
+++ b/mirgecom/euler.py
@@ -66,7 +66,7 @@ from mirgecom.inviscid import (
 from mirgecom.operators import div_operator
 
 
-def euler_operator(discr, state, gas_model, boundaries, time=0.0,
+def euler_operator(dcoll, state, gas_model, boundaries, time=0.0,
                    inviscid_numerical_flux_func=inviscid_facial_flux_rusanov,
                    quadrature_tag=None, operator_states_quad=None):
     r"""Compute RHS of the Euler flow equations.
@@ -112,7 +112,7 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
     dd_quad_faces = DOFDesc("all_faces", quadrature_tag)
 
     if operator_states_quad is None:
-        operator_states_quad = make_operator_fluid_states(discr, state, gas_model,
+        operator_states_quad = make_operator_fluid_states(dcoll, state, gas_model,
                                                           boundaries, quadrature_tag)
 
     volume_state_quad, interior_state_pairs_quad, domain_boundary_states_quad = \
@@ -123,11 +123,11 @@ def euler_operator(discr, state, gas_model, boundaries, time=0.0,
 
     # Compute interface contributions
     inviscid_flux_bnd = inviscid_flux_on_element_boundary(
-        discr, gas_model, boundaries, interior_state_pairs_quad,
+        dcoll, gas_model, boundaries, interior_state_pairs_quad,
         domain_boundary_states_quad, quadrature_tag=quadrature_tag,
         numerical_flux_func=inviscid_numerical_flux_func, time=time)
 
-    return -div_operator(discr, dd_quad_vol, dd_quad_faces,
+    return -div_operator(dcoll, dd_quad_vol, dd_quad_faces,
                          inviscid_flux_vol, inviscid_flux_bnd)
 
 

--- a/mirgecom/initializers.py
+++ b/mirgecom/initializers.py
@@ -492,7 +492,7 @@ class Lump:
         return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom)
 
-    def exact_rhs(self, discr, cv, time=0.0):
+    def exact_rhs(self, dcoll, cv, time=0.0):
         """
         Create the RHS for the lump-of-mass solution at time *t*, locations *x_vec*.
 
@@ -509,7 +509,7 @@ class Lump:
         """
         t = time
         actx = cv.array_context
-        nodes = actx.thaw(discr.nodes())
+        nodes = actx.thaw(dcoll.nodes())
         lump_loc = self._center + t * self._velocity
         # coordinates relative to lump center
         rel_center = make_obj_array(
@@ -671,7 +671,7 @@ class MulticomponentLump:
         return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom, species_mass=species_mass)
 
-    def exact_rhs(self, discr, cv, time=0.0):
+    def exact_rhs(self, dcoll, cv, time=0.0):
         """
         Create a RHS for multi-component lump soln at time *t*, locations *x_vec*.
 
@@ -688,7 +688,7 @@ class MulticomponentLump:
         """
         t = time
         actx = cv.array_context
-        nodes = actx.thaw(discr.nodes())
+        nodes = actx.thaw(dcoll.nodes())
         loc_update = t * self._velocity
 
         mass = 0 * nodes[0] + self._rho0
@@ -865,7 +865,7 @@ class Uniform:
         return make_conserved(dim=self._dim, mass=mass, energy=energy,
                               momentum=mom, species_mass=species_mass)
 
-    def exact_rhs(self, discr, cv, time=0.0):
+    def exact_rhs(self, dcoll, cv, time=0.0):
         """
         Create the RHS for the uniform solution. (Hint - it should be all zero).
 
@@ -877,7 +877,7 @@ class Uniform:
             Time at which RHS is desired (unused)
         """
         actx = cv.array_context
-        nodes = actx.thaw(discr.nodes())
+        nodes = actx.thaw(dcoll.nodes())
         mass = nodes[0].copy()
         mass[:] = 1.0
         massrhs = 0.0 * mass

--- a/mirgecom/io.py
+++ b/mirgecom/io.py
@@ -52,11 +52,11 @@ def make_init_message(*, dim, order, dt, t_final,
     )
 
 
-def make_status_message(*, discr, t, step, dt, cfl, dependent_vars):
+def make_status_message(*, dcoll, t, step, dt, cfl, dependent_vars):
     r"""Make simulation status and health message."""
     dv = dependent_vars
-    _min = partial(op.nodal_min, discr, "vol")
-    _max = partial(op.nodal_max, discr, "vol")
+    _min = partial(op.nodal_min, dcoll, "vol")
+    _max = partial(op.nodal_max, dcoll, "vol")
     statusmsg = (
         f"Status: {step=} {t=}\n"
         f"------- P({_min(dv.pressure):.3g}, {_max(dv.pressure):.3g})\n"

--- a/mirgecom/operators.py
+++ b/mirgecom/operators.py
@@ -31,13 +31,13 @@ THE SOFTWARE.
 import grudge.op as op
 
 
-def grad_operator(discr, dd_vol, dd_faces, u, flux):
+def grad_operator(dcoll, dd_vol, dd_faces, u, flux):
     r"""Compute a DG gradient for the input *u* with flux given by *flux*.
 
     Parameters
     ----------
-    discr: grudge.discretization.DiscretizationCollection
-        the discretization to use
+    dcoll: grudge.discretization.DiscretizationCollection
+        the discretization collection to use
     dd_vol: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the volume discretization.
         This determines the type of quadrature to be used.
@@ -57,18 +57,18 @@ def grad_operator(discr, dd_vol, dd_faces, u, flux):
         the dg gradient operator applied to *u*
     """
     # pylint: disable=invalid-unary-operand-type
-    return - op.inverse_mass(discr,
-        op.weak_local_grad(discr, dd_vol, u)
-        - op.face_mass(discr, dd_faces, flux))
+    return - op.inverse_mass(dcoll,
+        op.weak_local_grad(dcoll, dd_vol, u)
+        - op.face_mass(dcoll, dd_faces, flux))
 
 
-def div_operator(discr, dd_vol, dd_faces, v, flux):
+def div_operator(dcoll, dd_vol, dd_faces, v, flux):
     r"""Compute DG divergence of vector-valued func *v* with flux given by *flux*.
 
     Parameters
     ----------
-    discr: grudge.discretization.DiscretizationCollection
-        the discretization to use
+    dcoll: grudge.discretization.DiscretizationCollection
+        the discretization collection to use
     dd_vol: grudge.dof_desc.DOFDesc
         the degree-of-freedom tag associated with the volume discretization.
         This determines the type of quadrature to be used.
@@ -88,6 +88,6 @@ def div_operator(discr, dd_vol, dd_faces, v, flux):
         the dg divergence operator applied to vector-valued function(s) *v*.
     """
     # pylint: disable=invalid-unary-operand-type
-    return - op.inverse_mass(discr,
-        op.weak_local_div(discr, dd_vol, v)
-        - op.face_mass(discr, dd_faces, flux))
+    return - op.inverse_mass(dcoll,
+        op.weak_local_div(dcoll, dd_vol, v)
+        - op.face_mass(dcoll, dd_faces, flux))

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -92,7 +92,7 @@ def check_step(step, interval):
     return False
 
 
-def get_sim_timestep(discr, state, t, dt, cfl, t_final, constant_cfl=False):
+def get_sim_timestep(dcoll, state, t, dt, cfl, t_final, constant_cfl=False):
     """Return the maximum stable timestep for a typical fluid simulation.
 
     This routine returns *dt*, the users defined constant timestep, or *max_dt*, the
@@ -109,8 +109,8 @@ def get_sim_timestep(discr, state, t, dt, cfl, t_final, constant_cfl=False):
 
     Parameters
     ----------
-    discr
-        Grudge discretization or discretization collection?
+    dcoll: grudge.discretization.DiscretizationCollection
+        The discretization collection to use
     state: :class:`~mirgecom.gas_model.FluidState`
         The full fluid conserved and thermal state
     t: float
@@ -136,12 +136,12 @@ def get_sim_timestep(discr, state, t, dt, cfl, t_final, constant_cfl=False):
         from grudge.op import nodal_min
         mydt = state.array_context.to_numpy(
             cfl * nodal_min(
-                discr, "vol",
-                get_viscous_timestep(discr=discr, state=state)))[()]
+                dcoll, "vol",
+                get_viscous_timestep(dcoll=dcoll, state=state)))[()]
     return min(t_remaining, mydt)
 
 
-def write_visfile(discr, io_fields, visualizer, vizname,
+def write_visfile(dcoll, io_fields, visualizer, vizname,
                   step=0, t=0, overwrite=False, vis_timer=None,
                   comm=None):
     """Write parallel VTK output for the fields specified in *io_fields*.
@@ -182,8 +182,8 @@ def write_visfile(discr, io_fields, visualizer, vizname,
     from mirgecom.io import make_rank_fname, make_par_fname
 
     if comm is None:  # None is OK for serial writes!
-        comm = discr.mpi_communicator
-        if comm is not None:  # It's *not* OK to get comm from discr
+        comm = dcoll.mpi_communicator
+        if comm is not None:  # It's *not* OK to get comm from dcoll
             from warnings import warn
             warn("Using `write_visfile` in parallel without an MPI communicator is "
                  "deprecated and will stop working in Fall 2022. For parallel "
@@ -311,12 +311,12 @@ def allsync(local_values, comm=None, op=None):
     return global_reduce(local_values, op_string, comm=comm)
 
 
-def check_range_local(discr: DiscretizationCollection, dd: str, field: DOFArray,
+def check_range_local(dcoll: DiscretizationCollection, dd: str, field: DOFArray,
                       min_value: float, max_value: float) -> List[float]:
     """Return the values that are outside the range [min_value, max_value]."""
     actx = field.array_context
-    local_min = actx.to_numpy(op.nodal_min_loc(discr, dd, field)).item()
-    local_max = actx.to_numpy(op.nodal_max_loc(discr, dd, field)).item()
+    local_min = actx.to_numpy(op.nodal_min_loc(dcoll, dd, field)).item()
+    local_max = actx.to_numpy(op.nodal_max_loc(dcoll, dd, field)).item()
 
     failing_values = []
 
@@ -328,15 +328,15 @@ def check_range_local(discr: DiscretizationCollection, dd: str, field: DOFArray,
     return failing_values
 
 
-def check_naninf_local(discr: DiscretizationCollection, dd: str,
+def check_naninf_local(dcoll: DiscretizationCollection, dd: str,
                        field: DOFArray) -> bool:
     """Return True if there are any NaNs or Infs in the field."""
     actx = field.array_context
-    s = actx.to_numpy(op.nodal_sum_loc(discr, dd, field))
+    s = actx.to_numpy(op.nodal_sum_loc(dcoll, dd, field))
     return not np.isfinite(s)
 
 
-def compare_fluid_solutions(discr, red_state, blue_state):
+def compare_fluid_solutions(dcoll, red_state, blue_state):
     """Return inf norm of (*red_state* - *blue_state*) for each component.
 
     .. note::
@@ -345,12 +345,12 @@ def compare_fluid_solutions(discr, red_state, blue_state):
     actx = red_state.array_context
     resid = red_state - blue_state
     resid_errs = actx.to_numpy(
-        flatten(componentwise_norms(discr, resid, order=np.inf), actx))
+        flatten(componentwise_norms(dcoll, resid, order=np.inf), actx))
 
     return resid_errs.tolist()
 
 
-def componentwise_norms(discr, fields, order=np.inf):
+def componentwise_norms(dcoll, fields, order=np.inf):
     """Return the *order*-norm for each component of *fields*.
 
     .. note::
@@ -358,15 +358,15 @@ def componentwise_norms(discr, fields, order=np.inf):
     """
     if not isinstance(fields, DOFArray):
         return map_array_container(
-            partial(componentwise_norms, discr, order=order), fields)
+            partial(componentwise_norms, dcoll, order=order), fields)
     if len(fields) > 0:
-        return op.norm(discr, fields, order)
+        return op.norm(dcoll, fields, order)
     else:
         # FIXME: This work-around for #575 can go away after #569
         return 0
 
 
-def max_component_norm(discr, fields, order=np.inf):
+def max_component_norm(dcoll, fields, order=np.inf):
     """Return the max *order*-norm over the components of *fields*.
 
     .. note::
@@ -374,7 +374,7 @@ def max_component_norm(discr, fields, order=np.inf):
     """
     actx = fields.array_context
     return max(actx.to_numpy(flatten(
-        componentwise_norms(discr, fields, order), actx)))
+        componentwise_norms(dcoll, fields, order), actx)))
 
 
 def generate_and_distribute_mesh(comm, generate_mesh):

--- a/mirgecom/viscous.py
+++ b/mirgecom/viscous.py
@@ -276,7 +276,7 @@ def viscous_flux(state, grad_cv, grad_t):
             momentum=tau, species_mass=-j)
 
 
-def viscous_facial_flux_central(discr, state_pair, grad_cv_pair, grad_t_pair,
+def viscous_facial_flux_central(dcoll, state_pair, grad_cv_pair, grad_t_pair,
                                 gas_model=None):
     r"""Return a central facial flux for the divergence operator.
 
@@ -292,9 +292,9 @@ def viscous_facial_flux_central(discr, state_pair, grad_cv_pair, grad_t_pair,
 
     Parameters
     ----------
-    discr: :class:`~grudge.discretization.DiscretizationCollection`
+    dcoll: :class:`~grudge.discretization.DiscretizationCollection`
 
-        The discretization to use
+        The discretization collection to use
 
     gas_model: :class:`~mirgecom.gas_model.GasModel`
         The physical model for the gas. Unused for this numerical flux function.
@@ -322,7 +322,7 @@ def viscous_facial_flux_central(discr, state_pair, grad_cv_pair, grad_t_pair,
     """
     from mirgecom.flux import num_flux_central
     actx = state_pair.int.array_context
-    normal = actx.thaw(discr.normal(state_pair.dd))
+    normal = actx.thaw(dcoll.normal(state_pair.dd))
 
     f_int = viscous_flux(state_pair.int, grad_cv_pair.int,
                          grad_t_pair.int)
@@ -333,7 +333,7 @@ def viscous_facial_flux_central(discr, state_pair, grad_cv_pair, grad_t_pair,
 
 
 def viscous_flux_on_element_boundary(
-        discr, gas_model, boundaries, interior_state_pairs,
+        dcoll, gas_model, boundaries, interior_state_pairs,
         domain_boundary_states, grad_cv, interior_grad_cv_pairs,
         grad_t, interior_grad_t_pairs, quadrature_tag=None,
         numerical_flux_func=viscous_facial_flux_central, time=0.0):
@@ -344,7 +344,7 @@ def viscous_flux_on_element_boundary(
 
     Parameters
     ----------
-    discr: :class:`~grudge.discretization.DiscretizationCollection`
+    dcoll: :class:`~grudge.discretization.DiscretizationCollection`
         A discretization collection encapsulating the DG elements
 
     gas_model: :class:`~mirgecom.gas_model.GasModel`
@@ -392,10 +392,10 @@ def viscous_flux_on_element_boundary(
 
     # viscous fluxes across interior faces (including partition and periodic bnd)
     def _fvisc_divergence_flux_interior(state_pair, grad_cv_pair, grad_t_pair):
-        return op.project(discr,
+        return op.project(dcoll,
             state_pair.dd, state_pair.dd.with_dtag("all_faces"),
             numerical_flux_func(
-                discr=discr, gas_model=gas_model, state_pair=state_pair,
+                dcoll=dcoll, gas_model=gas_model, state_pair=state_pair,
                 grad_cv_pair=grad_cv_pair, grad_t_pair=grad_t_pair))
 
     # viscous part of bcs applied here
@@ -403,12 +403,12 @@ def viscous_flux_on_element_boundary(
         # Make sure we fields on the quadrature grid
         # restricted to the tag *btag*
         return op.project(
-            discr, dd_btag, dd_btag.with_dtag("all_faces"),
+            dcoll, dd_btag, dd_btag.with_dtag("all_faces"),
             boundary.viscous_divergence_flux(
-                discr=discr, btag=dd_btag, gas_model=gas_model,
+                dcoll=dcoll, btag=dd_btag, gas_model=gas_model,
                 state_minus=state_minus,
-                grad_cv_minus=op.project(discr, dd_base, dd_btag, grad_cv),
-                grad_t_minus=op.project(discr, dd_base, dd_btag, grad_t),
+                grad_cv_minus=op.project(dcoll, dd_base, dd_btag, grad_cv),
+                grad_t_minus=op.project(dcoll, dd_base, dd_btag, grad_t),
                 time=time, numerical_flux_func=numerical_flux_func))
 
     # }}} viscous flux helpers
@@ -436,14 +436,14 @@ def viscous_flux_on_element_boundary(
     return bnd_term
 
 
-def get_viscous_timestep(discr, state):
+def get_viscous_timestep(dcoll, state):
     """Routine returns the the node-local maximum stable viscous timestep.
 
     Parameters
     ----------
-    discr: grudge.discretization.DiscretizationCollection
+    dcoll: grudge.discretization.DiscretizationCollection
 
-        the discretization to use
+        the discretization collection to use
 
     state: :class:`~mirgecom.gas_model.FluidState`
 
@@ -457,7 +457,7 @@ def get_viscous_timestep(discr, state):
     """
     from grudge.dt_utils import characteristic_lengthscales
 
-    length_scales = characteristic_lengthscales(state.array_context, discr)
+    length_scales = characteristic_lengthscales(state.array_context, dcoll)
 
     nu = 0
     d_alpha_max = 0
@@ -475,14 +475,14 @@ def get_viscous_timestep(discr, state):
     )
 
 
-def get_viscous_cfl(discr, dt, state):
+def get_viscous_cfl(dcoll, dt, state):
     """Calculate and return node-local CFL based on current state and timestep.
 
     Parameters
     ----------
-    discr: :class:`~grudge.discretization.DiscretizationCollection`
+    dcoll: :class:`~grudge.discretization.DiscretizationCollection`
 
-        the discretization to use
+        the discretization collection to use
 
     dt: float or :class:`~meshmode.dof_array.DOFArray`
 
@@ -498,7 +498,7 @@ def get_viscous_cfl(discr, dt, state):
 
         The CFL at each node.
     """
-    return dt / get_viscous_timestep(discr, state=state)
+    return dt / get_viscous_timestep(dcoll, state=state)
 
 
 def get_local_max_species_diffusivity(actx, d_alpha):

--- a/mirgecom/wave.py
+++ b/mirgecom/wave.py
@@ -35,12 +35,12 @@ from grudge.trace_pair import TracePair, interior_trace_pairs
 import grudge.op as op
 
 
-def _flux(discr, c, w_tpair):
+def _flux(dcoll, c, w_tpair):
     u = w_tpair[0]
     v = w_tpair[1:]
 
     actx = w_tpair.int[0].array_context
-    normal = actx.thaw(discr.normal(w_tpair.dd))
+    normal = actx.thaw(dcoll.normal(w_tpair.dd))
 
     flux_weak = flat_obj_array(
         np.dot(v.avg, normal),
@@ -53,20 +53,20 @@ def _flux(discr, c, w_tpair):
         0.5*normal*np.dot(normal, v.ext-v.int),
         )
 
-    return op.project(discr, w_tpair.dd, "all_faces", c*flux_weak)
+    return op.project(dcoll, w_tpair.dd, "all_faces", c*flux_weak)
 
 
 class _WaveTag:
     pass
 
 
-def wave_operator(discr, c, w):
+def wave_operator(dcoll, c, w):
     """Compute the RHS of the wave equation.
 
     Parameters
     ----------
-    discr: grudge.discretization.DiscretizationCollection
-        the discretization to use
+    dcoll: grudge.discretization.DiscretizationCollection
+        the discretization collection to use
     c: float
         the (constant) wave speed
     w: numpy.ndarray
@@ -80,25 +80,25 @@ def wave_operator(discr, c, w):
     u = w[0]
     v = w[1:]
 
-    dir_u = op.project(discr, "vol", BTAG_ALL, u)
-    dir_v = op.project(discr, "vol", BTAG_ALL, v)
+    dir_u = op.project(dcoll, "vol", BTAG_ALL, u)
+    dir_v = op.project(dcoll, "vol", BTAG_ALL, v)
     dir_bval = flat_obj_array(dir_u, dir_v)
     dir_bc = flat_obj_array(-dir_u, dir_v)
 
     return (
-        op.inverse_mass(discr,
+        op.inverse_mass(dcoll,
             flat_obj_array(
-                -c*op.weak_local_div(discr, "vol", v),
-                -c*op.weak_local_grad(discr, "vol", u)
+                -c*op.weak_local_div(dcoll, "vol", v),
+                -c*op.weak_local_grad(dcoll, "vol", u)
                 )
             +  # noqa: W504
-            op.face_mass(discr,
-                _flux(discr, c=c,
+            op.face_mass(dcoll,
+                _flux(dcoll, c=c,
                       w_tpair=TracePair(BTAG_ALL, interior=dir_bval,
                                         exterior=dir_bc))
                 + sum(
-                    _flux(discr, c=c, w_tpair=tpair)
-                    for tpair in interior_trace_pairs(discr, w, comm_tag=_WaveTag))
+                    _flux(dcoll, c=c, w_tpair=tpair)
+                    for tpair in interior_trace_pairs(dcoll, w, comm_tag=_WaveTag))
                 )
             )
         )

--- a/test/test_av.py
+++ b/test/test_av.py
@@ -86,8 +86,8 @@ def test_tag_cells(ctx_factory, dim, order):
     nel_1d = 2
     tolerance = 1.e-16
 
-    def norm_indicator(expected, discr, soln, **kwargs):
-        return (op.norm(discr, expected-smoothness_indicator(discr, soln, **kwargs),
+    def norm_indicator(expected, dcoll, soln, **kwargs):
+        return (op.norm(dcoll, expected-smoothness_indicator(dcoll, soln, **kwargs),
                         np.inf))
 
     from meshmode.mesh.generation import generate_regular_rect_mesh
@@ -96,18 +96,18 @@ def test_tag_cells(ctx_factory, dim, order):
         a=(-1.0, )*dim,  b=(1.0, )*dim,  n=(nel_1d, ) * dim
     )
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
     nele = mesh.nelements
     zeros = 0.0*nodes[0]
 
     # Test jump discontinuity
     soln = actx.np.where(nodes[0] > 0.0+zeros, 1.0+zeros, zeros)
-    err = norm_indicator(1.0, discr, soln)
+    err = norm_indicator(1.0, dcoll, soln)
     assert err < tolerance,  "Jump discontinuity should trigger indicator (1.0)"
 
     # get meshmode polynomials
-    group = discr.discr_from_dd("vol").groups[0]
+    group = dcoll.discr_from_dd("vol").groups[0]
     basis = group.basis()  # only one group
     unit_nodes = group.unit_nodes
     modes = group.mode_ids()
@@ -121,7 +121,7 @@ def test_tag_cells(ctx_factory, dim, order):
             expected = 1.0
         else:
             expected = 0.0
-        err = norm_indicator(expected, discr, soln)
+        err = norm_indicator(expected, dcoll, soln)
         assert err < tolerance,  "Only highest modes should trigger indicator (1.0)"
 
     # Test s0
@@ -140,7 +140,7 @@ def test_tag_cells(ctx_factory, dim, order):
     ele_soln = ((phi_n_p+eps)*basis[n_p](unit_nodes)
                 + phi_n_pm1*basis[n_pm1](unit_nodes))
     soln[0].set(np.tile(ele_soln, (nele, 1)))
-    err = norm_indicator(1.0, discr, soln, s0=s0, kappa=0.0)
+    err = norm_indicator(1.0, dcoll, soln, s0=s0, kappa=0.0)
     assert err < tolerance,  (
         "A function with an indicator >s0 should trigger indicator")
 
@@ -148,7 +148,7 @@ def test_tag_cells(ctx_factory, dim, order):
     ele_soln = ((phi_n_p-eps)*basis[n_p](unit_nodes)
                 + phi_n_pm1*basis[n_pm1](unit_nodes))
     soln[0].set(np.tile(ele_soln, (nele, 1)))
-    err = norm_indicator(0.0, discr, soln, s0=s0, kappa=0.0)
+    err = norm_indicator(0.0, dcoll, soln, s0=s0, kappa=0.0)
     assert err < tolerance, (
         "A function with an indicator <s0 should not trigger indicator")
 
@@ -159,22 +159,22 @@ def test_tag_cells(ctx_factory, dim, order):
     ele_soln = (phi_n_p*basis[n_p](unit_nodes)
                 + phi_n_pm1*basis[n_pm1](unit_nodes))
     soln[0].set(np.tile(ele_soln, (nele, 1)))
-    err = norm_indicator(0.5, discr, soln, s0=s0, kappa=kappa)
+    err = norm_indicator(0.5, dcoll, soln, s0=s0, kappa=kappa)
     assert err < 1.0e-10,  "A function with s_e=s_0 should return 0.5"
 
     # test bounds
     # lower bound
     shift = 1.0e-5
-    err = norm_indicator(0.0, discr, soln, s0=s0+kappa+shift, kappa=kappa)
+    err = norm_indicator(0.0, dcoll, soln, s0=s0+kappa+shift, kappa=kappa)
     assert err < tolerance,  "s_e<s_0-kappa should not trigger indicator"
-    err = norm_indicator(0.0, discr, soln, s0=s0+kappa-shift, kappa=kappa)
+    err = norm_indicator(0.0, dcoll, soln, s0=s0+kappa-shift, kappa=kappa)
     assert err > tolerance,  "s_e>s_0-kappa should trigger indicator"
 
     # upper bound
-    err = norm_indicator(1.0, discr, soln, s0=s0-(kappa+shift), kappa=kappa)
+    err = norm_indicator(1.0, dcoll, soln, s0=s0-(kappa+shift), kappa=kappa)
     # s_e>s_0+kappa should fully trigger indicator (1.0)
     assert err < tolerance
-    err = norm_indicator(1.0, discr, soln, s0=s0-(kappa-shift), kappa=kappa)
+    err = norm_indicator(1.0, dcoll, soln, s0=s0-(kappa-shift), kappa=kappa)
     # s_e<s_0+kappa should not fully trigger indicator (1.0)
     assert err > tolerance
 
@@ -201,8 +201,8 @@ def test_artificial_viscosity(ctx_factory, dim, order):
         a=(1.0, )*dim, b=(2.0, )*dim, nelements_per_axis=(nel_1d, )*dim
     )
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     class TestBoundary:
 
@@ -220,7 +220,7 @@ def test_artificial_viscosity(ctx_factory, dim, order):
 
         def av_flux(self, disc, btag, diffusion, **kwargs):
             nhat = actx.thaw(disc.normal(btag))
-            diffusion_minus = op.project(discr, "vol", btag, diffusion)
+            diffusion_minus = op.project(dcoll, "vol", btag, diffusion)
             diffusion_plus = diffusion_minus
             from grudge.trace_pair import TracePair
             bnd_grad_pair = TracePair(btag, interior=diffusion_minus,
@@ -245,11 +245,11 @@ def test_artificial_viscosity(ctx_factory, dim, order):
         )
         gas_model = GasModel(eos=IdealSingleGas())
         fluid_state = make_fluid_state(cv=cv, gas_model=gas_model)
-        rhs = av_laplacian_operator(discr, boundaries=boundaries,
+        rhs = av_laplacian_operator(dcoll, boundaries=boundaries,
                                     gas_model=gas_model,
                                     fluid_state=fluid_state, alpha=1.0, s0=-np.inf)
         print(f"{rhs=}")
-        err = op.norm(discr, rhs-exp_rhs_1d, np.inf)
+        err = op.norm(dcoll, rhs-exp_rhs_1d, np.inf)
         assert err < tolerance
 
     # Quadratic field return constant 2*dim
@@ -262,10 +262,10 @@ def test_artificial_viscosity(ctx_factory, dim, order):
         species_mass=make_obj_array([soln for _ in range(dim)])
     )
     fluid_state = make_fluid_state(cv=cv, gas_model=gas_model)
-    rhs = av_laplacian_operator(discr, boundaries=boundaries,
+    rhs = av_laplacian_operator(dcoll, boundaries=boundaries,
                                 gas_model=gas_model,
                                 fluid_state=fluid_state, alpha=1.0, s0=-np.inf)
-    err = op.norm(discr, 2.*dim-rhs, np.inf)
+    err = op.norm(dcoll, 2.*dim-rhs, np.inf)
     assert err < tolerance
 
 
@@ -294,8 +294,8 @@ def test_trig(ctx_factory, dim, order):
             periodic=(True,)*dim
         )
 
-        discr = create_discretization_collection(actx, mesh, order=order)
-        nodes = actx.thaw(discr.nodes())
+        dcoll = create_discretization_collection(actx, mesh, order=order)
+        nodes = actx.thaw(dcoll.nodes())
 
         boundaries = {}
 
@@ -316,11 +316,11 @@ def test_trig(ctx_factory, dim, order):
             species_mass=make_obj_array([soln for _ in range(dim)])
         )
         fluid_state = make_fluid_state(cv=cv, gas_model=gas_model)
-        rhs = av_laplacian_operator(discr, boundaries=boundaries,
+        rhs = av_laplacian_operator(dcoll, boundaries=boundaries,
                                     gas_model=gas_model,
                                     fluid_state=fluid_state, alpha=1.0, s0=-np.inf)
 
-        err_rhs = actx.to_numpy(op.norm(discr, rhs-exp_rhs, np.inf))
+        err_rhs = actx.to_numpy(op.norm(dcoll, rhs-exp_rhs, np.inf))
         eoc_rec.add_data_point(1.0/nel_1d, err_rhs)
 
     logger.info(
@@ -402,9 +402,9 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
     gas_model = GasModel(eos=IdealSingleGas(gas_const=1.0),
                          transport=transport_model)
 
-    def _boundary_state_func(discr, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state_func(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(prescribed_soln(r=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -414,12 +414,12 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
     b = 2.0
     mesh = _get_box_mesh(dim=dim, a=a, b=b, n=npts_geom)
     from mirgecom.discretization import create_discretization_collection
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
     cv = prescribed_soln(r=nodes, eos=gas_model.eos)
     fluid_state = make_fluid_state(cv, gas_model)
 
-    boundary_nhat = actx.thaw(discr.normal(BTAG_ALL))
+    boundary_nhat = actx.thaw(dcoll.normal(BTAG_ALL))
 
     from mirgecom.boundary import (
         PrescribedFluidBoundary,
@@ -434,12 +434,12 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
     fluid_boundaries = {BTAG_ALL: prescribed_boundary}
     from mirgecom.navierstokes import grad_cv_operator
     fluid_grad_cv = \
-        grad_cv_operator(discr, gas_model, fluid_boundaries, fluid_state)
+        grad_cv_operator(dcoll, gas_model, fluid_boundaries, fluid_state)
 
     # Put in a testing field for AV - doesn't matter what - as long as it
     # is spatially-dependent in all dimensions.
     av_diffusion = 0. * fluid_grad_cv + np.dot(nodes, nodes)
-    av_diffusion_boundary = op.project(discr, "vol", BTAG_ALL, av_diffusion)
+    av_diffusion_boundary = op.project(dcoll, "vol", BTAG_ALL, av_diffusion)
 
     # Prescribed boundaries are used for inflow/outflow-type boundaries
     # where we expect to _preserve_ the soln gradient
@@ -448,12 +448,12 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
     all_faces_dd = dd_bnd.with_dtag("all_faces")
     expected_av_flux_prescribed_boundary = av_diffusion_boundary@boundary_nhat
     print(f"{expected_av_flux_prescribed_boundary=}")
-    exp_av_flux = op.project(discr, dd_bnd, all_faces_dd,
+    exp_av_flux = op.project(dcoll, dd_bnd, all_faces_dd,
                                 expected_av_flux_prescribed_boundary)
     print(f"{exp_av_flux=}")
 
     prescribed_boundary_av_flux = \
-        prescribed_boundary.av_flux(discr, BTAG_ALL, av_diffusion)
+        prescribed_boundary.av_flux(dcoll, BTAG_ALL, av_diffusion)
     print(f"{prescribed_boundary_av_flux=}")
 
     bnd_flux_resid = (prescribed_boundary_av_flux - exp_av_flux)
@@ -462,11 +462,11 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
 
     # Solid wall boundaries are expected to have 0 AV flux
     wall_bnd_flux = \
-        adiabatic_noslip.av_flux(discr, BTAG_ALL, av_diffusion)
+        adiabatic_noslip.av_flux(dcoll, BTAG_ALL, av_diffusion)
     print(f"adiabatic_noslip: {wall_bnd_flux=}")
     assert wall_bnd_flux == 0
 
     wall_bnd_flux = \
-        isothermal_noslip.av_flux(discr, BTAG_ALL, av_diffusion)
+        isothermal_noslip.av_flux(dcoll, BTAG_ALL, av_diffusion)
     print(f"isothermal_noslip: {wall_bnd_flux=}")
     assert wall_bnd_flux == 0

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -77,11 +77,11 @@ def test_slipwall_identity(actx_factory, dim):
     )
 
     order = 3
-    discr = create_discretization_collection(actx, mesh, order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order)
+    nodes = actx.thaw(dcoll.nodes())
     eos = IdealSingleGas()
     orig = np.zeros(shape=(dim,))
-    nhat = actx.thaw(discr.normal(BTAG_ALL))
+    nhat = actx.thaw(dcoll.normal(BTAG_ALL))
     gas_model = GasModel(eos=eos)
 
     logger.info(f"Number of {dim}d elems: {mesh.nelements}")
@@ -96,14 +96,14 @@ def test_slipwall_identity(actx_factory, dim):
             wall = AdiabaticSlipBoundary()
 
             uniform_state = initializer(nodes)
-            cv_minus = op.project(discr, "vol", BTAG_ALL, uniform_state)
+            cv_minus = op.project(dcoll, "vol", BTAG_ALL, uniform_state)
             state_minus = make_fluid_state(cv=cv_minus, gas_model=gas_model)
 
             def bnd_norm(vec):
-                return actx.to_numpy(op.norm(discr, vec, p=np.inf, dd=BTAG_ALL))
+                return actx.to_numpy(op.norm(dcoll, vec, p=np.inf, dd=BTAG_ALL))
 
             state_plus = \
-                wall.adiabatic_slip_state(discr, btag=BTAG_ALL, gas_model=gas_model,
+                wall.adiabatic_slip_state(dcoll, btag=BTAG_ALL, gas_model=gas_model,
                                           state_minus=state_minus)
 
             bnd_pair = TracePair(BTAG_ALL, interior=state_minus.cv,
@@ -152,13 +152,13 @@ def test_slipwall_flux(actx_factory, dim, order, flux_func):
             a=(-0.5,) * dim, b=(0.5,) * dim, nelements_per_axis=(nel_1d,) * dim
         )
 
-        discr = create_discretization_collection(actx, mesh, order=order)
-        nodes = actx.thaw(discr.nodes())
-        nhat = actx.thaw(discr.normal(BTAG_ALL))
+        dcoll = create_discretization_collection(actx, mesh, order=order)
+        nodes = actx.thaw(dcoll.nodes())
+        nhat = actx.thaw(dcoll.normal(BTAG_ALL))
         h = 1.0 / nel_1d
 
         def bnd_norm(vec):
-            return actx.to_numpy(op.norm(discr, vec, p=np.inf, dd=BTAG_ALL))
+            return actx.to_numpy(op.norm(dcoll, vec, p=np.inf, dd=BTAG_ALL))
 
         logger.info(f"Number of {dim}d elems: {mesh.nelements}")
         # for velocities in each direction
@@ -174,11 +174,11 @@ def test_slipwall_flux(actx_factory, dim, order, flux_func):
                 uniform_state = initializer(nodes)
                 fluid_state = make_fluid_state(uniform_state, gas_model)
 
-                interior_soln = project_fluid_state(discr, "vol", BTAG_ALL,
+                interior_soln = project_fluid_state(dcoll, "vol", BTAG_ALL,
                                                     state=fluid_state,
                                                     gas_model=gas_model)
 
-                bnd_soln = wall.adiabatic_slip_state(discr, btag=BTAG_ALL,
+                bnd_soln = wall.adiabatic_slip_state(dcoll, btag=BTAG_ALL,
                                                      gas_model=gas_model,
                                                      state_minus=interior_soln)
 
@@ -193,7 +193,7 @@ def test_slipwall_flux(actx_factory, dim, order, flux_func):
                 avg_state = 0.5*(bnd_pair.int + bnd_pair.ext)
                 err_max = max(err_max, bnd_norm(np.dot(avg_state.momentum, nhat)))
 
-                normal = actx.thaw(discr.normal(BTAG_ALL))
+                normal = actx.thaw(dcoll.normal(BTAG_ALL))
                 bnd_flux = flux_func(state_pair, gas_model, normal)
 
                 err_max = max(err_max, bnd_norm(bnd_flux.mass),
@@ -249,23 +249,23 @@ def test_noslip(actx_factory, dim, flux_func):
     b = 2.0
     mesh = _get_box_mesh(dim=dim, a=a, b=b, n=npts_geom)
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    nhat = actx.thaw(discr.normal(BTAG_ALL))
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    nhat = actx.thaw(dcoll.normal(BTAG_ALL))
     print(f"{nhat=}")
 
     from mirgecom.flux import num_flux_central
 
     def scalar_flux_interior(int_tpair):
         from arraycontext import outer
-        normal = actx.thaw(discr.normal(int_tpair.dd))
+        normal = actx.thaw(dcoll.normal(int_tpair.dd))
         # Hard-coding central per [Bassi_1997]_ eqn 13
         flux_weak = outer(num_flux_central(int_tpair.int, int_tpair.ext), normal)
-        return op.project(discr, int_tpair.dd, "all_faces", flux_weak)
+        return op.project(dcoll, int_tpair.dd, "all_faces", flux_weak)
 
     # utility to compare stuff on the boundary only
     # from functools import partial
-    # bnd_norm = partial(op.norm, discr, p=np.inf, dd=BTAG_ALL)
+    # bnd_norm = partial(op.norm, dcoll, p=np.inf, dd=BTAG_ALL)
 
     logger.info(f"Number of {dim}d elems: {mesh.nelements}")
 
@@ -281,7 +281,7 @@ def test_noslip(actx_factory, dim, flux_func):
             initializer = Uniform(dim=dim, velocity=vel)
             uniform_cv = initializer(nodes, eos=gas_model.eos)
             uniform_state = make_fluid_state(cv=uniform_cv, gas_model=gas_model)
-            state_minus = project_fluid_state(discr, "vol", BTAG_ALL,
+            state_minus = project_fluid_state(dcoll, "vol", BTAG_ALL,
                                               uniform_state, gas_model)
 
             print(f"{uniform_state=}")
@@ -299,7 +299,7 @@ def test_noslip(actx_factory, dim, flux_func):
             print(f"{expected_temperature_bc=}")
             print(f"{expected_noslip_cv=}")
 
-            cv_interior_pairs = interior_trace_pairs(discr, uniform_state.cv)
+            cv_interior_pairs = interior_trace_pairs(dcoll, uniform_state.cv)
             cv_int_tpair = cv_interior_pairs[0]
 
             state_pairs = make_fluid_state_trace_pairs(cv_interior_pairs, gas_model)
@@ -309,15 +309,15 @@ def test_noslip(actx_factory, dim, flux_func):
             print(f"{cv_flux_int=}")
 
             wall_state = wall.isothermal_noslip_state(
-                discr, btag=BTAG_ALL, gas_model=gas_model, state_minus=state_minus)
+                dcoll, btag=BTAG_ALL, gas_model=gas_model, state_minus=state_minus)
             print(f"{wall_state=}")
 
-            cv_grad_flux_wall = wall.cv_gradient_flux(discr, btag=BTAG_ALL,
+            cv_grad_flux_wall = wall.cv_gradient_flux(dcoll, btag=BTAG_ALL,
                                                  gas_model=gas_model,
                                                  state_minus=state_minus)
 
             cv_grad_flux_allfaces = \
-                op.project(discr, as_dofdesc(BTAG_ALL),
+                op.project(dcoll, as_dofdesc(BTAG_ALL),
                            as_dofdesc(BTAG_ALL).with_dtag("all_faces"),
                            cv_grad_flux_wall)
 
@@ -328,29 +328,29 @@ def test_noslip(actx_factory, dim, flux_func):
             temperature_bc = wall.temperature_bc(state_minus)
             print(f"{temperature_bc=}")
 
-            t_int_tpair = interior_trace_pair(discr, temper)
+            t_int_tpair = interior_trace_pair(dcoll, temper)
             t_flux_int = scalar_flux_interior(t_int_tpair)
-            t_flux_bc = wall.temperature_gradient_flux(discr, btag=BTAG_ALL,
+            t_flux_bc = wall.temperature_gradient_flux(dcoll, btag=BTAG_ALL,
                                                        gas_model=gas_model,
                                                        state_minus=state_minus)
 
-            t_flux_bc = op.project(discr, as_dofdesc(BTAG_ALL),
+            t_flux_bc = op.project(dcoll, as_dofdesc(BTAG_ALL),
                                     as_dofdesc(BTAG_ALL).with_dtag("all_faces"),
                                     t_flux_bc)
 
             t_flux_bnd = t_flux_bc + t_flux_int
 
-            i_flux_bc = wall.inviscid_divergence_flux(discr, btag=BTAG_ALL,
+            i_flux_bc = wall.inviscid_divergence_flux(dcoll, btag=BTAG_ALL,
                                                       gas_model=gas_model,
                                                       state_minus=state_minus)
 
-            nhat = actx.thaw(discr.normal(state_pair.dd))
+            nhat = actx.thaw(dcoll.normal(state_pair.dd))
             bnd_flux = flux_func(state_pair, gas_model, nhat)
             dd = state_pair.dd
             dd_allfaces = dd.with_dtag("all_faces")
-            i_flux_int = op.project(discr, dd, dd_allfaces, bnd_flux)
+            i_flux_int = op.project(dcoll, dd, dd_allfaces, bnd_flux)
             bc_dd = as_dofdesc(BTAG_ALL)
-            i_flux_bc = op.project(discr, bc_dd, dd_allfaces, i_flux_bc)
+            i_flux_bc = op.project(dcoll, bc_dd, dd_allfaces, i_flux_bc)
 
             i_flux_bnd = i_flux_bc + i_flux_int
 
@@ -362,17 +362,17 @@ def test_noslip(actx_factory, dim, flux_func):
             dd_vol = as_dofdesc("vol")
             dd_faces = as_dofdesc("all_faces")
             grad_cv_minus = \
-                op.project(discr, "vol", BTAG_ALL,
-                              grad_operator(discr, dd_vol, dd_faces,
+                op.project(dcoll, "vol", BTAG_ALL,
+                              grad_operator(dcoll, dd_vol, dd_faces,
                                             uniform_state.cv, cv_flux_bnd))
-            grad_t_minus = op.project(discr, "vol", BTAG_ALL,
-                                         grad_operator(discr, dd_vol, dd_faces,
+            grad_t_minus = op.project(dcoll, "vol", BTAG_ALL,
+                                         grad_operator(dcoll, dd_vol, dd_faces,
                                                        temper, t_flux_bnd))
 
             print(f"{grad_cv_minus=}")
             print(f"{grad_t_minus=}")
 
-            v_flux_bc = wall.viscous_divergence_flux(discr, btag=BTAG_ALL,
+            v_flux_bc = wall.viscous_divergence_flux(dcoll, btag=BTAG_ALL,
                                                      gas_model=gas_model,
                                                      state_minus=state_minus,
                                                      grad_cv_minus=grad_cv_minus,
@@ -461,9 +461,9 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
     # (*note): Most people will never change these as they are used internally
     #          to compute a DG gradient of Q and temperature.
 
-    def _boundary_state_func(discr, btag, gas_model, state_minus, **kwargs):
+    def _boundary_state_func(dcoll, btag, gas_model, state_minus, **kwargs):
         actx = state_minus.array_context
-        bnd_discr = discr.discr_from_dd(btag)
+        bnd_discr = dcoll.discr_from_dd(btag)
         nodes = actx.thaw(bnd_discr.nodes())
         return make_fluid_state(prescribed_soln(r=nodes, eos=gas_model.eos,
                                             **kwargs), gas_model)
@@ -480,24 +480,24 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
     b = 2.0
     mesh = _get_box_mesh(dim=dim, a=a, b=b, n=npts_geom)
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    boundary_discr = discr.discr_from_dd(BTAG_ALL)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    boundary_discr = dcoll.discr_from_dd(BTAG_ALL)
     boundary_nodes = actx.thaw(boundary_discr.nodes())
     expected_boundary_solution = prescribed_soln(r=boundary_nodes, eos=gas_model.eos)
 
-    nhat = actx.thaw(discr.normal(BTAG_ALL))
+    nhat = actx.thaw(dcoll.normal(BTAG_ALL))
     print(f"{nhat=}")
 
     from mirgecom.flux import num_flux_central
 
     def scalar_flux_interior(int_tpair):
         from arraycontext import outer
-        normal = actx.thaw(discr.normal(int_tpair.dd))
+        normal = actx.thaw(dcoll.normal(int_tpair.dd))
         # Hard-coding central per [Bassi_1997]_ eqn 13
         flux_weak = outer(num_flux_central(int_tpair.int, int_tpair.ext),
                           normal)
-        return op.project(discr, int_tpair.dd, "all_faces", flux_weak)
+        return op.project(dcoll, int_tpair.dd, "all_faces", flux_weak)
 
     logger.info(f"Number of {dim}d elems: {mesh.nelements}")
     # for velocities in each direction
@@ -512,54 +512,54 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             initializer = Uniform(dim=dim, velocity=vel)
             cv = initializer(nodes, eos=gas_model.eos)
             state = make_fluid_state(cv, gas_model)
-            state_minus = project_fluid_state(discr, "vol", BTAG_ALL,
+            state_minus = project_fluid_state(dcoll, "vol", BTAG_ALL,
                                               state, gas_model)
 
             print(f"{cv=}")
             temper = state.temperature
             print(f"{temper=}")
 
-            cv_int_tpair = interior_trace_pair(discr, cv)
+            cv_int_tpair = interior_trace_pair(dcoll, cv)
             cv_flux_int = scalar_flux_interior(cv_int_tpair)
-            cv_flux_bc = domain_boundary.cv_gradient_flux(discr, btag=BTAG_ALL,
+            cv_flux_bc = domain_boundary.cv_gradient_flux(dcoll, btag=BTAG_ALL,
                                                gas_model=gas_model,
                                                state_minus=state_minus)
 
-            cv_flux_bc = op.project(discr, as_dofdesc(BTAG_ALL),
+            cv_flux_bc = op.project(dcoll, as_dofdesc(BTAG_ALL),
                                     as_dofdesc(BTAG_ALL).with_dtag("all_faces"),
                                     cv_flux_bc)
 
             cv_flux_bnd = cv_flux_bc + cv_flux_int
 
-            t_int_tpair = interior_trace_pair(discr, temper)
+            t_int_tpair = interior_trace_pair(dcoll, temper)
             t_flux_int = scalar_flux_interior(t_int_tpair)
             t_flux_bc = \
-                domain_boundary.temperature_gradient_flux(discr, btag=BTAG_ALL,
+                domain_boundary.temperature_gradient_flux(dcoll, btag=BTAG_ALL,
                                                           gas_model=gas_model,
                                                           state_minus=state_minus)
 
-            t_flux_bc = op.project(discr, as_dofdesc(BTAG_ALL),
+            t_flux_bc = op.project(dcoll, as_dofdesc(BTAG_ALL),
                                     as_dofdesc(BTAG_ALL).with_dtag("all_faces"),
                                     t_flux_bc)
 
             t_flux_bnd = t_flux_bc + t_flux_int
 
             i_flux_bc = \
-                domain_boundary.inviscid_divergence_flux(discr, btag=BTAG_ALL,
+                domain_boundary.inviscid_divergence_flux(dcoll, btag=BTAG_ALL,
                                                          gas_model=gas_model,
                                                          state_minus=state_minus)
 
-            cv_int_pairs = interior_trace_pairs(discr, cv)
+            cv_int_pairs = interior_trace_pairs(dcoll, cv)
             state_pairs = make_fluid_state_trace_pairs(cv_int_pairs, gas_model)
             state_pair = state_pairs[0]
 
-            nhat = actx.thaw(discr.normal(state_pair.dd))
+            nhat = actx.thaw(dcoll.normal(state_pair.dd))
             bnd_flux = flux_func(state_pair, gas_model, nhat)
             dd = state_pair.dd
             dd_allfaces = dd.with_dtag("all_faces")
             bc_dd = as_dofdesc(BTAG_ALL)
-            i_flux_bc = op.project(discr, bc_dd, dd_allfaces, i_flux_bc)
-            i_flux_int = op.project(discr, dd, dd_allfaces, bnd_flux)
+            i_flux_bc = op.project(dcoll, bc_dd, dd_allfaces, i_flux_bc)
+            i_flux_int = op.project(dcoll, dd, dd_allfaces, bnd_flux)
 
             i_flux_bnd = i_flux_bc + i_flux_int
 
@@ -570,22 +570,22 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             from mirgecom.operators import grad_operator
             dd_vol = as_dofdesc("vol")
             dd_faces = as_dofdesc("all_faces")
-            grad_cv = grad_operator(discr, dd_vol, dd_faces, cv, cv_flux_bnd)
-            grad_t = grad_operator(discr, dd_vol, dd_faces, temper, t_flux_bnd)
-            grad_cv_minus = op.project(discr, "vol", BTAG_ALL, grad_cv)
-            grad_t_minus = op.project(discr, "vol", BTAG_ALL, grad_t)
+            grad_cv = grad_operator(dcoll, dd_vol, dd_faces, cv, cv_flux_bnd)
+            grad_t = grad_operator(dcoll, dd_vol, dd_faces, temper, t_flux_bnd)
+            grad_cv_minus = op.project(dcoll, "vol", BTAG_ALL, grad_cv)
+            grad_t_minus = op.project(dcoll, "vol", BTAG_ALL, grad_t)
 
             print(f"{grad_cv_minus=}")
             print(f"{grad_t_minus=}")
 
             v_flux_bc = \
-                domain_boundary.viscous_divergence_flux(discr=discr, btag=BTAG_ALL,
+                domain_boundary.viscous_divergence_flux(dcoll=dcoll, btag=BTAG_ALL,
                                                         gas_model=gas_model,
                                                         state_minus=state_minus,
                                                         grad_cv_minus=grad_cv_minus,
                                                         grad_t_minus=grad_t_minus)
             print(f"{v_flux_bc=}")
             bc_soln = \
-                domain_boundary._boundary_state_pair(discr, BTAG_ALL, gas_model,
+                domain_boundary._boundary_state_pair(dcoll, BTAG_ALL, gas_model,
                                                      state_minus=state_minus).ext.cv
             assert bc_soln == expected_boundary_solution

--- a/test/test_eos.py
+++ b/test/test_eos.py
@@ -91,7 +91,7 @@ def test_pyrometheus_mechanisms(ctx_factory, mechname, rate_tol, y0):
 
     logger.info(f"Number of elements {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
 
     # Pyrometheus initialization
     mech_input = get_mechanism_input(mechname)
@@ -127,7 +127,7 @@ def test_pyrometheus_mechanisms(ctx_factory, mechname, rate_tol, y0):
         can_r = cantera_soln.net_rates_of_progress
         can_omega = cantera_soln.net_production_rates
 
-        ones = discr.zeros(actx) + 1.0
+        ones = dcoll.zeros(actx) + 1.0
         tin = can_t * ones
         pin = can_p * ones
         yin = make_obj_array([can_y[i] * ones for i in range(nspecies)])
@@ -157,7 +157,7 @@ def test_pyrometheus_mechanisms(ctx_factory, mechname, rate_tol, y0):
         print(f"prom_omega = {prom_omega}")
 
         def inf_norm(x):
-            return actx.to_numpy(op.norm(discr, x, np.inf))
+            return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
         assert inf_norm((prom_c - can_c)) < 1e-14
         assert inf_norm((prom_t - can_t) / can_t) < 1e-14
@@ -199,8 +199,8 @@ def test_pyrometheus_eos(ctx_factory, mechname, dim, y0, vel):
 
     logger.info(f"Number of elements {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     # Pyrometheus initialization
     mech_input = get_mechanism_input(mechname)
@@ -226,7 +226,7 @@ def test_pyrometheus_eos(ctx_factory, mechname, dim, y0, vel):
 
         print(f"Testing {mechname}(t,P) = ({tempin}, {pressin})")
 
-        ones = discr.zeros(actx) + 1.0
+        ones = dcoll.zeros(actx) + 1.0
         tin = tempin * ones
         pin = pressin * ones
         yin = y0s * ones
@@ -260,7 +260,7 @@ def test_pyrometheus_eos(ctx_factory, mechname, dim, y0, vel):
         print(f"pyro_eos.e = {internal_energy}")
 
         def inf_norm(x):
-            return actx.to_numpy(op.norm(discr, x, np.inf))
+            return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
         tol = 1e-14
         assert inf_norm((cv.mass - pyro_rho) / pyro_rho) < tol
@@ -300,8 +300,8 @@ def test_pyrometheus_kinetics(ctx_factory, mechname, rate_tol, y0):
 
     logger.info(f"Number of elements {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    ones = discr.zeros(actx) + 1.0
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    ones = dcoll.zeros(actx) + 1.0
 
     # Pyrometheus initialization
     mech_input = get_mechanism_input(mechname)
@@ -364,7 +364,7 @@ def test_pyrometheus_kinetics(ctx_factory, mechname, rate_tol, y0):
 
         # Print
         def inf_norm(x):
-            return actx.to_numpy(op.norm(discr, x, np.inf))
+            return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
         print(f"can_r = {can_r}")
         print(f"pyro_r = {pyro_r}")
@@ -408,8 +408,8 @@ def test_idealsingle_lump(ctx_factory, dim):
     order = 3
     logger.info(f"Number of elements {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     # Init soln with Vortex
     center = np.zeros(shape=(dim,))
@@ -420,7 +420,7 @@ def test_idealsingle_lump(ctx_factory, dim):
     cv = lump(nodes)
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     p = eos.pressure(cv)
     exp_p = 1.0
@@ -463,15 +463,15 @@ def test_idealsingle_vortex(ctx_factory):
     order = 3
     logger.info(f"Number of elements {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
     eos = IdealSingleGas()
     # Init soln with Vortex
     vortex = Vortex2D()
     cv = vortex(nodes)
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     gamma = eos.gamma()
     p = eos.pressure(cv)

--- a/test/test_fluid.py
+++ b/test/test_fluid.py
@@ -62,9 +62,9 @@ def test_velocity_gradient_sanity(actx_factory, dim, mass_exp, vel_fac):
 
     order = 3
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    zeros = discr.zeros(actx)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    zeros = dcoll.zeros(actx)
     ones = zeros + 1.0
 
     mass = 1*ones
@@ -77,13 +77,13 @@ def test_velocity_gradient_sanity(actx_factory, dim, mass_exp, vel_fac):
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
     from grudge.op import local_grad
-    grad_cv = local_grad(discr, cv)
+    grad_cv = local_grad(dcoll, cv)
 
     grad_v = velocity_gradient(cv, grad_cv)
 
     tol = 1e-11
     exp_result = vel_fac * np.eye(dim) * ones
-    grad_v_err = [actx.to_numpy(op.norm(discr, grad_v[i] - exp_result[i], np.inf))
+    grad_v_err = [actx.to_numpy(op.norm(dcoll, grad_v[i] - exp_result[i], np.inf))
                   for i in range(dim)]
 
     assert max(grad_v_err) < tol
@@ -111,9 +111,9 @@ def test_velocity_gradient_eoc(actx_factory, dim):
             a=(1.0,) * dim, b=(2.0,) * dim, nelements_per_axis=(nel_1d,) * dim
         )
 
-        discr = create_discretization_collection(actx, mesh, order=order)
-        nodes = actx.thaw(discr.nodes())
-        zeros = discr.zeros(actx)
+        dcoll = create_discretization_collection(actx, mesh, order=order)
+        nodes = actx.thaw(dcoll.nodes())
+        zeros = dcoll.zeros(actx)
 
         mass = nodes[dim-1]*nodes[dim-1]
         energy = zeros + 2.5
@@ -122,7 +122,7 @@ def test_velocity_gradient_eoc(actx_factory, dim):
 
         cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
         from grudge.op import local_grad
-        grad_cv = local_grad(discr, cv)
+        grad_cv = local_grad(dcoll, cv)
         grad_v = velocity_gradient(cv, grad_cv)
 
         def exact_grad_row(xdata, gdim, dim):
@@ -132,7 +132,7 @@ def test_velocity_gradient_eoc(actx_factory, dim):
 
         comp_err = make_obj_array([
             actx.to_numpy(
-                op.norm(discr, grad_v[i] - exact_grad_row(nodes[i], i, dim), np.inf))
+                op.norm(dcoll, grad_v[i] - exact_grad_row(nodes[i], i, dim), np.inf))
             for i in range(dim)])
         err_max = comp_err.max()
         eoc.add_data_point(h, err_max)
@@ -159,9 +159,9 @@ def test_velocity_gradient_structure(actx_factory):
 
     order = 1
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    zeros = discr.zeros(actx)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    zeros = dcoll.zeros(actx)
     ones = zeros + 1.0
 
     mass = 2*ones
@@ -176,7 +176,7 @@ def test_velocity_gradient_structure(actx_factory):
 
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
     from grudge.op import local_grad
-    grad_cv = local_grad(discr, cv)
+    grad_cv = local_grad(dcoll, cv)
     grad_v = velocity_gradient(cv, grad_cv)
 
     tol = 1e-11
@@ -188,7 +188,7 @@ def test_velocity_gradient_structure(actx_factory):
     assert type(grad_v[0, 0]) == DOFArray
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     assert inf_norm(grad_v - exp_result) < tol
     assert inf_norm(grad_v.T - exp_trans) < tol
@@ -208,9 +208,9 @@ def test_species_mass_gradient(actx_factory, dim):
 
     order = 1
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    zeros = discr.zeros(actx)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    zeros = dcoll.zeros(actx)
     ones = zeros + 1
 
     nspecies = 2*dim
@@ -230,7 +230,7 @@ def test_species_mass_gradient(actx_factory, dim):
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom,
                         species_mass=species_mass)
     from grudge.op import local_grad
-    grad_cv = local_grad(discr, cv)
+    grad_cv = local_grad(dcoll, cv)
 
     from mirgecom.fluid import species_mass_fraction_gradient
     grad_y = species_mass_fraction_gradient(cv, grad_cv)
@@ -240,7 +240,7 @@ def test_species_mass_gradient(actx_factory, dim):
     assert type(grad_y[0, 0]) == DOFArray
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     tol = 1e-11
     for idim in range(dim):

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -73,8 +73,8 @@ def test_uniform_init(ctx_factory, dim, nspecies):
     order = 3
     logger.info(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     velocity = np.ones(shape=(dim,))
     from mirgecom.initializers import Uniform
@@ -85,7 +85,7 @@ def test_uniform_init(ctx_factory, dim, nspecies):
 
     def inf_norm(data):
         if len(data) > 0:
-            return actx.to_numpy(op.norm(discr, data, np.inf))
+            return actx.to_numpy(op.norm(dcoll, data, np.inf))
         else:
             return 0.0
 
@@ -128,8 +128,8 @@ def test_lump_init(ctx_factory):
     order = 3
     logger.info(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     # Init soln with Vortex
     center = np.zeros(shape=(dim,))
@@ -141,7 +141,7 @@ def test_lump_init(ctx_factory):
 
     p = 0.4 * (cv.energy - 0.5 * np.dot(cv.momentum, cv.momentum) / cv.mass)
     exp_p = 1.0
-    errmax = actx.to_numpy(op.norm(discr, p - exp_p, np.inf))
+    errmax = actx.to_numpy(op.norm(dcoll, p - exp_p, np.inf))
 
     logger.info(f"lump_soln = {cv}")
     logger.info(f"pressure = {p}")
@@ -169,8 +169,8 @@ def test_vortex_init(ctx_factory):
     order = 3
     logger.info(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     # Init soln with Vortex
     vortex = Vortex2D()
@@ -178,7 +178,7 @@ def test_vortex_init(ctx_factory):
     gamma = 1.4
     p = 0.4 * (cv.energy - 0.5 * np.dot(cv.momentum, cv.momentum) / cv.mass)
     exp_p = cv.mass ** gamma
-    errmax = actx.to_numpy(op.norm(discr, p - exp_p, np.inf))
+    errmax = actx.to_numpy(op.norm(dcoll, p - exp_p, np.inf))
 
     logger.info(f"vortex_soln = {cv}")
     logger.info(f"pressure = {p}")
@@ -207,8 +207,8 @@ def test_shock_init(ctx_factory):
     order = 3
     print(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     initr = SodShock1D()
     initsoln = initr(time=0.0, x_vec=nodes)
@@ -222,7 +222,7 @@ def test_shock_init(ctx_factory):
     p = eos.pressure(initsoln)
 
     assert actx.to_numpy(
-        op.norm(discr, actx.np.where(nodes_x < 0.5, p-xpl, p-xpr), np.inf)) < tol
+        op.norm(dcoll, actx.np.where(nodes_x < 0.5, p-xpl, p-xpr), np.inf)) < tol
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
@@ -246,8 +246,8 @@ def test_uniform(ctx_factory, dim):
     order = 1
     print(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
     print(f"DIM = {dim}, {len(nodes)}")
     print(f"Nodes={nodes}")
 
@@ -257,7 +257,7 @@ def test_uniform(ctx_factory, dim):
     tol = 1e-15
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     assert inf_norm(initsoln.mass - 1.0) < tol
     assert inf_norm(initsoln.energy - 2.5) < tol
@@ -291,8 +291,8 @@ def test_pulse(ctx_factory, dim):
     order = 1
     print(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
     print(f"DIM = {dim}, {len(nodes)}")
     print(f"Nodes={nodes}")
 
@@ -307,7 +307,7 @@ def test_pulse(ctx_factory, dim):
     print(f"Pulse = {pulse}")
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     # does it return the expected exponential?
     pulse_check = actx.np.exp(-.5 * r2)
@@ -354,8 +354,8 @@ def test_multilump(ctx_factory, dim):
     order = 3
     logger.info(f"Number of elements: {mesh.nelements}")
 
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     rho0 = 1.5
     centers = make_obj_array([np.zeros(shape=(dim,)) for i in range(nspecies)])
@@ -379,7 +379,7 @@ def test_multilump(ctx_factory, dim):
     print(f"get_num_species = {numcvspec}")
 
     def inf_norm(x):
-        return actx.to_numpy(op.norm(discr, x, np.inf))
+        return actx.to_numpy(op.norm(dcoll, x, np.inf))
 
     assert numcvspec == nspecies
     assert inf_norm(cv.mass - rho0) == 0.0

--- a/test/test_limiter.py
+++ b/test/test_limiter.py
@@ -45,15 +45,15 @@ def test_positivity_preserving_limiter(actx_factory, order, dim):
         a=(0.0,) * dim, b=(0.5,) * dim, nelements_per_axis=(nel_1d,) * dim
     )
 
-    discr = create_discretization_collection(actx, mesh, order=order)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
 
     # create cells with negative values "eps"
-    nodes = actx.thaw(actx.freeze(discr.nodes()))
+    nodes = actx.thaw(actx.freeze(dcoll.nodes()))
     eps = -0.001
     field = nodes[0] + eps
 
     # apply positivity-preserving limiter
-    limited_field = bound_preserving_limiter(discr, field, mmin=0.0)
+    limited_field = bound_preserving_limiter(dcoll, field, mmin=0.0)
     lmtd_fld_min = np.min(actx.to_numpy(limited_field[0]))
     assert lmtd_fld_min > -1e-13
 
@@ -71,14 +71,14 @@ def test_bound_preserving_limiter(actx_factory, order, dim):
         a=(0.0,) * dim, b=(0.5,) * dim, nelements_per_axis=(nel_1d,) * dim
     )
 
-    discr = create_discretization_collection(actx, mesh, order=order)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
 
     # create cells with values larger than 1.0
-    nodes = actx.thaw(actx.freeze(discr.nodes()))
+    nodes = actx.thaw(actx.freeze(dcoll.nodes()))
     eps = 0.01
     field = 0.5 + nodes[0] + eps
 
     # apply limiter
-    limited_field = bound_preserving_limiter(discr, field, mmin=0.0, mmax=1.0)
+    limited_field = bound_preserving_limiter(dcoll, field, mmin=0.0, mmax=1.0)
     lmtd_fld_max = np.max(actx.to_numpy(limited_field[0]))
     assert lmtd_fld_max < 1.0 + 1.0e-13

--- a/test/test_restart.py
+++ b/test/test_restart.py
@@ -49,8 +49,8 @@ def test_restart_cv(actx_factory, nspecies):
         a=(-0.5,) * dim, b=(0.5,) * dim, nelements_per_axis=(nel_1d,) * dim
     )
     order = 3
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
 
     mass = nodes[0]
     energy = nodes[1]
@@ -76,4 +76,4 @@ def test_restart_cv(actx_factory, nspecies):
 
     resid = test_state - restart_data["state"]
     from mirgecom.simutil import max_component_norm
-    assert max_component_norm(discr, resid, np.inf) == 0
+    assert max_component_norm(dcoll, resid, np.inf) == 0

--- a/test/test_simutil.py
+++ b/test/test_simutil.py
@@ -51,9 +51,9 @@ def test_basic_cfd_healthcheck(actx_factory):
     )
 
     order = 3
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    zeros = discr.zeros(actx)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    zeros = dcoll.zeros(actx)
     ones = zeros + 1.0
 
     # Let's make a very bad state (negative mass)
@@ -67,8 +67,8 @@ def test_basic_cfd_healthcheck(actx_factory):
     pressure = eos.pressure(cv)
 
     from mirgecom.simutil import check_range_local
-    assert check_range_local(discr, "vol", mass, min_value=0, max_value=np.inf)
-    assert check_range_local(discr, "vol", pressure, min_value=1e-6,
+    assert check_range_local(dcoll, "vol", mass, min_value=0, max_value=np.inf)
+    assert check_range_local(dcoll, "vol", pressure, min_value=1e-6,
                              max_value=np.inf)
 
     # Let's make another very bad state (nans)
@@ -81,7 +81,7 @@ def test_basic_cfd_healthcheck(actx_factory):
     pressure = eos.pressure(cv)
 
     from mirgecom.simutil import check_naninf_local
-    assert check_naninf_local(discr, "vol", pressure)
+    assert check_naninf_local(dcoll, "vol", pressure)
 
     # Let's make one last very bad state (inf)
     mass = 1*ones
@@ -92,15 +92,15 @@ def test_basic_cfd_healthcheck(actx_factory):
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
     pressure = eos.pressure(cv)
 
-    assert check_naninf_local(discr, "vol", pressure)
+    assert check_naninf_local(dcoll, "vol", pressure)
 
     # What the hey, test a good one
     energy = 2.5 + .5*np.dot(mom, mom)
     cv = make_conserved(dim, mass=mass, energy=energy, momentum=mom)
     pressure = eos.pressure(cv)
 
-    assert not check_naninf_local(discr, "vol", pressure)
-    assert not check_range_local(discr, "vol", pressure, min_value=0,
+    assert not check_naninf_local(dcoll, "vol", pressure)
+    assert not check_range_local(dcoll, "vol", pressure, min_value=0,
                                  max_value=np.inf)
 
 
@@ -120,9 +120,9 @@ def test_analytic_comparison(actx_factory):
     )
 
     order = 2
-    discr = create_discretization_collection(actx, mesh, order=order)
-    nodes = actx.thaw(discr.nodes())
-    zeros = discr.zeros(actx)
+    dcoll = create_discretization_collection(actx, mesh, order=order)
+    nodes = actx.thaw(dcoll.nodes())
+    zeros = dcoll.zeros(actx)
     ones = zeros + 1.0
     mass = ones
     energy = ones
@@ -135,10 +135,10 @@ def test_analytic_comparison(actx_factory):
     resid = vortex_soln - cv
 
     expected_errors = actx.to_numpy(
-        flatten(componentwise_norms(discr, resid, order=np.inf), actx)).tolist()
+        flatten(componentwise_norms(dcoll, resid, order=np.inf), actx)).tolist()
 
-    errors = compare_fluid_solutions(discr, cv, cv)
+    errors = compare_fluid_solutions(dcoll, cv, cv)
     assert max(errors) == 0
 
-    errors = compare_fluid_solutions(discr, cv, vortex_soln)
+    errors = compare_fluid_solutions(dcoll, cv, vortex_soln)
     assert errors == expected_errors

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -298,9 +298,9 @@ def test_symbolic_evaluation(actx_factory):
         b=(np.pi/2,)*2,
         nelements_per_axis=(4,)*2)
 
-    discr = create_discretization_collection(actx, mesh, order=2)
+    dcoll = create_discretization_collection(actx, mesh, order=2)
 
-    nodes = actx.thaw(discr.nodes())
+    nodes = actx.thaw(dcoll.nodes())
 
     sym_coords = pmbl.make_sym_vector("x", 2)
 
@@ -313,8 +313,8 @@ def test_symbolic_evaluation(actx_factory):
 
     expected_f = np.exp(-0.5) * actx.np.cos(nodes[0]) * actx.np.sin(nodes[1])
     assert actx.to_numpy(
-        op.norm(discr, f - expected_f, np.inf)
-        / op.norm(discr, expected_f, np.inf)) < 1e-12
+        op.norm(dcoll, f - expected_f, np.inf)
+        / op.norm(dcoll, expected_f, np.inf)) < 1e-12
 
     # Vector
     sym_f = make_obj_array([
@@ -328,8 +328,8 @@ def test_symbolic_evaluation(actx_factory):
         actx.np.cos(nodes[0]),
         actx.np.sin(nodes[1])])
     assert actx.to_numpy(
-        op.norm(discr, f - expected_f, np.inf)
-        / op.norm(discr, expected_f, np.inf)) < 1e-12
+        op.norm(dcoll, f - expected_f, np.inf)
+        / op.norm(dcoll, expected_f, np.inf)) < 1e-12
 
     # Array container
     from mirgecom.fluid import make_conserved
@@ -353,7 +353,7 @@ def test_symbolic_evaluation(actx_factory):
     # This awkward construction works around an issue with empty
     # arrays inside the CV: (https://github.com/inducer/grudge/issues/266)
     from mirgecom.simutil import compare_fluid_solutions
-    assert max(compare_fluid_solutions(discr, f, expected_f)) < 1e-12
+    assert max(compare_fluid_solutions(dcoll, f, expected_f)) < 1e-12
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bulk rename of `discr` to `dcoll` - most importantly to the _interfaces_ of functions, reflecting that we are working with _collections_ of discretizations instead of a single discretization.
 
closes #509 

**Questions for the review**:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
  - [x] ~~The PR should have a guide if needed (e.g., an ordering).~~
- [x] Is every top-level method and class documented? Are things that should be documented actually so?
	- The interfaces were already mostly documented properly in #692	
- [x] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [x] Does the implementation do what the docstring claims?
- [x] Is everything that is implemented covered by tests?
- [x] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?