### PR TITLE
Update CI action components

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,9 @@ jobs:
         name: Flake8
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         -
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             # matches compat target in setup.py
             python-version: '3.8'
@@ -31,9 +31,9 @@ jobs:
         name: Pylint
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         -
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: '3.x'
         - name: Install
@@ -49,9 +49,9 @@ jobs:
     pydocstyle:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         -
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: '3.x'
         - name: Run Pydocstyle
@@ -67,7 +67,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Install
           run: |
             . .ci-support/install.sh
@@ -88,7 +88,7 @@ jobs:
             os: [ubuntu-latest, porter]
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Install
           run: |
             . .ci-support/install.sh
@@ -116,7 +116,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Install
           run: |
             . .ci-support/install.sh
@@ -142,7 +142,7 @@ jobs:
             os: [ubuntu-latest, macos-latest]
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Install emirge
           run: |
             [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
@@ -168,7 +168,7 @@ jobs:
             os: [ubuntu-latest, macos-latest, porter]
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             fetch-depth: '0'
         - name: Prepare production environment


### PR DESCRIPTION
Fixes warnings of the type


- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2
