### PR TITLE
Fix issues with `==` in tests and update to work with numpy 1.25

### DIFF
--- a/mirgecom/eos.py
+++ b/mirgecom/eos.py
@@ -65,7 +65,7 @@ class MixtureEOSNeededError(Exception):
 
 
 @dataclass_array_container
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class GasDependentVars:
     """State-dependent quantities for :class:`GasEOS`.
 
@@ -89,7 +89,7 @@ class GasDependentVars:
 
 
 @dataclass_array_container
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class MixtureDependentVars(GasDependentVars):
     """Mixture state-dependent quantities for :class:`MixtureEOS`.
 

--- a/mirgecom/filter.py
+++ b/mirgecom/filter.py
@@ -87,9 +87,9 @@ def get_element_spectrum_from_modal_representation(actx, vol_discr, modal_fields
         Array with the element modes accumulated into the corresponding
         "modes" for the polynomial basis functions for each field.
     """
-    modal_spectra = np.stack(
+    modal_spectra = np.stack([
         actx.to_numpy(ary)[0]
-        for ary in modal_fields)
+        for ary in modal_fields])
 
     numfields, numelem, nummodes = modal_spectra.shape
 

--- a/mirgecom/fluid.py
+++ b/mirgecom/fluid.py
@@ -52,9 +52,10 @@ from arraycontext import (
                            bcast_container_types=(DOFArray, np.ndarray),
                            matmul=True,
                            _cls_has_array_context_attr=True,
-                           rel_comparison=True)
+                           eq_comparison=False,
+                           rel_comparison=False)
 @dataclass_array_container
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class ConservedVars:
     r"""Store and resolve quantities according to the fluid conservation equations.
 

--- a/mirgecom/gas_model.py
+++ b/mirgecom/gas_model.py
@@ -94,7 +94,7 @@ class GasModel:
 
 
 @dataclass_array_container
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class FluidState:
     r"""Gas model-consistent fluid state.
 

--- a/mirgecom/transport.py
+++ b/mirgecom/transport.py
@@ -63,7 +63,7 @@ class TransportModelError(Exception):
 
 
 @dataclass_array_container
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class GasTransportVars:
     """State-dependent quantities for :class:`TransportModel`.
 

--- a/test/test_av.py
+++ b/test/test_av.py
@@ -454,10 +454,10 @@ def test_fluid_av_boundaries(ctx_factory, prescribed_soln, order):
 
     bnd_flux_resid = (prescribed_boundary_av_flux - exp_av_flux)
     print(f"{bnd_flux_resid=}")
-    assert bnd_flux_resid == 0
+    assert actx.np.equal(bnd_flux_resid, 0)
 
     # Solid wall boundaries are expected to have 0 AV flux
     wall_bnd_flux = \
         adiabatic_noslip.av_flux(dcoll, BTAG_ALL, av_diffusion)
     print(f"adiabatic_noslip: {wall_bnd_flux=}")
-    assert wall_bnd_flux == 0
+    assert actx.np.equal(wall_bnd_flux, 0)

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -291,7 +291,7 @@ def test_farfield_boundary(actx_factory, dim, flux_func):
                                                       grad_t_minus=grad_t_minus)
             print(f"{v_flux_bc=}")
 
-            assert ff_bndry_state.cv == exp_ff_cv
+            assert actx.np.equal(ff_bndry_state.cv, exp_ff_cv)
             assert actx.np.all(temperature_bc == ff_temp)
             for idim in range(dim):
                 assert actx.np.all(ff_bndry_state.momentum_density[idim]
@@ -387,7 +387,7 @@ def test_outflow_boundary(actx_factory, dim, flux_func):
 
             print(f"{exp_flowbnd_cv=}")
 
-            assert flowbnd_bndry_state.cv == exp_flowbnd_cv
+            assert actx.np.equal(flowbnd_bndry_state.cv, exp_flowbnd_cv)
             assert actx.np.all(flowbnd_bndry_temperature == flowbnd_press_bc)
             assert actx.np.all(flowbnd_bndry_pressure == flowbnd_press_bc)
 
@@ -421,7 +421,7 @@ def test_outflow_boundary(actx_factory, dim, flux_func):
             exp_flowbnd_cv = make_conserved(dim=dim, mass=bnd_dens,
                                               momentum=bnd_mom, energy=bnd_ener)
 
-            assert flowbnd_bndry_state.cv == exp_flowbnd_cv
+            assert actx.np.equal(flowbnd_bndry_state.cv, exp_flowbnd_cv)
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])
@@ -585,7 +585,7 @@ def test_isothermal_wall_boundary(actx_factory, dim, flux_func):
                                                      grad_t_minus=grad_t_minus)
             print(f"{v_flux_bc=}")
 
