### PR TITLE
CI: use mambaforge, uninstall pocl before doc build

### DIFF
--- a/.ci-support/install.sh
+++ b/.ci-support/install.sh
@@ -12,7 +12,7 @@ if [[ "$(uname)" = "Darwin" ]]; then
 else
     if ! command -v mpicc &> /dev/null ;then
         sudo apt-get update
-        sudo apt-get -y install libopenmpi-dev openmpi-bin moreutils
+        sudo apt-get -y install libopenmpi-dev openmpi-bin
     fi
     if ! command -v octave &> /dev/null ;then
         sudo apt-get -y install octave
@@ -29,7 +29,7 @@ bash "$MINIFORGE_INSTALL_SH" -b -p "$MINIFORGE_INSTALL_DIR"
 #PATH="$MINIFORGE_INSTALL_DIR/bin/:$PATH" conda update conda --yes --quiet
 #PATH="$MINIFORGE_INSTALL_DIR/bin/:$PATH" conda update --all --yes --quiet
 
-$MINIFORGE_INSTALL_DIR/bin/mamba env create --file conda-env.yml --name testing | ts
+$MINIFORGE_INSTALL_DIR/bin/mamba env create --file conda-env.yml --name testing
 
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 conda list
@@ -38,5 +38,5 @@ conda list
 rm -rf $MINIFORGE_INSTALL_DIR/envs/testing/x86_64-conda-linux-gnu/sysroot
 
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-pip install -r requirements.txt | ts
-python setup.py install | ts
+pip install -r requirements.txt
+python setup.py install

--- a/.ci-support/install.sh
+++ b/.ci-support/install.sh
@@ -2,13 +2,14 @@
 
 set -ex
 
+myos=$(uname)
+myarch=$(uname -m)
+
 if [[ "$(uname)" = "Darwin" ]]; then
-    PLATFORM=MacOSX
     brew update
     brew install open-mpi
     brew install octave
 else
-    PLATFORM=Linux
     if ! command -v mpicc &> /dev/null ;then
         sudo apt-get update
         sudo apt-get -y install libopenmpi-dev openmpi-bin moreutils
@@ -19,16 +20,16 @@ else
 fi
 
 MINIFORGE_INSTALL_DIR=.miniforge3
-MINIFORGE_INSTALL_SH=Miniforge3-$PLATFORM-x86_64.sh
+MINIFORGE_INSTALL_SH=Mambaforge-$myos-$myarch.sh
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/$MINIFORGE_INSTALL_SH"
 rm -Rf "$MINIFORGE_INSTALL_DIR"
-bash "$MINIFORGE_INSTALL_SH" -b -p "$MINIFORGE_INSTALL_DIR" | ts
+bash "$MINIFORGE_INSTALL_SH" -b -p "$MINIFORGE_INSTALL_DIR"
 
 # Temporarily disabled to get CI unstuck
 #PATH="$MINIFORGE_INSTALL_DIR/bin/:$PATH" conda update conda --yes --quiet
 #PATH="$MINIFORGE_INSTALL_DIR/bin/:$PATH" conda update --all --yes --quiet
 
-$MINIFORGE_INSTALL_DIR/bin/conda env create --file conda-env.yml --name testing | ts
+$MINIFORGE_INSTALL_DIR/bin/mamba env create --file conda-env.yml --name testing | ts
 
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 conda list

--- a/.ci-support/install.sh
+++ b/.ci-support/install.sh
@@ -11,7 +11,7 @@ else
     PLATFORM=Linux
     if ! command -v mpicc &> /dev/null ;then
         sudo apt-get update
-        sudo apt-get -y install libopenmpi-dev openmpi-bin
+        sudo apt-get -y install libopenmpi-dev openmpi-bin moreutils
     fi
     if ! command -v octave &> /dev/null ;then
         sudo apt-get -y install octave
