### PR TITLE
Add fluid operator arg to support esdg in prediction

### DIFF
--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -76,7 +76,7 @@ from mirgecom.gas_model import (
 )
 from mirgecom.navierstokes import (
     grad_t_operator as fluid_grad_t_operator,
-    ns_operator,
+    ns_operator
 )
 from mirgecom.diffusion import (
     grad_facial_flux_weighted,
@@ -1063,6 +1063,7 @@ def coupled_ns_heat_operator(
         fluid_gradient_numerical_flux_func=num_flux_central,
         inviscid_numerical_flux_func=inviscid_facial_flux_rusanov,
         viscous_numerical_flux_func=viscous_facial_flux_harmonic,
+        fluid_operator=ns_operator,
         return_gradients=False):
     r"""
     Compute the RHS of the fluid and wall subdomains.
@@ -1273,7 +1274,7 @@ def coupled_ns_heat_operator(
 
     # Compute the subdomain NS/diffusion operators using the augmented boundaries
 
-    ns_result = ns_operator(
+    ns_result = fluid_operator(
         dcoll, gas_model, fluid_state, fluid_all_boundaries,
         time=time, quadrature_tag=quadrature_tag, dd=fluid_dd,
         viscous_numerical_flux_func=viscous_numerical_flux_func,


### PR DESCRIPTION
Preparing to add ESDG as a prediction option.   This change set adds a `fluid_operator` argument to the multiphysics interface.  The idea is that setting the `fluid_operator` is in the hands of the driver.  The driver will set it to:
`ns_operator` 
-or-
`entropy_stable_ns_operator` (once its moved down out of #877 )

The multiphysics example is modified to illustrate the planned usage pattern.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