-            assert wall_state.cv == expected_noslip_cv
+            assert actx.np.equal(wall_state.cv, expected_noslip_cv)
             assert actx.np.all(temperature_bc == expected_wall_temperature)
             for idim in range(dim):
                 assert actx.np.all(wall_state.momentum_density[idim]
@@ -762,8 +762,8 @@ def test_adiabatic_noslip_wall_boundary(actx_factory, dim, flux_func):
                                                      grad_t_minus=grad_t_minus)
             print(f"{v_flux_bc=}")
 
-            assert adv_wall_state.cv == expected_adv_wall_cv
-            assert diff_wall_state.cv == expected_diff_wall_cv
+            assert actx.np.equal(adv_wall_state.cv, expected_adv_wall_cv)
+            assert actx.np.equal(diff_wall_state.cv, expected_diff_wall_cv)
             assert actx.np.all(temperature_bc == expected_wall_temperature)
             for idim in range(dim):
                 assert actx.np.all(adv_wall_state.momentum_density[idim]
@@ -956,8 +956,8 @@ def test_symmetry_wall_boundary(actx_factory, dim, flux_func):
             temperature_bc = wall.temperature_bc(
                 dcoll, dd_bdry=BTAG_ALL, state_minus=state_minus)
 
-            assert adv_wall_state.cv == expected_adv_wall_cv
-            assert diff_wall_state.cv == expected_diff_wall_cv
+            assert actx.np.equal(adv_wall_state.cv, expected_adv_wall_cv)
+            assert actx.np.equal(diff_wall_state.cv, expected_diff_wall_cv)
             assert actx.np.all(temperature_bc == expected_temp_boundary)
 
             for idim in range(dim):
@@ -1342,4 +1342,4 @@ def test_prescribed(actx_factory, prescribed_soln, flux_func):
             bc_soln = \
                 domain_boundary._boundary_state_pair(dcoll, BTAG_ALL, gas_model,
                                                      state_minus=state_minus).ext.cv
-            assert bc_soln == expected_boundary_solution
+            assert actx.np.equal(bc_soln, expected_boundary_solution)

--- a/test/test_navierstokes.py
+++ b/test/test_navierstokes.py
@@ -615,7 +615,7 @@ def test_exact_mms(actx_factory, order, dim, manufactured_soln, mu):
     tol = 1e-15
 
     if mu == 0:
-        assert sym_ns_source == sym_euler_source
+        assert actx.np.equal(sym_ns_source, sym_euler_source)
         sym_source = sym_euler_source
     else:
         sym_source = sym_ns_source

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -131,16 +131,23 @@ def _array_container_deriv_pair():
     _obj_array_deriv_pair(),
     _array_container_deriv_pair(),
 ])
-def test_symbolic_diff(sym_f, expected_sym_df):
+def test_symbolic_diff(actx_factory, sym_f, expected_sym_df):
     """
     Compute the symbolic derivative of an expression and compare it to an
     expected result.
     """
+    actx = actx_factory()
+
     sym_df = sym.diff(pmbl.var("x"))(sym_f)
-    if isinstance(sym_f, np.ndarray):
+
+    from pymbolic.primitives import Expression
+    if isinstance(sym_f, Expression):
+        assert sym_df == expected_sym_df
+    elif isinstance(sym_f, np.ndarray):
         assert (sym_df == expected_sym_df).all()
     else:
-        assert sym_df == expected_sym_df
+        # Array container
+        assert actx.np.equal(sym_df, expected_sym_df)
 
 
 def test_symbolic_div():


### PR DESCRIPTION
We seem to have some bugs in our tests that were uncovered by the changes in object array behavior in numpy 1.25. Specifically, in a few places we assert on the equality of `ConservedVars` objects:

```python
            assert ff_bndry_state.cv == exp_ff_cv
```

which looks reasonable enough, but upon inspection:

```python
ff_bndry_state.cv == exp_ff_cv=ConservedVars(mass=DOFArray((cl.TaggableCLArray([[1],
       [1]], dtype=int8),)), energy=DOFArray((cl.TaggableCLArray([[1],
       [1]], dtype=int8),)), momentum=False, species_mass=array([], dtype=bool))
bool(ff_bndry_state.cv == exp_ff_cv)=True
```

i.e., `==` here is doing some strange things, and CV's boolean conversion is questionable. The discretization here is the boundary of a 1D mesh, so it looks like most of the components are doing elementwise equality, except for momentum.

If I understand correctly, `ConservedVars` gets its `__eq__` operator from arraycontext's `with_container_arithmetic` decorator. @inducer Is the equality operator resulting from this decorator intended to do elementwise comparison? If so, is there a way we can make it work for array containers containing object arrays? Or do we just need to disable `==` for `ConservedVars`, as I've attempted to do here?

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
