### PR TITLE
Remove calls to `mpi_distribute`

### DIFF
--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -841,8 +841,6 @@ def distribute_mesh(comm, get_mesh_data, partition_generator_func=None):
     global_nelements: :class:`int`
         The number of elements in the global mesh
     """
-    from meshmode.distributed import mpi_distribute
-
     num_ranks = comm.Get_size()
 
     if partition_generator_func is None:
@@ -872,7 +870,11 @@ def distribute_mesh(comm, get_mesh_data, partition_generator_func=None):
                 rank: np.where(rank_per_element == rank)[0]
                 for rank in range(num_ranks)}
 
-            rank_to_mesh_data = partition_mesh(mesh, rank_to_elements)
+            rank_to_mesh_data_dict = partition_mesh(mesh, rank_to_elements)
+
+            rank_to_mesh_data = [
+                rank_to_mesh_data_dict[rank]
+                for rank in range(num_ranks)]
 
         else:
             tag_to_volume = {
@@ -923,21 +925,20 @@ def distribute_mesh(comm, get_mesh_data, partition_generator_func=None):
 
             part_id_to_mesh = partition_mesh(mesh, part_id_to_elements)
 
-            rank_to_mesh_data = {
-                rank: {
+            rank_to_mesh_data = [
+                {
                     vol: (
                         part_id_to_mesh[PartID(vol, rank)],
                         part_id_to_tag_to_elements[PartID(vol, rank)])
                     for vol in volumes}
-                for rank in range(num_ranks)}
+                for rank in range(num_ranks)]
 
-        local_mesh_data = mpi_distribute(
-            comm, source_rank=0, source_data=rank_to_mesh_data)
+        local_mesh_data = comm.scatter(rank_to_mesh_data, root=0)
 
         global_nelements = comm.bcast(mesh.nelements, root=0)
 
     else:
-        local_mesh_data = mpi_distribute(comm, source_rank=0)
+        local_mesh_data = comm.scatter(None, root=0)
 
         global_nelements = comm.bcast(None, root=0)
 


### PR DESCRIPTION
After revisiting https://github.com/inducer/meshmode/pull/342 and looking at how `mpi_distribute` is used inside `distribute_mesh`, I'm not sure it's actually needed anymore. `comm.scatter` may be good enough.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
