### PR TITLE
Make compatible with non-coupling-enabled versions of grudge

### DIFF
--- a/examples/thermally-coupled-mpi.py
+++ b/examples/thermally-coupled-mpi.py
@@ -97,6 +97,13 @@ def main(ctx_factory=cl.create_some_context, use_logmgr=True,
     if casename is None:
         casename = "mirgecom"
 
+    try:
+        from grudge.discretization import PartID  # noqa: F401
+    except ImportError:
+        from warnings import warn
+        warn("This example requires a coupling-enabled branch of grudge; exiting.")
+        return
+
     from mpi4py import MPI
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -53,7 +53,6 @@ from abc import abstractmethod
 
 from grudge.trace_pair import (
     TracePair,
-    inter_volume_trace_pairs
 )
 from grudge.dof_desc import (
     DISCR_TAG_BASE,
@@ -661,6 +660,8 @@ def _kappa_inter_volume_trace_pairs(
 
     pairwise_kappa = {
         (fluid_dd, wall_dd): (fluid_kappa, wall_kappa)}
+    from grudge.trace_pair import \
+        inter_volume_trace_pairs  # pylint: disable=no-name-in-module
     return inter_volume_trace_pairs(
         dcoll, pairwise_kappa, comm_tag=_KappaInterVolTag)
 
@@ -674,6 +675,8 @@ def _temperature_inter_volume_trace_pairs(
     pairwise_temperature = {
         (fluid_dd, wall_dd):
             (fluid_state.temperature, wall_temperature)}
+    from grudge.trace_pair import \
+        inter_volume_trace_pairs  # pylint: disable=no-name-in-module
     return inter_volume_trace_pairs(
         dcoll, pairwise_temperature, comm_tag=_TemperatureInterVolTag)
 
@@ -687,6 +690,8 @@ def _grad_temperature_inter_volume_trace_pairs(
     pairwise_grad_temperature = {
         (fluid_dd, wall_dd):
             (fluid_grad_temperature, wall_grad_temperature)}
+    from grudge.trace_pair import \
+        inter_volume_trace_pairs  # pylint: disable=no-name-in-module
     return inter_volume_trace_pairs(
         dcoll, pairwise_grad_temperature, comm_tag=_GradTemperatureInterVolTag)
 

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -78,7 +78,7 @@ from meshmode.dof_array import DOFArray
 from mirgecom.viscous import get_viscous_timestep
 
 from typing import List, Dict, Optional
-from grudge.discretization import DiscretizationCollection, PartID
+from grudge.discretization import DiscretizationCollection
 from grudge.dof_desc import DD_VOLUME_ALL
 from mirgecom.utils import normalize_boundaries
 import pyopencl as cl
@@ -891,6 +891,9 @@ def distribute_mesh(comm, get_mesh_data, partition_generator_func=None):
 
             if np.any(volume_index_per_element < 0):
                 raise ValueError("Missing volume specification for some elements.")
+
+            from grudge.discretization import \
+                PartID  # pylint: disable=no-name-in-module
 
             part_id_to_elements = {
                 PartID(volumes[vol_idx], rank):

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -165,6 +165,11 @@ def test_independent_volumes(actx_factory, order, visualize=False):
 def test_thermally_coupled_fluid_wall(
         actx_factory, order, use_overintegration, visualize=False):
     """Check the thermally-coupled fluid/wall interface."""
+    try:
+        from grudge.discretization import PartID  # noqa: F401
+    except ImportError:
+        pytest.skip("Test requires a coupling-enabled branch of grudge.")
+
     actx = actx_factory()
 
     from pytools.convergence import EOCRecorder


### PR DESCRIPTION
Makes coupling functionality conditional on having a coupling-enabled branch of grudge.

cc @inducer

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