@@ -22,13 +22,13 @@ MINIFORGE_INSTALL_DIR=.miniforge3
 MINIFORGE_INSTALL_SH=Miniforge3-$PLATFORM-x86_64.sh
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/$MINIFORGE_INSTALL_SH"
 rm -Rf "$MINIFORGE_INSTALL_DIR"
-bash "$MINIFORGE_INSTALL_SH" -b -p "$MINIFORGE_INSTALL_DIR"
+bash "$MINIFORGE_INSTALL_SH" -b -p "$MINIFORGE_INSTALL_DIR" | ts
 
 # Temporarily disabled to get CI unstuck
 #PATH="$MINIFORGE_INSTALL_DIR/bin/:$PATH" conda update conda --yes --quiet
 #PATH="$MINIFORGE_INSTALL_DIR/bin/:$PATH" conda update --all --yes --quiet
 
-PATH="$MINIFORGE_INSTALL_DIR/bin:$PATH" conda env create --file conda-env.yml --name testing --quiet
+$MINIFORGE_INSTALL_DIR/bin/conda env create --file conda-env.yml --name testing | ts
 
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 conda list
@@ -36,7 +36,6 @@ conda list
 # See https://github.com/conda-forge/qt-feedstock/issues/208
 rm -rf $MINIFORGE_INSTALL_DIR/envs/testing/x86_64-conda-linux-gnu/sysroot
 
-MINIFORGE_INSTALL_DIR=.miniforge3
 . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-pip install -r requirements.txt
-python setup.py install
+pip install -r requirements.txt | ts
+python setup.py install | ts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,7 +152,8 @@ jobs:
             pip install sphinx-math-dollar sphinx-copybutton furo
             cd doc
             ulimit -a
-            make html SPHINXOPTS="-W --keep-going -n"
+            free -h
+            /bin/time -v make html SPHINXOPTS="-W --keep-going -n"
             make latexpdf SPHINXOPTS="-W --keep-going -n"
 
     # emirge:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,42 +9,42 @@ on:
 
 
 jobs:
-    flake8:
-        name: Flake8
-        runs-on: ubuntu-latest
-        steps:
-        - uses: actions/checkout@v3
-        -
-          uses: actions/setup-python@v4
-          with:
-            # matches compat target in setup.py
-            python-version: '3.8'
-        - name: Flake8 test
-          run: |
-            python3 -m venv myenv
-            source myenv/bin/activate
-            python -m pip install wheel
-            python -m pip install flake8 pep8-naming flake8-quotes flake8-bugbear
-            python -m flake8 --show-source --statistics "$(basename $GITHUB_REPOSITORY)" test examples setup.py doc/conf.py bin/ && echo "Flake8 found no errors."
+    # flake8:
+    #     name: Flake8
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #     -
+    #       uses: actions/setup-python@v4
+    #       with:
+    #         # matches compat target in setup.py
+    #         python-version: '3.8'
+    #     - name: Flake8 test
+    #       run: |
+    #         python3 -m venv myenv
+    #         source myenv/bin/activate
+    #         python -m pip install wheel
+    #         python -m pip install flake8 pep8-naming flake8-quotes flake8-bugbear
+    #         python -m flake8 --show-source --statistics "$(basename $GITHUB_REPOSITORY)" test examples setup.py doc/conf.py bin/ && echo "Flake8 found no errors."
 
-    mypy:
-        name: Mypy
-        runs-on: ubuntu-latest
-        steps:
-        -   uses: actions/checkout@v3
-        -
-            uses: actions/setup-python@v4
-            with:
-                python-version: '3.x'
-        -   name: Install
-            run: |
-                . .ci-support/install.sh
-        -   name: Run mypy
-            run: |
-                MINIFORGE_INSTALL_DIR=.miniforge3
-                . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-                python -m pip install types-psutil types-PyYAML
-                ./run-mypy.sh
+    # mypy:
+    #     name: Mypy
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #     -   uses: actions/checkout@v3
+    #     -
+    #         uses: actions/setup-python@v4
+    #         with:
+    #             python-version: '3.x'
+    #     -   name: Install
+    #         run: |
+    #             . .ci-support/install.sh
+    #     -   name: Run mypy
+    #         run: |
+    #             MINIFORGE_INSTALL_DIR=.miniforge3
+    #             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+    #             python -m pip install types-psutil types-PyYAML
+    #             ./run-mypy.sh
 
     pylint:
         name: Pylint
