### PR TITLE
Add limiter_func to interface and pass to make_operator_fluid_states

### DIFF
--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -1165,7 +1165,7 @@ def coupled_ns_heat_operator(
     limiter_func:
 
         Callable function to be passed to
-        :func:`~mirgecom.gas_model.make_fluid_operator_states`
+        :func:`~mirgecom.gas_model.make_operator_fluid_states`
         that filters or limits the produced fluid states.  This is used to keep
         species mass fractions in physical and realizable states, for example.
 

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -1060,6 +1060,7 @@ def coupled_ns_heat_operator(
         use_kappa_weighted_grad_flux_in_fluid=False,
         wall_penalty_amount=None,
         quadrature_tag=DISCR_TAG_BASE,
+        limiter_func=None,
         fluid_gradient_numerical_flux_func=num_flux_central,
         inviscid_numerical_flux_func=inviscid_facial_flux_rusanov,
         viscous_numerical_flux_func=viscous_facial_flux_harmonic,
@@ -1161,6 +1162,13 @@ def coupled_ns_heat_operator(
         for the divergence of the viscous transport flux.  This defaults to
         :func:`~mirgecom.viscous.viscous_facial_flux_harmonic`.
 
+    limiter_func:
+
+        Callable function to be passed to
+        :func:`~mirgecom.gas_model.make_fluid_operator_states`
+        that filters or limits the produced fluid states.  This is used to keep
+        species mass fractions in physical and realizable states, for example.
+
     Returns
     -------
 
@@ -1220,7 +1228,8 @@ def coupled_ns_heat_operator(
 
     fluid_operator_states_quad = make_operator_fluid_states(
         dcoll, fluid_state, gas_model, fluid_all_boundaries_no_grad,
-        quadrature_tag, dd=fluid_dd, comm_tag=_FluidOpStatesTag)
+        quadrature_tag, dd=fluid_dd, comm_tag=_FluidOpStatesTag,
+        limiter_func=limiter_func)
 
     # Compute the temperature gradient for both subdomains
 


### PR DESCRIPTION
Currently, multiphysics runs with mixtures are sending unlimited fluid states to the fluid operators.   This change set fixes that issue.

**Questions for the review**:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
  - [x] The PR should have a guide if needed (e.g., an ordering).
- [x] Is every top-level method and class documented? Are things that should be documented actually so?
- [x] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [x] Does the implementation do what the docstring claims?
- [x] Is everything that is implemented covered by tests?
- [x] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
