### PR TITLE
Add override options for array context fallbacks

### DIFF
--- a/mirgecom/array_context.py
+++ b/mirgecom/array_context.py
@@ -32,7 +32,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import Type, Optional, TYPE_CHECKING
+from typing import Type, Optional, Dict, Any, TYPE_CHECKING
 
 import pyopencl as cl
 from arraycontext import ArrayContext
@@ -105,48 +105,51 @@ def actx_class_is_numpy(actx_class: Type[ArrayContext]) -> bool:
         return False
 
 
-def initialize_actx(actx_class: Type[ArrayContext], comm: Optional["Comm"]) \
-        -> ArrayContext:
+def initialize_actx(
+        actx_class: Type[ArrayContext],
+        comm: Optional["Comm"] = None) -> ArrayContext:
     """Initialize a new :class:`~arraycontext.ArrayContext` based on *actx_class*."""
     from arraycontext import PyOpenCLArrayContext, PytatoPyOpenCLArrayContext
     from grudge.array_context import (MPIPyOpenCLArrayContext,
-                                      MPIPytatoArrayContext)
+                                      MPIPytatoArrayContext,
+                                      MPINumpyArrayContext)
 
-    # Special handling for NumpyArrayContext since it needs no CL context
+    actx_kwargs: Dict[str, Any] = {}
+
+    if comm:
+        actx_kwargs["mpi_communicator"] = comm
+
     if actx_class_is_numpy(actx_class):
         if comm:
-            return actx_class(mpi_communicator=comm)  # type: ignore[call-arg]
+            assert issubclass(actx_class, MPINumpyArrayContext)
         else:
-            return actx_class()
-
-    cl_ctx = cl.create_some_context()
-    if actx_class_is_profiling(actx_class):
-        queue = cl.CommandQueue(cl_ctx,
-            properties=cl.command_queue_properties.PROFILING_ENABLE)
+            assert not issubclass(actx_class, MPINumpyArrayContext)
     else:
-        queue = cl.CommandQueue(cl_ctx)
-
-    from mirgecom.simutil import get_reasonable_memory_pool
-    alloc = get_reasonable_memory_pool(cl_ctx, queue)
-
-    if actx_class_is_lazy(actx_class):
-        assert issubclass(actx_class, PytatoPyOpenCLArrayContext)
-        if comm:
-            assert issubclass(actx_class, MPIPytatoArrayContext)
-            actx: ArrayContext = actx_class(mpi_communicator=comm, queue=queue,
-                                        mpi_base_tag=12000,
-                                        allocator=alloc)  # type: ignore[call-arg]
+        cl_ctx = cl.create_some_context()
+        if actx_class_is_profiling(actx_class):
+            queue = cl.CommandQueue(cl_ctx,
+                properties=cl.command_queue_properties.PROFILING_ENABLE)
         else:
-            assert not issubclass(actx_class, MPIPytatoArrayContext)
-            actx = actx_class(queue, allocator=alloc)
-    else:
-        assert issubclass(actx_class, PyOpenCLArrayContext)
-        if comm:
-            assert issubclass(actx_class, MPIPyOpenCLArrayContext)
-            actx = actx_class(mpi_communicator=comm, queue=queue, allocator=alloc,
-                              force_device_scalars=True)  # type: ignore[call-arg]
-        else:
-            assert not issubclass(actx_class, MPIPyOpenCLArrayContext)
-            actx = actx_class(queue, allocator=alloc, force_device_scalars=True)
+            queue = cl.CommandQueue(cl_ctx)
+        actx_kwargs["queue"] = queue
 
-    return actx
+        from mirgecom.simutil import get_reasonable_memory_pool
+        alloc = get_reasonable_memory_pool(cl_ctx, queue)
+        actx_kwargs["allocator"] = alloc
+
+        if actx_class_is_lazy(actx_class):
+            assert issubclass(actx_class, PytatoPyOpenCLArrayContext)
+            if comm:
+                assert issubclass(actx_class, MPIPytatoArrayContext)
+                actx_kwargs["mpi_base_tag"] = 12000
+            else:
+                assert not issubclass(actx_class, MPIPytatoArrayContext)
+        else:
+            assert issubclass(actx_class, PyOpenCLArrayContext)
+            actx_kwargs["force_device_scalars"] = True
+            if comm:
+                assert issubclass(actx_class, MPIPyOpenCLArrayContext)
+            else:
+                assert not issubclass(actx_class, MPIPyOpenCLArrayContext)
+
+    return actx_class(**actx_kwargs)

--- a/mirgecom/array_context.py
+++ b/mirgecom/array_context.py
@@ -107,7 +107,9 @@ def actx_class_is_numpy(actx_class: Type[ArrayContext]) -> bool:
 
 def initialize_actx(
         actx_class: Type[ArrayContext],
-        comm: Optional["Comm"] = None) -> ArrayContext:
+        comm: Optional["Comm"] = None, *,
+        use_axis_tag_inference_fallback: bool = False,
+        use_einsum_inference_fallback: bool = False) -> ArrayContext:
     """Initialize a new :class:`~arraycontext.ArrayContext` based on *actx_class*."""
     from arraycontext import PyOpenCLArrayContext, PytatoPyOpenCLArrayContext
     from grudge.array_context import (MPIPyOpenCLArrayContext,
@@ -139,6 +141,10 @@ def initialize_actx(
 
         if actx_class_is_lazy(actx_class):
             assert issubclass(actx_class, PytatoPyOpenCLArrayContext)
+            actx_kwargs["use_axis_tag_inference_fallback"] = \
+                use_axis_tag_inference_fallback
+            actx_kwargs["use_einsum_inference_fallback"] = \
+                use_einsum_inference_fallback
             if comm:
                 assert issubclass(actx_class, MPIPytatoArrayContext)
                 actx_kwargs["mpi_base_tag"] = 12000


### PR DESCRIPTION
Adds options to `initialize_actx` reflecting the disabling of array context fallbacks and the override options that were added to meshmode/grudge. Also tweaked the implementation to try to simplify the logic a bit.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
