### PR TITLE
Deprecate duplicate `force_evaluation`

### DIFF
--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -31,11 +31,6 @@ Simulation support utilities
 
 .. autofunction:: configurate
 
-Lazy eval utilities
--------------------
-
-.. autofunction:: force_evaluation
-
 File comparison utilities
 -------------------------
 
@@ -1070,7 +1065,13 @@ def boundary_report(dcoll, boundaries, outfile_name, *, dd=DD_VOLUME_ALL,
 
 
 def force_evaluation(actx, expn):
-    """Wrap freeze/thaw forcing evaluation of expressions."""
+    """Wrap freeze/thaw forcing evaluation of expressions.
+
+    Deprecated; use :func:`mirgecom.utils.force_evaluation` instead.
+    """
+    from warnings import warn
+    warn("simutil.force_evaluation is deprecated and will disappear in Q3 2023. "
+         "Use utils.force_evaluation instead.", DeprecationWarning, stacklevel=2)
     return actx.thaw(actx.freeze(expn))
 
 


### PR DESCRIPTION
Turns out we have two versions of `force_evaluation`, one in `utils` and one in `simutil`. I think the one in `utils` is the preferred implementation (it uses `freeze_thaw` instead of `thaw(freeze(...))`), so let's keep that one.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
