### PR TITLE
Update Riemann and Linear BCs 

### DIFF
--- a/examples/blasius.py
+++ b/examples/blasius.py
@@ -246,10 +246,12 @@ def main(actx_class, use_overintegration, casename, rst_filename, use_esdg):
     velocity[0] = 0.3*np.sqrt(1.4*1.0*2.0)
     flow_init = Initializer(dim=2, velocity=velocity)
 
-    linear_outflow_bnd = LinearizedOutflow2DBoundary(free_stream_density=0.5,
+    linear_outflow_bnd = LinearizedOutflow2DBoundary(
+        dim=dim, free_stream_density=0.5,
         free_stream_pressure=1.0, free_stream_velocity=velocity)
 
-    linear_inflow_bnd = LinearizedInflow2DBoundary(free_stream_density=0.5,
+    linear_inflow_bnd = LinearizedInflow2DBoundary(
+        dim=dim, free_stream_density=0.5,
         free_stream_pressure=1.0, free_stream_velocity=velocity)
 
     boundaries = {

--- a/examples/blasius.py
+++ b/examples/blasius.py
@@ -51,8 +51,8 @@ from mirgecom.boundary import (
     PressureOutflowBoundary,
     AdiabaticSlipBoundary,
     IsothermalWallBoundary,
-    LinearizedInflow2DBoundary,
-    LinearizedOutflow2DBoundary,
+    LinearizedInflowBoundary,
+    LinearizedOutflowBoundary,
 )
 from mirgecom.utils import force_evaluation
 from mirgecom.fluid import make_conserved
@@ -248,13 +248,13 @@ def main(actx_class, use_overintegration, casename, rst_filename, use_esdg):
     velocity[0] = 0.3*np.sqrt(1.4*1.0*2.0)
     flow_init = Initializer(dim=2, velocity=velocity)
 
-    linear_outflow_bnd = LinearizedOutflow2DBoundary(
-        dim=dim, free_stream_density=0.5,
-        free_stream_pressure=1.0, free_stream_velocity=velocity)
+    linear_outflow_bnd = LinearizedOutflowBoundary(
+        free_stream_density=0.5, free_stream_pressure=1.0,
+        free_stream_velocity=velocity)
 
-    linear_inflow_bnd = LinearizedInflow2DBoundary(
-        dim=dim, free_stream_density=0.5,
-        free_stream_pressure=1.0, free_stream_velocity=velocity)
+    linear_inflow_bnd = LinearizedInflowBoundary(
+        free_stream_density=0.5, free_stream_pressure=1.0,
+        free_stream_velocity=velocity)
 
     boundaries = {
         dd_vol.trace("inlet").domain_tag:

--- a/examples/pulse-mixture.py
+++ b/examples/pulse-mixture.py
@@ -189,7 +189,7 @@ def main(actx_class, use_esdg=False,
 
     get_fluid_state = actx.compile(_get_fluid_state)
 
-    # ~~~~ solution initilization
+    # ~~~~ solution initialization
     velocity = np.zeros(shape=(dim,))
     velocity[0] = 10.0
     from pytools.obj_array import make_obj_array

--- a/examples/pulse-mixture.py
+++ b/examples/pulse-mixture.py
@@ -44,8 +44,8 @@ from mirgecom.utils import force_evaluation
 from mirgecom.integrators import rk4_step
 from mirgecom.steppers import advance_state
 from mirgecom.boundary import (
-    LinearizedOutflow2DBoundary,
-    LinearizedInflow2DBoundary,
+    LinearizedOutflowBoundary,
+    LinearizedInflowBoundary,
     # RiemannInflowBoundary,
     PressureOutflowBoundary,
     AdiabaticSlipBoundary
@@ -341,10 +341,9 @@ def main(actx_class, use_esdg=False,
         y_inlet[0] = 1.0
         mass = eos.get_density(pressure=101325.0, temperature=300.0,
                                species_mass_fractions=y_inlet)
-        linear_inflow_bnd = LinearizedInflow2DBoundary(
-            dim=dim, free_stream_density=mass,
-            free_stream_velocity=velocity, free_stream_pressure=101325.0,
-            free_stream_species_mass_fractions=y_inlet)
+        linear_inflow_bnd = LinearizedInflowBoundary(
+            free_stream_density=mass, free_stream_species_mass_fractions=y_inlet,
+            free_stream_velocity=velocity, free_stream_pressure=101325.)
 
         # Linearized outflow
         y_outlet_right = op.project(dcoll, DD_VOLUME_ALL,
@@ -352,9 +351,9 @@ def main(actx_class, use_esdg=False,
                                     fluid_state.cv.species_mass_fractions)
         mass = eos.get_density(pressure=101325.0, temperature=300.0,
                                species_mass_fractions=y_outlet_right)
-        linear_outflow_bnd = LinearizedOutflow2DBoundary(
-            dim=dim, free_stream_density=mass,
-            free_stream_velocity=velocity, free_stream_pressure=101325.0,
+        linear_outflow_bnd = LinearizedOutflowBoundary(
+            free_stream_density=mass, free_stream_velocity=velocity,
+            free_stream_pressure=101325.0,
             free_stream_species_mass_fractions=y_outlet_right)
 
         # Pressure prescribed outflow boundary

--- a/examples/pulse-mixture.py
+++ b/examples/pulse-mixture.py
@@ -341,7 +341,8 @@ def main(actx_class, use_esdg=False,
         y_inlet[0] = 1.0
         mass = eos.get_density(pressure=101325.0, temperature=300.0,
                                species_mass_fractions=y_inlet)
-        linear_inflow_bnd = LinearizedInflow2DBoundary(free_stream_density=mass,
+        linear_inflow_bnd = LinearizedInflow2DBoundary(
+            dim=dim, free_stream_density=mass,
             free_stream_velocity=velocity, free_stream_pressure=101325.0,
             free_stream_species_mass_fractions=y_inlet)
 
@@ -351,7 +352,8 @@ def main(actx_class, use_esdg=False,
                                     fluid_state.cv.species_mass_fractions)
         mass = eos.get_density(pressure=101325.0, temperature=300.0,
                                species_mass_fractions=y_outlet_right)
-        linear_outflow_bnd = LinearizedOutflow2DBoundary(free_stream_density=mass,
+        linear_outflow_bnd = LinearizedOutflow2DBoundary(
+            dim=dim, free_stream_density=mass,
             free_stream_velocity=velocity, free_stream_pressure=101325.0,
             free_stream_species_mass_fractions=y_outlet_right)
 

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -2032,10 +2032,10 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
         nhat = -1.0*actx.thaw(dcoll.normal(dd_bdry))
 
         # rtilde = state_minus.cv.mass - self._ref_mass
-        ptilde = state_minus.dv.pressure - self._ref_pressure
         utilde = state_minus.velocity - self._ref_velocity
+        ptilde = state_minus.dv.pressure - self._ref_pressure
 
-        # only works with the normal component. The tangent one is useless.
+        # get the normal component of velocity. The tangential is not required.
         un_tilde = utilde@nhat
 
         a = state_minus.speed_of_sound

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -1591,10 +1591,10 @@ class RiemannOutflowBoundary(MengaldoBoundaryCondition):
             # extrapolate species
             species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
         else:
-            species_mass_boundary = None
             energy_boundary = (
                 pressure_boundary / (gamma_boundary - 1)
                 + 0.5*rho_boundary*np.dot(velocity_boundary, velocity_boundary))
+            species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
 
         boundary_cv = make_conserved(dim=state_minus.dim, mass=rho_boundary,
                                      energy=energy_boundary,

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -1165,16 +1165,13 @@ class FarfieldBoundary(MengaldoBoundaryCondition):
     .. automethod:: grad_temperature_bc
     """
 
-    def __init__(self, dim, free_stream_pressure, free_stream_velocity,
+    def __init__(self, free_stream_pressure, free_stream_velocity,
                  free_stream_temperature, free_stream_mass_fractions=None):
         """Initialize the boundary condition object."""
         self._temperature = free_stream_temperature
         self._pressure = free_stream_pressure
         self._species_mass_fractions = free_stream_mass_fractions
         self._velocity = free_stream_velocity
-
-        from warnings import warn
-        warn("Passing 'dim' as an argument was deprecated in Q4 2023.", stacklevel=2)
 
     def state_plus(self, dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         """Get the exterior solution on the boundary."""
@@ -1464,7 +1461,6 @@ class RiemannInflowBoundary(MengaldoBoundaryCondition):
         )**(1.0/(gamma_plus-1.0))  # in the reference, Eq. 24 lacks the exponent.
         pressure_boundary = rho_boundary * c_boundary**2 / gamma_boundary
 
-        species_mass_boundary = None
         if state_minus.is_mixture:
             y_plus = self._cv_plus.species_mass_fractions
             energy_boundary = rho_boundary * (
@@ -1477,6 +1473,10 @@ class RiemannInflowBoundary(MengaldoBoundaryCondition):
             energy_boundary = (
                 pressure_boundary / (gamma_boundary - 1)
                 + 0.5*rho_boundary*np.dot(velocity_boundary, velocity_boundary))
+
+            # in case of passive scalars
+            species_mass_boundary = \
+                rho_boundary * state_minus.cv.species_mass_fractions
 
         boundary_cv = make_conserved(dim=state_minus.dim, mass=rho_boundary,
                                      energy=energy_boundary,
@@ -1585,17 +1585,15 @@ class RiemannOutflowBoundary(MengaldoBoundaryCondition):
 
             energy_boundary = rho_boundary * (
                 gas_model.eos.get_internal_energy(
-                    temperature_boundary, self._cv_plus.species_mass_fractions)
+                    temperature_boundary, state_minus.cv.species_mass_fractions)
                 + 0.5*np.dot(velocity_boundary, velocity_boundary))
-
-            # extrapolate species
-            species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
         else:
             energy_boundary = (
                 pressure_boundary / (gamma_boundary - 1)
                 + 0.5*rho_boundary*np.dot(velocity_boundary, velocity_boundary))
-            #species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
-            species_mass_boundary = rho_boundary * self._cv_plus.species_mass_fractions
+
+        # extrapolate species
+        species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
 
         boundary_cv = make_conserved(dim=state_minus.dim, mass=rho_boundary,
                                      energy=energy_boundary,
@@ -1889,16 +1887,11 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
     .. automethod:: grad_temperature_bc
     """
 
-    def __init__(self, free_stream_state=None,
-                 free_stream_density=None,
-                 free_stream_velocity=None,
-                 free_stream_pressure=None,
-                 free_stream_species_mass_fractions=None):
+    def __init__(
+            self, dim=None, free_stream_state=None, free_stream_density=None,
+            free_stream_velocity=None, free_stream_pressure=None,
+            free_stream_species_mass_fractions=None):
         """Initialize the BC object."""
-        self._slip = _SlipBoundaryComponent()
-        self._impermeable = _ImpermeableBoundaryComponent()
-        self._adiabatic = _AdiabaticBoundaryComponent()
-
         if free_stream_state is None:
             self._ref_mass = free_stream_density
             self._ref_velocity = free_stream_velocity
@@ -1910,59 +1903,67 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
             self._ref_pressure = free_stream_state.pressure
             self._spec_mass_fracs = free_stream_state.cv.species_mass_fractions
 
-        if self._ref_velocity.shape[0] != 2:
+        if dim == 3:
+            raise ValueError("This BC only supports 1 or 2-dimensional inputs.")
+
+        if self._ref_velocity.shape[0] != dim:
             vel_shape = self._ref_velocity.shape[0]
-            raise ValueError(f"Expected 2-dimensional inputs, got {vel_shape}.")
+            raise ValueError(f"Expected {dim}-dimensional inputs, got {vel_shape}.")
 
         if free_stream_species_mass_fractions is None:
             self._spec_mass_fracs = np.empty((0,), dtype=object)
 
     def state_plus(self, dcoll, dd_bdry, gas_model, state_minus, **kwargs):
         """Non-reflecting outflow."""
+        dim = state_minus.dim
         actx = state_minus.array_context
         nhat = actx.thaw(dcoll.normal(dd_bdry))
 
         rtilde = state_minus.cv.mass - self._ref_mass
-        utilde = state_minus.velocity[0] - self._ref_velocity[0]
-        vtilde = state_minus.velocity[1] - self._ref_velocity[1]
+        utilde = state_minus.velocity - self._ref_velocity
         ptilde = state_minus.dv.pressure - self._ref_pressure
 
-        un_tilde = +utilde*nhat[0] + vtilde*nhat[1]
-        ut_tilde = -utilde*nhat[1] + vtilde*nhat[0]
+        rotation_matrix = _get_rotation_matrix(nhat)
+        ur_tilde = rotation_matrix@utilde
 
         a = state_minus.speed_of_sound
 
         # zero-out the last, out-going characteristic variable
         c1 = -rtilde*a**2 + ptilde
-        c2 = self._ref_mass*a*ut_tilde
-        c3 = self._ref_mass*a*un_tilde + ptilde
+        c3 = self._ref_mass*a*ur_tilde[0] + ptilde
         c4 = 0.0  # -self._ref_mass*a*un_tilde + ptilde
 
         r_tilde_bnd = 1.0/(a**2)*(-c1 + 0.5*c3 + 0.5*c4)
         un_tilde_bnd = 1.0/(self._ref_mass*a)*(0.5*c3 - 0.5*c4)
-        ut_tilde_bnd = 1.0/(self._ref_mass*a)*c2
         p_tilde_bnd = 0.5*c3 + 0.5*c4
 
+        if dim == 1:
+            velocity = self._ref_velocity + un_tilde_bnd
+        else:
+            c2 = self._ref_mass*a*ur_tilde[1]
+            ut_tilde_bnd = 1.0/(self._ref_mass*a)*c2
+            ur_tilde_bnd = make_obj_array([un_tilde_bnd, ut_tilde_bnd])
+            velocity = self._ref_velocity + rotation_matrix.T@ur_tilde_bnd
+
         mass = r_tilde_bnd + self._ref_mass
-        u_x = self._ref_velocity[0] + (nhat[0]*un_tilde_bnd - nhat[1]*ut_tilde_bnd)
-        u_y = self._ref_velocity[1] + (nhat[1]*un_tilde_bnd + nhat[0]*ut_tilde_bnd)
         pressure = p_tilde_bnd + self._ref_pressure
 
-        kin_energy = 0.5*mass*(u_x**2 + u_y**2)
+        kin_energy = 0.5*mass*np.dot(velocity, velocity)
         if state_minus.is_mixture:
             gas_const = gas_model.eos.gas_const(
                 species_mass_fractions=state_minus.cv.species_mass_fractions)
-            temperature = self._ref_pressure/(self._ref_mass*gas_const)
+            temperature = pressure/(mass*gas_const)
             int_energy = mass*gas_model.eos.get_internal_energy(
-                temperature, self._spec_mass_fracs)  # XXX use state_minus?
+                temperature, state_minus.cv.species_mass_fractions)
         else:
             int_energy = pressure/(gas_model.eos.gamma() - 1.0)
 
-        boundary_cv = make_conserved(dim=2,
-                                     mass=mass,
-                                     energy=kin_energy + int_energy,
-                                     momentum=make_obj_array([u_x*mass, u_y*mass]),
-                                     species_mass=mass*self._spec_mass_fracs)
+        boundary_cv = make_conserved(
+            dim=dim,
+            mass=mass,
+            energy=kin_energy + int_energy,
+            momentum=mass*velocity,
+            species_mass=mass*state_minus.cv.species_mass_fractions)
 
         return make_fluid_state(cv=boundary_cv, gas_model=gas_model,
                                 temperature_seed=state_minus.temperature,
@@ -1979,12 +1980,8 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
         return state_minus.temperature
 
     def grad_temperature_bc(self, dcoll, dd_bdry, grad_t_minus, normal, **kwargs):
-        """Compute temperature gradient on the plus state.
-
-        Impose the opposite normal component to enforce zero energy flux
-        from conduction.
-        """
-        return self._adiabatic.grad_temperature_bc(grad_t_minus, normal)
+        """Return grad(T) to be used in the boundary calculation of viscous flux."""
+        return grad_t_minus
 
     def grad_cv_bc(self, dcoll, dd_bdry, gas_model, state_minus, grad_cv_minus,
                    normal, **kwargs):
@@ -2003,16 +2000,11 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
     .. automethod:: grad_temperature_bc
     """
 
-    def __init__(self, free_stream_state=None,
-                 free_stream_density=None,
-                 free_stream_velocity=None,
-                 free_stream_pressure=None,
-                 free_stream_species_mass_fractions=None):
+    def __init__(
+            self, dim=None, free_stream_state=None, free_stream_velocity=None,
+            free_stream_pressure=None, free_stream_density=None,
+            free_stream_species_mass_fractions=None):
         """Initialize the BC object."""
-        self._slip = _SlipBoundaryComponent()
-        self._impermeable = _ImpermeableBoundaryComponent()
-        self._adiabatic = _AdiabaticBoundaryComponent()
-
         if free_stream_state is None:
             self._ref_mass = free_stream_density
             self._ref_velocity = free_stream_velocity
@@ -2024,12 +2016,12 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
             self._ref_pressure = free_stream_state.pressure
             self._spec_mass_fracs = free_stream_state.cv.species_mass_fractions
 
-        if free_stream_species_mass_fractions is None:
-            self._spec_mass_fracs = np.empty((0,), dtype=object)
+        if dim == 3:
+            raise ValueError("This BC only supports 1 or 2-dimensional inputs.")
 
-        if self._ref_velocity.shape[0] != 2:
+        if self._ref_velocity.shape[0] != dim:
             vel_shape = self._ref_velocity.shape[0]
-            raise ValueError(f"Expected 2-dimensional inputs, got {vel_shape}.")
+            raise ValueError(f"Expected {dim}-dimensional inputs, got {vel_shape}.")
 
         if free_stream_species_mass_fractions is None:
             self._spec_mass_fracs = np.empty((0,), dtype=object)
@@ -2040,45 +2032,43 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
         nhat = -1.0*actx.thaw(dcoll.normal(dd_bdry))
 
         # rtilde = state_minus.cv.mass - self._ref_mass
-        utilde = state_minus.velocity[0] - self._ref_velocity[0]
-        vtilde = state_minus.velocity[1] - self._ref_velocity[1]
         ptilde = state_minus.dv.pressure - self._ref_pressure
+        utilde = state_minus.velocity - self._ref_velocity
 
-        un_tilde = +utilde*nhat[0] + vtilde*nhat[1]
-        # ut_tilde = -utilde*nhat[1] + vtilde*nhat[0]
+        # only works with the normal component. The tangent one is useless.
+        un_tilde = utilde@nhat
 
         a = state_minus.speed_of_sound
 
         # zero-out the first three, incoming characteristics
         c1 = 0.0  # -rtilde*a**2 + ptilde
-        c2 = 0.0  # self._ref_mass*a*ut_tilde
+        c2 = 0.0  # self._ref_mass*a*ut_tilde  # noqa
         c3 = 0.0  # self._ref_mass*a*un_tilde + ptilde
         c4 = -1.0*self._ref_mass*a*un_tilde + ptilde
 
         r_tilde_bnd = 1.0/(a**2)*(-c1 + 0.5*c3 + 0.5*c4)
         un_tilde_bnd = 1.0/(self._ref_mass*a)*(0.5*c3 - 0.5*c4)
-        ut_tilde_bnd = 1.0/(self._ref_mass*a)*c2
+        # ut_tilde_bnd = 1.0/(self._ref_mass*a)*c2
         p_tilde_bnd = 0.5*c3 + 0.5*c4
 
         mass = r_tilde_bnd + self._ref_mass
-        u_x = self._ref_velocity[0] + (nhat[0]*un_tilde_bnd - nhat[1]*ut_tilde_bnd)
-        u_y = self._ref_velocity[1] + (nhat[1]*un_tilde_bnd + nhat[0]*ut_tilde_bnd)
+        velocity = self._ref_velocity + un_tilde_bnd*nhat
         pressure = p_tilde_bnd + self._ref_pressure
 
-        kin_energy = 0.5*mass*(u_x**2 + u_y**2)
+        kin_energy = 0.5*mass*np.dot(velocity, velocity)
         if state_minus.is_mixture:
             gas_const = gas_model.eos.gas_const(
-                species_mass_fractions=state_minus.cv.species_mass_fractions)
+                species_mass_fractions=self._spec_mass_fracs)
             temperature = self._ref_pressure/(self._ref_mass*gas_const)
             int_energy = mass*gas_model.eos.get_internal_energy(
                 temperature, self._spec_mass_fracs)
         else:
             int_energy = pressure/(gas_model.eos.gamma() - 1.0)
 
-        boundary_cv = make_conserved(dim=2,
+        boundary_cv = make_conserved(dim=state_minus.dim,
                                      mass=mass,
                                      energy=kin_energy + int_energy,
-                                     momentum=make_obj_array([u_x*mass, u_y*mass]),
+                                     momentum=mass*velocity,
                                      species_mass=mass*self._spec_mass_fracs)
 
         return make_fluid_state(cv=boundary_cv, gas_model=gas_model,
@@ -2093,39 +2083,10 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
         return state_minus.temperature
 
     def grad_temperature_bc(self, dcoll, dd_bdry, grad_t_minus, normal, **kwargs):
-        """Compute temperature gradient on the plus state.
-
-        Impose the opposite normal component to enforce zero energy flux
-        from conduction.
-        """
-        return self._adiabatic.grad_temperature_bc(grad_t_minus, normal)
+        """Return grad(T) used in the boundary calculation of viscous flux."""
+        return grad_t_minus
 
     def grad_cv_bc(self, dcoll, dd_bdry, gas_model, state_minus, grad_cv_minus,
                    normal, **kwargs):
-        """Return external grad(CV) used in the boundary calculation of viscous flux.
-
-        Specify the velocity gradients on the external state to ensure zero
-        energy and momentum flux due to shear stresses.
-
-        Gradients of species mass fractions are set to zero in the normal direction
-        to ensure zero flux of species across the boundary.
-        """
-        dd_bdry = as_dofdesc(dd_bdry)
-        normal = state_minus.array_context.thaw(dcoll.normal(dd_bdry))
-        state_bc = self.state_bc(
-            dcoll=dcoll, dd_bdry=dd_bdry, gas_model=gas_model,
-            state_minus=state_minus, **kwargs)
-
-        grad_v_bc = self._slip.grad_velocity_bc(
-            state_minus, state_bc, grad_cv_minus, normal)
-
-        grad_mom_bc = (
-            state_bc.mass_density * grad_v_bc
-            + np.outer(state_bc.velocity, grad_cv_minus.mass))
-
-        grad_species_mass_bc = self._impermeable.grad_species_mass_bc(
-            state_minus, grad_cv_minus, normal)
-
-        return grad_cv_minus.replace(
-            momentum=grad_mom_bc,
-            species_mass=grad_species_mass_bc)
+        """Return grad(CV) used in the boundary calculation of viscous flux."""
+        return grad_cv_minus

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -1875,9 +1875,7 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
     of propagations and enable the creation of non-reflecting outflow boundaries.
 
     This can also be applied for Navier-Stokes equations in regions where
-    viscous effects are not dominant, such as the far-field. Thus, the normal
-    gradients of velocity, temperature and species are forced to be null in
-    order to recover the inviscid behavior.
+    viscous effects are not dominant, such as the far-field.
 
     .. automethod:: __init__
     .. automethod:: state_plus

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -1594,7 +1594,8 @@ class RiemannOutflowBoundary(MengaldoBoundaryCondition):
             energy_boundary = (
                 pressure_boundary / (gamma_boundary - 1)
                 + 0.5*rho_boundary*np.dot(velocity_boundary, velocity_boundary))
-            species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
+            #species_mass_boundary = rho_boundary * state_minus.species_mass_fractions
+            species_mass_boundary = rho_boundary * self._cv_plus.species_mass_fractions
 
         boundary_cv = make_conserved(dim=state_minus.dim, mass=rho_boundary,
                                      energy=energy_boundary,
@@ -1987,30 +1988,8 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
 
     def grad_cv_bc(self, dcoll, dd_bdry, gas_model, state_minus, grad_cv_minus,
                    normal, **kwargs):
-        """Return external grad(CV) used in the boundary calculation of viscous flux.
-
-        The normal gradients of velocity, temperature and species are forced
-        to zero in order to recover the inviscid equations.
-        """
-        dd_bdry = as_dofdesc(dd_bdry)
-        normal = state_minus.array_context.thaw(dcoll.normal(dd_bdry))
-        state_bc = self.state_bc(
-            dcoll=dcoll, dd_bdry=dd_bdry, gas_model=gas_model,
-            state_minus=state_minus, **kwargs)
-
-        grad_v_bc = self._slip.grad_velocity_bc(
-            state_minus, state_bc, grad_cv_minus, normal)
-
-        grad_mom_bc = (
-            state_bc.mass_density * grad_v_bc
-            + np.outer(state_bc.velocity, grad_cv_minus.mass))
-
-        grad_species_mass_bc = self._impermeable.grad_species_mass_bc(
-            state_minus, grad_cv_minus, normal)
-
-        return grad_cv_minus.replace(
-            momentum=grad_mom_bc,
-            species_mass=grad_species_mass_bc)
+        """Return grad(CV) to be used in the boundary calculation of viscous flux."""
+        return grad_cv_minus
 
 
 class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -23,8 +23,8 @@ Boundary Conditions
 .. autoclass:: IsothermalWallBoundary
 .. autoclass:: AdiabaticSlipBoundary
 .. autoclass:: AdiabaticNoslipWallBoundary
-.. autoclass:: LinearizedOutflow2DBoundary
-.. autoclass:: LinearizedInflow2DBoundary
+.. autoclass:: LinearizedOutflowBoundary
+.. autoclass:: LinearizedInflowBoundary
 """
 
 __copyright__ = """
@@ -1852,7 +1852,7 @@ class AdiabaticNoslipWallBoundary(MengaldoBoundaryCondition):
         return self._adiabatic.grad_temperature_bc(grad_t_minus, normal)
 
 
-class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
+class LinearizedOutflowBoundary(MengaldoBoundaryCondition):
     r"""Characteristics outflow BCs for linearized Euler equations.
 
     Implement non-reflecting outflow based on characteristic variables for
@@ -1886,7 +1886,7 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
     """
 
     def __init__(
-            self, dim=None, free_stream_state=None, free_stream_density=None,
+            self, free_stream_state=None, free_stream_density=None,
             free_stream_velocity=None, free_stream_pressure=None,
             free_stream_species_mass_fractions=None):
         """Initialize the BC object."""
@@ -1901,12 +1901,8 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
             self._ref_pressure = free_stream_state.pressure
             self._spec_mass_fracs = free_stream_state.cv.species_mass_fractions
 
-        if dim == 3:
+        if self._ref_velocity.shape[0] > 2:
             raise ValueError("This BC only supports 1 or 2-dimensional inputs.")
-
-        if self._ref_velocity.shape[0] != dim:
-            vel_shape = self._ref_velocity.shape[0]
-            raise ValueError(f"Expected {dim}-dimensional inputs, got {vel_shape}.")
 
         if free_stream_species_mass_fractions is None:
             from warnings import warn
@@ -1993,7 +1989,7 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
         return grad_cv_minus
 
 
-class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
+class LinearizedInflowBoundary(MengaldoBoundaryCondition):
     r"""Characteristics inflow BCs for linearized Euler equations.
 
     .. automethod:: __init__
@@ -2005,7 +2001,7 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
     """
 
     def __init__(
-            self, dim=None, free_stream_state=None, free_stream_velocity=None,
+            self, free_stream_state=None, free_stream_velocity=None,
             free_stream_pressure=None, free_stream_density=None,
             free_stream_species_mass_fractions=None):
         """Initialize the BC object."""
@@ -2020,12 +2016,8 @@ class LinearizedInflow2DBoundary(MengaldoBoundaryCondition):
             self._ref_pressure = free_stream_state.pressure
             self._spec_mass_fracs = free_stream_state.cv.species_mass_fractions
 
-        if dim == 3:
+        if self._ref_velocity.shape[0] > 2:
             raise ValueError("This BC only supports 1 or 2-dimensional inputs.")
-
-        if self._ref_velocity.shape[0] != dim:
-            vel_shape = self._ref_velocity.shape[0]
-            raise ValueError(f"Expected {dim}-dimensional inputs, got {vel_shape}.")
 
         if free_stream_species_mass_fractions is None:
             self._spec_mass_fracs = np.empty((0,), dtype=object)

--- a/mirgecom/boundary.py
+++ b/mirgecom/boundary.py
@@ -1857,8 +1857,8 @@ class LinearizedOutflow2DBoundary(MengaldoBoundaryCondition):
 
     Implement non-reflecting outflow based on characteristic variables for
     the Euler equations assuming small perturbations based on [Giles_1988]_.
-    The implementation assume an uniform, steady flow and linerize the Euler
-    equations in this reference state, yielding a linear equation in the form
+    The implementation assumes an uniform, steady flow in which the Euler
+    equations are linearized about, yielding
 
     .. math::
         \frac{\partial U}{\partial t} + A \frac{\partial U}{\partial x} +

--- a/test/test_bc.py
+++ b/test/test_bc.py
@@ -157,8 +157,7 @@ def test_farfield_boundary(actx_factory, dim, flux_func):
     gas_model = GasModel(eos=IdealSingleGas(gas_const=1.0),
                          transport=SimpleTransport(viscosity=sigma,
                                                    thermal_conductivity=kappa))
-    bndry = FarfieldBoundary(dim=dim,
-                             free_stream_velocity=ff_vel,
+    bndry = FarfieldBoundary(free_stream_velocity=ff_vel,
                              free_stream_pressure=ff_press,
                              free_stream_temperature=ff_temp)
 


### PR DESCRIPTION
- Update `species_mass_fractions` for non-mixture cases in RiemannBC.
- Allow either to prescribe or to extrapolate species in LinearOutflowBC; also, do not enforce the gradients to be zeros (over-specified).
- Extended LinearInflowBC and LinearOutflowBC to 1D

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
