### PR TITLE
Use fusion actx env.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,17 +8,19 @@ pymetis
 importlib-resources
 psutil
 pyyaml
+git+https://github.com/pythological/kanren.git#egg=miniKanren
 
 # The following packages will be git cloned by emirge:
 --editable git+https://github.com/inducer/pymbolic.git#egg=pymbolic
 #--editable git+https://github.com/inducer/pyopencl.git#egg=pyopencl
---editable git+https://github.com/inducer/loopy.git#egg=loopy
+--editable git+https://github.com/kaushikcfd/loopy.git#egg=loopy
 --editable git+https://github.com/inducer/dagrt.git#egg=dagrt
 --editable git+https://github.com/inducer/leap.git#egg=leap
 --editable git+https://github.com/inducer/modepy.git#egg=modepy
---editable git+https://github.com/inducer/arraycontext.git#egg=arraycontext
---editable git+https://github.com/inducer/meshmode.git#egg=meshmode
+--editable git+https://github.com/kaushikcfd/arraycontext.git#egg=arraycontext
+--editable git+https://github.com/kaushikcfd/meshmode.git#egg=meshmode
 --editable git+https://github.com/majosm/grudge.git@multi-main#egg=grudge
---editable git+https://github.com/inducer/pytato.git#egg=pytato
+--editable git+https://github.com/kaushikcfd/pytato.git#egg=pytato
 --editable git+https://github.com/ecisneros8/pyrometheus.git#egg=pyrometheus
 --editable git+https://github.com/illinois-ceesd/logpyle.git#egg=logpyle
+--editable git+https://github.com/kaushikcfd/feinsum.git#egg=feinsum


### PR DESCRIPTION
This change set will point `mirgecom@main` at the fusion array context, and upstream packages required for our prediction runs.  It renders our GPU testing more effective in that it speeds it up by more than an order of magnitude, and allows us to test lazy multi-species runs from main (which does not work with the default array context).

**Questions for the review** @lukeolson:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
  - [x] The PR should have a guide if needed (e.g., an ordering).
- [x] ~~Is every top-level method and class documented? Are things that should be documented actually so?~~
- [x] ~~Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?~~
- [x] ~~Does the implementation do what the docstring claims?~~
- [x] Is everything that is implemented covered by tests?
- [x] ~~Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?~~
