### PR TITLE
add py.typed marker to "export" type info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ def main():
               "importlib-resources>=1.1.0; python_version < '3.9'",
           ],
 
+          package_data={"mirgecom": ["py.typed"]},
+
           include_package_data=True,)
 
 


### PR DESCRIPTION
With this PR, other packages using mirgecom can use mypy to check for type conformance with the mirgecom API.
See https://peps.python.org/pep-0561/ for context.