@@ -65,149 +65,149 @@ jobs:
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             ./run-pylint.sh
 
-    pydocstyle:
-        runs-on: ubuntu-latest
-        steps:
-        - uses: actions/checkout@v3
-        -
-          uses: actions/setup-python@v4
-          with:
-            python-version: '3.x'
-        - name: Run Pydocstyle
-          run: |
-            python3 -m venv myenv
-            source myenv/bin/activate
-            python -m pip install wheel
-            python -m pip install pydocstyle
-            python -m pydocstyle "$(basename $GITHUB_REPOSITORY)" && echo "pydocstyle found no errors."
+    # pydocstyle:
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #     -
+    #       uses: actions/setup-python@v4
+    #       with:
+    #         python-version: '3.x'
+    #     - name: Run Pydocstyle
+    #       run: |
+    #         python3 -m venv myenv
+    #         source myenv/bin/activate
+    #         python -m pip install wheel
+    #         python -m pip install pydocstyle
+    #         python -m pydocstyle "$(basename $GITHUB_REPOSITORY)" && echo "pydocstyle found no errors."
 
-    pytest:
-        name: Pytest
-        runs-on: ubuntu-latest
+    # pytest:
+    #     name: Pytest
+    #     runs-on: ubuntu-latest
 
-        steps:
-        - uses: actions/checkout@v3
-        - name: Install
-          run: |
-            . .ci-support/install.sh
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #     - name: Install
+    #       run: |
+    #         . .ci-support/install.sh
 
-        - name: Run tests
-          run: |
-            MINIFORGE_INSTALL_DIR=.miniforge3
-            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-            cd test
-            python -m pip install pytest
-            python -m pytest --cov=mirgecom --durations=0 --tb=native --junitxml=pytest.xml --doctest-modules -rxsw . ../doc/*.rst ../doc/*/*.rst
+    #     - name: Run tests
+    #       run: |
+    #         MINIFORGE_INSTALL_DIR=.miniforge3
+    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+    #         cd test
+    #         python -m pip install pytest
+    #         python -m pytest --cov=mirgecom --durations=0 --tb=native --junitxml=pytest.xml --doctest-modules -rxsw . ../doc/*.rst ../doc/*/*.rst
 
-    examples:
-        name: Examples
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [ubuntu-latest, porter]
+    # examples:
+    #     name: Examples
+    #     runs-on: ${{ matrix.os }}
+    #     strategy:
+    #       matrix:
+    #         os: [ubuntu-latest, porter]
 
-        steps:
-        - uses: actions/checkout@v3
-        - name: Install
-          run: |
-            . .ci-support/install.sh
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #     - name: Install
+    #       run: |
+    #         . .ci-support/install.sh
 
