### PR TITLE
Pass through inviscid numerical flux func.

### DIFF
--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -1285,6 +1285,7 @@ def coupled_ns_heat_operator(
     ns_result = ns_operator(
         dcoll, gas_model, fluid_state, fluid_all_boundaries,
         time=time, quadrature_tag=quadrature_tag, dd=fluid_dd,
+        inviscid_numerical_flux_func=inviscid_numerical_flux_func,
         viscous_numerical_flux_func=viscous_numerical_flux_func,
         return_gradients=return_gradients,
         operator_states_quad=fluid_operator_states_quad,


### PR DESCRIPTION
~~Fixes~~ Mitigates a bug in the multiphysics interface that prevents callers from setting `inviscid_numerical_flux_func`.  

Defaulting this causes a pretty harmful thing.   If nothing is passed as `inviscid_numerical_flux_func` to `ns_operator`, then it defaults to `inviscid_facial_flux_rusanov`.    But if nothing is passed  as `inviscid_numerical_flux_func` to `entropy_stable_ns_operator`, it defaults to `entropy_stable_inviscid_flux_rusanov`.    

By internally defaulting this parameter, the multiphysics operator actually changes the expected default behavior.  If nothing is passed as `inviscid_numerical_flux_func` to the coupled operator, then it passes `invsicid_numerical_flux_func=inviscid_facial_flux_rusanov` regardless of whether we use the entropy stable or the standard NS operator.  This will fail for entropy stable.

On the other hand, not fixing this bug renders the driver setting of `inviscid_numerical_flux_func` ineffective.  For the prediction driver, we _always_ pass the `inviscid_numerical_flux_func` argument.  We do not default this setting, including for entropy stable, so fixing it like this will make it work as-intended for prediction. 

One thing we _could_ do is make `*_numerical_flux_func` required arguments of the coupled operator.

@majosm , @anderson2981 

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