-        - name: Test lazy accuracy
-          run: |
-            MINIFORGE_INSTALL_DIR=.miniforge3
-            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-            conda install vtk  # needed for the accuracy comparison
-            export XDG_CACHE_HOME=/tmp
-            [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME && conda install pocl-cuda
-            # && export POCL_DEBUG=cuda
-            scripts/run-integrated-tests.sh --lazy-accuracy
-        - name: Run examples
-          run: |
-            MINIFORGE_INSTALL_DIR=.miniforge3
-            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-            export XDG_CACHE_HOME=/tmp
-            [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME && conda install pocl-cuda
-            # && export POCL_DEBUG=cuda
-            scripts/run-integrated-tests.sh --examples
+    #     - name: Test lazy accuracy
+    #       run: |
+    #         MINIFORGE_INSTALL_DIR=.miniforge3
+    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+    #         conda install vtk  # needed for the accuracy comparison
+    #         export XDG_CACHE_HOME=/tmp
+    #         [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME && conda install pocl-cuda
+    #         # && export POCL_DEBUG=cuda
+    #         scripts/run-integrated-tests.sh --lazy-accuracy
+    #     - name: Run examples
+    #       run: |
+    #         MINIFORGE_INSTALL_DIR=.miniforge3
+    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+    #         export XDG_CACHE_HOME=/tmp
+    #         [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME && conda install pocl-cuda
+    #         # && export POCL_DEBUG=cuda
+    #         scripts/run-integrated-tests.sh --examples
 
-    doc:
-        name: Documentation
-        runs-on: ubuntu-latest
+    # doc:
+    #     name: Documentation
+    #     runs-on: ubuntu-latest
 
-        steps:
-        - uses: actions/checkout@v3
-        - name: Install
-          run: |
-            . .ci-support/install.sh
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #     - name: Install
+    #       run: |
+    #         . .ci-support/install.sh
 
-        - name: Build docs
-          run: |
-            MINIFORGE_INSTALL_DIR=.miniforge3
-            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+    #     - name: Build docs
+    #       run: |
+    #         MINIFORGE_INSTALL_DIR=.miniforge3
+    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 
-            sudo apt-get update
-            sudo apt-get install texlive-latex-extra latexmk
-            conda install sphinx graphviz 'docutils>=0.16'
-            pip install sphinx-math-dollar sphinx-copybutton furo
-            cd doc
-            make html SPHINXOPTS="-W --keep-going -n"
-            make latexpdf SPHINXOPTS="-W --keep-going -n"
+    #         sudo apt-get update
+    #         sudo apt-get install texlive-latex-extra latexmk
+    #         conda install sphinx graphviz 'docutils>=0.16'
+    #         pip install sphinx-math-dollar sphinx-copybutton furo
+    #         cd doc
+    #         make html SPHINXOPTS="-W --keep-going -n"
+    #         make latexpdf SPHINXOPTS="-W --keep-going -n"
 
-    emirge:
-        name: Emirge installation
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [ubuntu-latest, macos-latest]
+    # emirge:
+    #     name: Emirge installation
+    #     runs-on: ${{ matrix.os }}
+    #     strategy:
+    #       matrix:
+    #         os: [ubuntu-latest, macos-latest]
 
-        steps:
-        - uses: actions/checkout@v3
-        - name: Install emirge
-          run: |
-            [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
-            [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
-            cd ..
-            git clone https://github.com/illinois-ceesd/emirge
-            cd emirge
-            cp -a ../mirgecom .
-            ./install.sh --skip-clone
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #     - name: Install emirge
+    #       run: |
+    #         [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
+    #         [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
+    #         cd ..
+    #         git clone https://github.com/illinois-ceesd/emirge
+    #         cd emirge
+    #         cp -a ../mirgecom .
+    #         ./install.sh --skip-clone
 
-        - name: Run simple mirgecom test
-          run: |
-            cd ..
-            source emirge/config/activate_env.sh
-            cd mirgecom/examples
-            python -m mpi4py ./pulse-mpi.py
+    #     - name: Run simple mirgecom test
+    #       run: |
+    #         cd ..
+    #         source emirge/config/activate_env.sh
+    #         cd mirgecom/examples
+    #         python -m mpi4py ./pulse-mpi.py
 
-    y1:
-        name: Production testing
-        runs-on: ${{ matrix.os }}
-        strategy:
-          matrix:
-            os: [ubuntu-latest, macos-latest, porter]
+    # y1:
+    #     name: Production testing
+    #     runs-on: ${{ matrix.os }}
+    #     strategy:
+    #       matrix:
+    #         os: [ubuntu-latest, macos-latest, porter]
 
-        steps:
-        - uses: actions/checkout@v3
-          with:
-            fetch-depth: '0'
-        - name: Prepare production environment
-          run: |
-            [[ $(uname) == Linux ]] && [[ $(hostname) != "porter" ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
-            [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
-            MIRGEDIR=$(pwd)
-            cat scripts/production-testing-env.sh
-            . scripts/production-testing-env.sh
-            cd ..
-            date
-            printf "Removing stale install ..."
-            rm -rf emirge.prod emirge.y1
-            printf "done.\n"
-            date
-            git clone https://github.com/illinois-ceesd/emirge emirge.prod
-            cd emirge.prod
-            . ../mirgecom/scripts/install-mirge-from-source.sh ${MIRGEDIR}/..
+    #     steps:
+    #     - uses: actions/checkout@v3
+    #       with:
+    #         fetch-depth: '0'
+    #     - name: Prepare production environment
+    #       run: |
+    #         [[ $(uname) == Linux ]] && [[ $(hostname) != "porter" ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
+    #         [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
+    #         MIRGEDIR=$(pwd)
+    #         cat scripts/production-testing-env.sh
+    #         . scripts/production-testing-env.sh
+    #         cd ..
+    #         date
+    #         printf "Removing stale install ..."
+    #         rm -rf emirge.prod emirge.y1
+    #         printf "done.\n"
+    #         date
+    #         git clone https://github.com/illinois-ceesd/emirge emirge.prod
+    #         cd emirge.prod
+    #         . ../mirgecom/scripts/install-mirge-from-source.sh ${MIRGEDIR}/..
 
-        - name: Run production test
-          run: |
-            source ../config/activate_env.sh
-            scripts/run-integrated-tests.sh --production
+    #     - name: Run production test
+    #       run: |
+    #         source ../config/activate_env.sh
+    #         scripts/run-integrated-tests.sh --production

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,42 +9,42 @@ on:
 
 
 jobs:
-    # flake8:
-    #     name: Flake8
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #     -
-    #       uses: actions/setup-python@v4
-    #       with:
-    #         # matches compat target in setup.py
-    #         python-version: '3.8'
-    #     - name: Flake8 test
-    #       run: |
-    #         python3 -m venv myenv
-    #         source myenv/bin/activate
-    #         python -m pip install wheel
-    #         python -m pip install flake8 pep8-naming flake8-quotes flake8-bugbear
-    #         python -m flake8 --show-source --statistics "$(basename $GITHUB_REPOSITORY)" test examples setup.py doc/conf.py bin/ && echo "Flake8 found no errors."
+    flake8:
+        name: Flake8
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v3
+        -
+          uses: actions/setup-python@v4
+          with:
+            # matches compat target in setup.py
+            python-version: '3.8'
+        - name: Flake8 test
+          run: |
+            python3 -m venv myenv
+            source myenv/bin/activate
+            python -m pip install wheel
+            python -m pip install flake8 pep8-naming flake8-quotes flake8-bugbear
+            python -m flake8 --show-source --statistics "$(basename $GITHUB_REPOSITORY)" test examples setup.py doc/conf.py bin/ && echo "Flake8 found no errors."
 
-    # mypy:
-    #     name: Mypy
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #     -   uses: actions/checkout@v3
-    #     -
-    #         uses: actions/setup-python@v4
-    #         with:
-    #             python-version: '3.x'
-    #     -   name: Install
-    #         run: |
-    #             . .ci-support/install.sh
-    #     -   name: Run mypy
-    #         run: |
-    #             MINIFORGE_INSTALL_DIR=.miniforge3
-    #             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-    #             python -m pip install types-psutil types-PyYAML
-    #             ./run-mypy.sh
+    mypy:
+        name: Mypy
+        runs-on: ubuntu-latest
+        steps:
+        -   uses: actions/checkout@v3
+        -
+            uses: actions/setup-python@v4
+            with:
+                python-version: '3.x'
+        -   name: Install
+            run: |
+                . .ci-support/install.sh
+        -   name: Run mypy
+            run: |
+                MINIFORGE_INSTALL_DIR=.miniforge3
+                . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+                python -m pip install types-psutil types-PyYAML
+                ./run-mypy.sh
 
     pylint:
         name: Pylint
@@ -65,70 +65,70 @@ jobs:
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
             ./run-pylint.sh
 
-    # pydocstyle:
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #     -
-    #       uses: actions/setup-python@v4
-    #       with:
-    #         python-version: '3.x'
-    #     - name: Run Pydocstyle
-    #       run: |
-    #         python3 -m venv myenv
-    #         source myenv/bin/activate
-    #         python -m pip install wheel
-    #         python -m pip install pydocstyle
-    #         python -m pydocstyle "$(basename $GITHUB_REPOSITORY)" && echo "pydocstyle found no errors."
+    pydocstyle:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v3
+        -
+          uses: actions/setup-python@v4
+          with:
+            python-version: '3.x'
+        - name: Run Pydocstyle
+          run: |
+            python3 -m venv myenv
+            source myenv/bin/activate
+            python -m pip install wheel
+            python -m pip install pydocstyle
+            python -m pydocstyle "$(basename $GITHUB_REPOSITORY)" && echo "pydocstyle found no errors."
 
-    # pytest:
-    #     name: Pytest
-    #     runs-on: ubuntu-latest
+    pytest:
+        name: Pytest
+        runs-on: ubuntu-latest
 
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #     - name: Install
-    #       run: |
-    #         . .ci-support/install.sh
+        steps:
+        - uses: actions/checkout@v3
+        - name: Install
+          run: |
+            . .ci-support/install.sh
 
-    #     - name: Run tests
-    #       run: |
-    #         MINIFORGE_INSTALL_DIR=.miniforge3
-    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-    #         cd test
-    #         python -m pip install pytest
-    #         python -m pytest --cov=mirgecom --durations=0 --tb=native --junitxml=pytest.xml --doctest-modules -rxsw . ../doc/*.rst ../doc/*/*.rst
+        - name: Run tests
+          run: |
+            MINIFORGE_INSTALL_DIR=.miniforge3
+            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+            cd test
+            python -m pip install pytest
+            python -m pytest --cov=mirgecom --durations=0 --tb=native --junitxml=pytest.xml --doctest-modules -rxsw . ../doc/*.rst ../doc/*/*.rst
 
-    # examples:
-    #     name: Examples
-    #     runs-on: ${{ matrix.os }}
-    #     strategy:
-    #       matrix:
-    #         os: [ubuntu-latest, porter]
+    examples:
+        name: Examples
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-latest, porter]
 
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #     - name: Install
-    #       run: |
-    #         . .ci-support/install.sh
+        steps:
+        - uses: actions/checkout@v3
+        - name: Install
+          run: |
+            . .ci-support/install.sh
 
-    #     - name: Test lazy accuracy
-    #       run: |
-    #         MINIFORGE_INSTALL_DIR=.miniforge3
-    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-    #         conda install vtk  # needed for the accuracy comparison
-    #         export XDG_CACHE_HOME=/tmp
-    #         [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME && conda install pocl-cuda
-    #         # && export POCL_DEBUG=cuda
-    #         scripts/run-integrated-tests.sh --lazy-accuracy
-    #     - name: Run examples
-    #       run: |
-    #         MINIFORGE_INSTALL_DIR=.miniforge3
-    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
-    #         export XDG_CACHE_HOME=/tmp
-    #         [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME && conda install pocl-cuda
-    #         # && export POCL_DEBUG=cuda
-    #         scripts/run-integrated-tests.sh --examples
+        - name: Test lazy accuracy
+          run: |
+            MINIFORGE_INSTALL_DIR=.miniforge3
+            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+            mamba install vtk  # needed for the accuracy comparison
+            export XDG_CACHE_HOME=/tmp
+            [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME
+            # && export POCL_DEBUG=cuda
+            scripts/run-integrated-tests.sh --lazy-accuracy
+        - name: Run examples
+          run: |
+            MINIFORGE_INSTALL_DIR=.miniforge3
+            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+            export XDG_CACHE_HOME=/tmp
+            [[ $(hostname) == "porter" ]] && export PYOPENCL_TEST="port:nv" && unset XDG_CACHE_HOME
+            # && export POCL_DEBUG=cuda
+            scripts/run-integrated-tests.sh --examples
 
     doc:
         name: Documentation
@@ -155,61 +155,61 @@ jobs:
             make html SPHINXOPTS="-W --keep-going -n"
             make latexpdf SPHINXOPTS="-W --keep-going -n"
 
-    # emirge:
-    #     name: Emirge installation
-    #     runs-on: ${{ matrix.os }}
-    #     strategy:
-    #       matrix:
-    #         os: [ubuntu-latest, macos-latest]
+    emirge:
+        name: Emirge installation
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-latest, macos-latest]
 
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #     - name: Install emirge
-    #       run: |
-    #         [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
-    #         [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
-    #         cd ..
-    #         git clone https://github.com/illinois-ceesd/emirge
-    #         cd emirge
-    #         cp -a ../mirgecom .
-    #         ./install.sh --skip-clone
+        steps:
+        - uses: actions/checkout@v3
+        - name: Install emirge
+          run: |
+            [[ $(uname) == Linux ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
+            [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
+            cd ..
+            git clone https://github.com/illinois-ceesd/emirge
+            cd emirge
+            cp -a ../mirgecom .
+            ./install.sh --skip-clone
 
-    #     - name: Run simple mirgecom test
-    #       run: |
-    #         cd ..
-    #         source emirge/config/activate_env.sh
-    #         cd mirgecom/examples
-    #         python -m mpi4py ./pulse-mpi.py
+        - name: Run simple mirgecom test
+          run: |
+            cd ..
+            source emirge/config/activate_env.sh
+            cd mirgecom/examples
+            python -m mpi4py ./pulse-mpi.py
 
-    # y1:
-    #     name: Production testing
-    #     runs-on: ${{ matrix.os }}
-    #     strategy:
-    #       matrix:
-    #         os: [ubuntu-latest, macos-latest, porter]
+    production:
+        name: Production testing
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-latest, macos-latest, porter]
 
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #       with:
-    #         fetch-depth: '0'
-    #     - name: Prepare production environment
-    #       run: |
-    #         [[ $(uname) == Linux ]] && [[ $(hostname) != "porter" ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
-    #         [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
-    #         MIRGEDIR=$(pwd)
-    #         cat scripts/production-testing-env.sh
-    #         . scripts/production-testing-env.sh
-    #         cd ..
-    #         date
-    #         printf "Removing stale install ..."
-    #         rm -rf emirge.prod emirge.y1
-    #         printf "done.\n"
-    #         date
-    #         git clone https://github.com/illinois-ceesd/emirge emirge.prod
-    #         cd emirge.prod
-    #         . ../mirgecom/scripts/install-mirge-from-source.sh ${MIRGEDIR}/..
+        steps:
+        - uses: actions/checkout@v3
+          with:
+            fetch-depth: '0'
+        - name: Prepare production environment
+          run: |
+            [[ $(uname) == Linux ]] && [[ $(hostname) != "porter" ]] && sudo apt-get update && sudo apt-get install -y openmpi-bin libopenmpi-dev
+            [[ $(uname) == Darwin ]] && brew upgrade && brew install mpich
+            MIRGEDIR=$(pwd)
+            cat scripts/production-testing-env.sh
+            . scripts/production-testing-env.sh
+            cd ..
+            date
+            printf "Removing stale install ..."
+            rm -rf emirge.prod emirge.y1
+            printf "done.\n"
+            date
+            git clone https://github.com/illinois-ceesd/emirge emirge.prod
+            cd emirge.prod
+            . ../mirgecom/scripts/install-mirge-from-source.sh ${MIRGEDIR}/..
 
-    #     - name: Run production test
-    #       run: |
-    #         source ../config/activate_env.sh
-    #         scripts/run-integrated-tests.sh --production
+        - name: Run production test
+          run: |
+            source ../config/activate_env.sh
+            scripts/run-integrated-tests.sh --production

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,10 @@ jobs:
             sudo apt-get update
             sudo apt-get install texlive-latex-extra latexmk
             mamba install sphinx graphviz 'docutils>=0.16'
+
+            # Work around "Not enough memory to run on this device." errors in CI:
             mamba uninstall pocl
+
             pip install sphinx-math-dollar sphinx-copybutton furo
             cd doc
             make html SPHINXOPTS="-W --keep-going -n"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,11 +149,10 @@ jobs:
             sudo apt-get update
             sudo apt-get install texlive-latex-extra latexmk
             mamba install sphinx graphviz 'docutils>=0.16'
+            mamba uninstall pocl
             pip install sphinx-math-dollar sphinx-copybutton furo
             cd doc
-            ulimit -a
-            free -h
-            /bin/time -v make html SPHINXOPTS="-W --keep-going -n"
+            make html SPHINXOPTS="-W --keep-going -n"
             make latexpdf SPHINXOPTS="-W --keep-going -n"
 
     # emirge:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,14 +142,16 @@ jobs:
 
         - name: Build docs
           run: |
+            set -x
             MINIFORGE_INSTALL_DIR=.miniforge3
             . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 
             sudo apt-get update
             sudo apt-get install texlive-latex-extra latexmk
-            conda install sphinx graphviz 'docutils>=0.16'
+            mamba install sphinx graphviz 'docutils>=0.16'
             pip install sphinx-math-dollar sphinx-copybutton furo
             cd doc
+            ulimit -a
             make html SPHINXOPTS="-W --keep-going -n"
             make latexpdf SPHINXOPTS="-W --keep-going -n"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,28 +130,28 @@ jobs:
     #         # && export POCL_DEBUG=cuda
     #         scripts/run-integrated-tests.sh --examples
 
-    # doc:
-    #     name: Documentation
-    #     runs-on: ubuntu-latest
+    doc:
+        name: Documentation
+        runs-on: ubuntu-latest
 
-    #     steps:
-    #     - uses: actions/checkout@v3
-    #     - name: Install
-    #       run: |
-    #         . .ci-support/install.sh
+        steps:
+        - uses: actions/checkout@v3
+        - name: Install
+          run: |
+            . .ci-support/install.sh
 
-    #     - name: Build docs
-    #       run: |
-    #         MINIFORGE_INSTALL_DIR=.miniforge3
-    #         . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
+        - name: Build docs
+          run: |
+            MINIFORGE_INSTALL_DIR=.miniforge3
+            . "$MINIFORGE_INSTALL_DIR/bin/activate" testing
 
-    #         sudo apt-get update
-    #         sudo apt-get install texlive-latex-extra latexmk
-    #         conda install sphinx graphviz 'docutils>=0.16'
-    #         pip install sphinx-math-dollar sphinx-copybutton furo
-    #         cd doc
-    #         make html SPHINXOPTS="-W --keep-going -n"
-    #         make latexpdf SPHINXOPTS="-W --keep-going -n"
+            sudo apt-get update
+            sudo apt-get install texlive-latex-extra latexmk
+            conda install sphinx graphviz 'docutils>=0.16'
+            pip install sphinx-math-dollar sphinx-copybutton furo
+            cd doc
+            make html SPHINXOPTS="-W --keep-going -n"
+            make latexpdf SPHINXOPTS="-W --keep-going -n"
 
     # emirge:
     #     name: Emirge installation


### PR DESCRIPTION
The doc CI error is likely caused by https://github.com/pocl/pocl/blob/569885d1a5e3b5abbaa40eb7a3061a51d35eada4/lib/CL/devices/common.c#L1198.

Using mambaforge for the CI install (like in emirge) massively speeds up installation time, from ~1hr to ~4 min.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
