### PR TITLE
Fix thermal interface for orthotropic cases

### DIFF
--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -695,6 +695,9 @@ def grad_operator(
     dd_vol_quad = dd_vol.with_discr_tag(quadrature_tag)
     dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
 
+    # Make sure it has an array context
+    kappa = kappa + dcoll.zeros(array_context=actx, dd=dd_vol)
+
     if kappa_tpairs is None:
         kappa_tpairs = interior_trace_pairs(
             dcoll, kappa, volume_dd=dd_vol, comm_tag=(_DiffusionKappaTag, comm_tag))
@@ -828,6 +831,9 @@ def diffusion_operator(
     dd_vol = dd
     dd_vol_quad = dd_vol.with_discr_tag(quadrature_tag)
     dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
+
+    # Make sure it has an array context
+    kappa = kappa + dcoll.zeros(array_context=actx, dd=dd_vol)
 
     kappa_tpairs = interior_trace_pairs(
         dcoll, kappa, volume_dd=dd_vol, comm_tag=(_DiffusionKappaTag, comm_tag))

--- a/mirgecom/diffusion.py
+++ b/mirgecom/diffusion.py
@@ -695,9 +695,6 @@ def grad_operator(
     dd_vol_quad = dd_vol.with_discr_tag(quadrature_tag)
     dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
 
-    # Make sure it has an array context
-    kappa = kappa + dcoll.zeros(array_context=actx, dd=dd_vol)
-
     if kappa_tpairs is None:
         kappa_tpairs = interior_trace_pairs(
             dcoll, kappa, volume_dd=dd_vol, comm_tag=(_DiffusionKappaTag, comm_tag))
@@ -831,9 +828,6 @@ def diffusion_operator(
     dd_vol = dd
     dd_vol_quad = dd_vol.with_discr_tag(quadrature_tag)
     dd_allfaces_quad = dd_vol_quad.trace(FACE_RESTR_ALL)
-
-    # Make sure it has an array context
-    kappa = kappa + dcoll.zeros(array_context=actx, dd=dd_vol)
 
     kappa_tpairs = interior_trace_pairs(
         dcoll, kappa, volume_dd=dd_vol, comm_tag=(_DiffusionKappaTag, comm_tag))

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -82,7 +82,6 @@ from grudge.dof_desc import (
 )
 import grudge.op as op
 
-from pytools.obj_array import make_obj_array
 from mirgecom.math import harmonic_mean
 from mirgecom.boundary import (
     MengaldoBoundaryCondition,

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -256,12 +256,28 @@ class _ThermallyCoupledHarmonicMeanBoundaryComponent:
         self._t_plus = t_plus
         self._grad_t_plus = grad_t_plus
 
-    def kappa_plus(self, dcoll, dd_bdry):
+    def proj_kappa_plus(self, dcoll, dd_bdry):
+        # project kappa plus in case of overintegration
+        if isinstance(self._kappa_plus, np.ndarray):
+            # orthotropic materials
+            actx = self._t_plus.array_context
+            normal = actx.thaw(dcoll.normal(dd_bdry))
+            kappa_plus = project_from_base(dcoll, dd_bdry, self._kappa_plus)
+            return np.dot(normal, kappa_plus*normal)
         return project_from_base(dcoll, dd_bdry, self._kappa_plus)
 
+    def proj_kappa_minus(self, dcoll, dd_bdry, kappa):
+        # state minus is already in the quadrature domain
+        if isinstance(kappa, np.ndarray):
+            # orthotropic materials
+            actx = self._t_plus.array_context
+            normal = actx.thaw(dcoll.normal(dd_bdry))
+            return np.dot(normal, kappa*normal)
+        return kappa
+
     def kappa_bc(self, dcoll, dd_bdry, kappa_minus):
-        kappa_plus = project_from_base(dcoll, dd_bdry, self._kappa_plus)
-        return harmonic_mean(kappa_minus, kappa_plus)
+        return harmonic_mean(self.proj_kappa_minus(dcoll, dd_bdry, kappa_minus),
+                             self.proj_kappa_plus(dcoll, dd_bdry))
 
     def temperature_plus(self, dcoll, dd_bdry):
         return project_from_base(dcoll, dd_bdry, self._t_plus)
@@ -269,7 +285,9 @@ class _ThermallyCoupledHarmonicMeanBoundaryComponent:
     def temperature_bc(self, dcoll, dd_bdry, kappa_minus, t_minus):
         t_plus = project_from_base(dcoll, dd_bdry, self._t_plus)
         actx = t_minus.array_context
-        kappa_plus = project_from_base(dcoll, dd_bdry, self._kappa_plus)
+        kappa_plus = self.proj_kappa_plus(dcoll, dd_bdry)
+        kappa_minus = self.proj_kappa_minus(dcoll, dd_bdry,
+                                            kappa_minus + t_minus*0.0)
         kappa_sum = actx.np.where(
             actx.np.greater(kappa_minus + kappa_plus, 0*kappa_minus),
             kappa_minus + kappa_plus,
@@ -366,9 +384,7 @@ class InterfaceFluidSlipBoundary(InterfaceFluidBoundary):
 
         cv_minus = state_minus.cv
 
-        kappa_minus = (
-            # Make sure it has an array context
-            state_minus.tv.thermal_conductivity + 0*state_minus.mass_density)
+        kappa_minus = state_minus.tv.thermal_conductivity
 
         # Grab a unit normal to the boundary
         nhat = actx.thaw(dcoll.normal(dd_bdry))
@@ -425,9 +441,7 @@ class InterfaceFluidSlipBoundary(InterfaceFluidBoundary):
         return self._thermally_coupled.temperature_plus(dcoll, dd_bdry)
 
     def temperature_bc(self, dcoll, dd_bdry, state_minus, **kwargs):  # noqa: D102
-        kappa_minus = (
-            # Make sure it has an array context
-            state_minus.tv.thermal_conductivity + 0*state_minus.mass_density)
+        kappa_minus = state_minus.tv.thermal_conductivity
         return self._thermally_coupled.temperature_bc(
             dcoll, dd_bdry, kappa_minus, state_minus.temperature)
 
@@ -506,9 +520,7 @@ class InterfaceFluidNoslipBoundary(InterfaceFluidBoundary):
             self, dcoll, dd_bdry, gas_model, state_minus, **kwargs):  # noqa: D102
         dd_bdry = as_dofdesc(dd_bdry)
 
-        kappa_minus = (
-            # Make sure it has an array context
-            state_minus.tv.thermal_conductivity + 0*state_minus.mass_density)
+        kappa_minus = state_minus.tv.thermal_conductivity
 
         mom_bc = self._no_slip.momentum_bc(state_minus.momentum_density)
 
@@ -544,9 +556,7 @@ class InterfaceFluidNoslipBoundary(InterfaceFluidBoundary):
         return self._thermally_coupled.temperature_plus(dcoll, dd_bdry)
 
     def temperature_bc(self, dcoll, dd_bdry, state_minus, **kwargs):  # noqa: D102
-        kappa_minus = (
-            # Make sure it has an array context
-            state_minus.tv.thermal_conductivity + 0*state_minus.mass_density)
+        kappa_minus = state_minus.tv.thermal_conductivity
         return self._thermally_coupled.temperature_bc(
             dcoll, dd_bdry, kappa_minus, state_minus.temperature)
 
@@ -599,6 +609,13 @@ class InterfaceWallBoundary(DiffusionBoundary):
         normal = actx.thaw(dcoll.normal(dd_bdry))
 
         kappa_plus = project_from_base(dcoll, dd_bdry, self.kappa_plus)
+
+#        # orthotropic materials
+#        if isinstance(kappa_minus, np.ndarray):
+#            kappa_minus = np.dot(normal, kappa_minus*normal)
+#        if isinstance(kappa_plus, np.ndarray):
+#            kappa_plus = np.dot(normal, kappa_plus*normal)
+
         kappa_tpair = TracePair(
             dd_bdry, interior=kappa_minus, exterior=kappa_plus)
 
@@ -619,6 +636,13 @@ class InterfaceWallBoundary(DiffusionBoundary):
         normal = actx.thaw(dcoll.normal(dd_bdry))
 
         kappa_plus = project_from_base(dcoll, dd_bdry, self.kappa_plus)
+
+#        # orthotropic materials
+#        if isinstance(kappa_minus, np.ndarray):
+#            kappa_minus = np.dot(normal, kappa_minus*normal)
+#        if isinstance(kappa_plus, np.ndarray):
+#            kappa_plus = np.dot(normal, kappa_plus*normal)
+
         kappa_tpair = TracePair(
             dd_bdry, interior=kappa_minus, exterior=kappa_plus)
 
@@ -699,6 +723,10 @@ class InterfaceWallRadiationBoundary(DiffusionBoundary):
             numerical_flux_func=grad_facial_flux_weighted):  # noqa: D102
         actx = u_minus.array_context
         normal = actx.thaw(dcoll.normal(dd_bdry))
+
+#        # orthotropic materials
+#        if isinstance(kappa_minus, np.ndarray):
+#            kappa_minus = np.dot(normal, kappa_minus*normal)
 
         kappa_tpair = TracePair(
             dd_bdry, interior=kappa_minus, exterior=kappa_minus)
@@ -1596,7 +1624,8 @@ def basic_coupled_ns_heat_operator(
         quadrature_tag=DISCR_TAG_BASE,
         limiter_func=None,
         return_gradients=False,
-        use_esdg=False):
+        use_esdg=False,
+        inviscid_terms_on=True):
     r"""
     Simple implementation of a thermally-coupled fluid/wall operator.
 
@@ -1776,7 +1805,7 @@ def basic_coupled_ns_heat_operator(
 
     my_ns_operator = partial(ns_operator,
         viscous_numerical_flux_func=viscous_facial_flux_harmonic,
-        use_esdg=use_esdg)
+        use_esdg=use_esdg, inviscid_terms_on=inviscid_terms_on)
     ns_result = my_ns_operator(
         dcoll, gas_model, fluid_state, fluid_all_boundaries,
         time=time, quadrature_tag=quadrature_tag, dd=fluid_dd,

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -283,10 +283,8 @@ class _ThermallyCoupledHarmonicMeanBoundaryComponent:
         return kappa
 
     def kappa_bc(self, dcoll, dd_bdry, kappa_minus):
-        kappa_plus = make_obj_array([
-            project_from_base(dcoll, dd_bdry, self._kappa_plus[i])
-            for i in range(self._kappa_plus.shape[0])])
-        return harmonic_mean(kappa_minus, kappa_plus)
+        return harmonic_mean(kappa_minus,
+                             project_from_base(dcoll, dd_bdry, self._kappa_plus))
 
     def temperature_plus(self, dcoll, dd_bdry):
         return project_from_base(dcoll, dd_bdry, self._t_plus)

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -610,12 +610,6 @@ class InterfaceWallBoundary(DiffusionBoundary):
 
         kappa_plus = project_from_base(dcoll, dd_bdry, self.kappa_plus)
 
-#        # orthotropic materials
-#        if isinstance(kappa_minus, np.ndarray):
-#            kappa_minus = np.dot(normal, kappa_minus*normal)
-#        if isinstance(kappa_plus, np.ndarray):
-#            kappa_plus = np.dot(normal, kappa_plus*normal)
-
         kappa_tpair = TracePair(
             dd_bdry, interior=kappa_minus, exterior=kappa_plus)
 
@@ -636,12 +630,6 @@ class InterfaceWallBoundary(DiffusionBoundary):
         normal = actx.thaw(dcoll.normal(dd_bdry))
 
         kappa_plus = project_from_base(dcoll, dd_bdry, self.kappa_plus)
-
-#        # orthotropic materials
-#        if isinstance(kappa_minus, np.ndarray):
-#            kappa_minus = np.dot(normal, kappa_minus*normal)
-#        if isinstance(kappa_plus, np.ndarray):
-#            kappa_plus = np.dot(normal, kappa_plus*normal)
 
         kappa_tpair = TracePair(
             dd_bdry, interior=kappa_minus, exterior=kappa_plus)
@@ -723,10 +711,6 @@ class InterfaceWallRadiationBoundary(DiffusionBoundary):
             numerical_flux_func=grad_facial_flux_weighted):  # noqa: D102
         actx = u_minus.array_context
         normal = actx.thaw(dcoll.normal(dd_bdry))
-
-#        # orthotropic materials
-#        if isinstance(kappa_minus, np.ndarray):
-#            kappa_minus = np.dot(normal, kappa_minus*normal)
 
         kappa_tpair = TracePair(
             dd_bdry, interior=kappa_minus, exterior=kappa_minus)

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -236,7 +236,7 @@ class InterfaceFluidBoundary(MengaldoBoundaryCondition):
 
         if isinstance(state_bc.thermal_conductivity, np.ndarray):
             # orthotropic materials
-            actx = self._t_plus.array_context
+            actx = state_minus.array_context
             normal = actx.thaw(dcoll.normal(dd_bdry))
             kappa_bc = np.dot(normal, state_bc.thermal_conductivity*normal)
         else:

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -291,9 +291,9 @@ class _ThermallyCoupledHarmonicMeanBoundaryComponent:
     def temperature_bc(self, dcoll, dd_bdry, kappa_minus, t_minus):
         t_plus = project_from_base(dcoll, dd_bdry, self._t_plus)
         actx = t_minus.array_context
-        kappa_plus = self.get_normal_kappa_plus(dcoll, dd_bdry)
-        kappa_minus = self.get_normal_kappa_minus(dcoll, dd_bdry,
-                                                  kappa_minus + t_minus*0.0)
+        kappa_plus = self._normal_kappa_plus(dcoll, dd_bdry)
+        kappa_minus = self._normal_kappa_minus(dcoll, dd_bdry,
+                                               kappa_minus + t_minus*0.0)
         kappa_sum = actx.np.where(
             actx.np.greater(kappa_minus + kappa_plus, 0*kappa_minus),
             kappa_minus + kappa_plus,

--- a/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
+++ b/mirgecom/multiphysics/thermally_coupled_fluid_wall.py
@@ -262,7 +262,7 @@ class _ThermallyCoupledHarmonicMeanBoundaryComponent:
         self._t_plus = t_plus
         self._grad_t_plus = grad_t_plus
 
-    def get_normal_kappa_plus(self, dcoll, dd_bdry):
+    def _normal_kappa_plus(self, dcoll, dd_bdry):
         # project kappa plus in case of overintegration
         if isinstance(self._kappa_plus, np.ndarray):
             # orthotropic materials
@@ -272,7 +272,7 @@ class _ThermallyCoupledHarmonicMeanBoundaryComponent:
             return np.dot(normal, kappa_plus*normal)
         return project_from_base(dcoll, dd_bdry, self._kappa_plus)
 
-    def get_normal_kappa_minus(self, dcoll, dd_bdry, kappa):
+    def _normal_kappa_minus(self, dcoll, dd_bdry, kappa):
         # state minus is already in the quadrature domain
         if isinstance(kappa, np.ndarray):
             # orthotropic materials

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -732,7 +732,7 @@ def test_orthotropic_diffusion(actx_factory):
     nodes = actx.thaw(dcoll.nodes())
 
     zeros = actx.np.zeros_like(nodes[0])
-    kappa = make_obj_array([kappa0 + zeros, kappa1 + zeros])
+    kappa = make_obj_array([kappa0, kappa1])
     u = 30.0*nodes[0] + 60.0*nodes[1]
 
     # exercise Neumann BC
@@ -753,8 +753,8 @@ def test_orthotropic_diffusion(actx_factory):
     assert err_grad_y < 1.e-9
 
     diff_flux = diffusion_flux(kappa, grad_u)
-    flux_x = -(kappa0 + zeros)*grad_u[0]
-    flux_y = -(kappa1 + zeros)*grad_u[1]
+    flux_x = -kappa0*grad_u[0]
+    flux_y = -kappa1*grad_u[1]
     err_flux_x = actx.to_numpy(op.norm(dcoll, diff_flux[0] - flux_x, np.inf))
     err_flux_y = actx.to_numpy(op.norm(dcoll, diff_flux[1] - flux_y, np.inf))
     assert err_flux_x < 1.e-9
@@ -785,8 +785,8 @@ def test_orthotropic_diffusion(actx_factory):
     assert err_grad_y < 1.e-9
 
     diff_flux = diffusion_flux(kappa, grad_u)
-    flux_x = -(kappa0 + zeros)*grad_u[0]
-    flux_y = -(kappa1 + zeros)*grad_u[1]
+    flux_x = -kappa0*grad_u[0]
+    flux_y = -kappa1*grad_u[1]
     err_flux_x = actx.to_numpy(op.norm(dcoll, diff_flux[0] - flux_x, np.inf))
     err_flux_y = actx.to_numpy(op.norm(dcoll, diff_flux[1] - flux_y, np.inf))
     assert err_flux_x < 1.e-9

--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -731,7 +731,6 @@ def test_orthotropic_diffusion(actx_factory):
     dcoll = create_discretization_collection(actx, mesh, order)
     nodes = actx.thaw(dcoll.nodes())
 
-    zeros = actx.np.zeros_like(nodes[0])
     kappa = make_obj_array([kappa0, kappa1])
     u = 30.0*nodes[0] + 60.0*nodes[1]
 

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -633,6 +633,7 @@ def test_orthotropic_flux(
 
     from meshmode.dof_array import DOFArray
     assert isinstance(fluid_rhs.energy, DOFArray)
+    assert isinstance(wall_energy_rhs, DOFArray)
 
 
 if __name__ == "__main__":

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -61,10 +61,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-import os  # noqa
-os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # noqa
-
-
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_independent_volumes(actx_factory, order, visualize=False):
     """Check multi-volume machinery by setting up two independent volumes."""
@@ -457,7 +453,7 @@ def test_thermally_coupled_fluid_wall(
         or eoc_rec_wall.max_error() < 1e-11)
 
 
-@pytest.mark.parametrize("order", [2, 3])
+@pytest.mark.parametrize("order", [1, 3])
 @pytest.mark.parametrize("use_overintegration", [False, True])
 @pytest.mark.parametrize("orthotropic_kappa", [False, True])
 def test_thermally_coupled_fluid_wall_with_radiation(

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -447,10 +447,8 @@ def test_thermally_coupled_fluid_wall(
 
 @pytest.mark.parametrize("order", [1, 3])
 @pytest.mark.parametrize("use_overintegration", [False, True])
-@pytest.mark.parametrize("orthotropic_kappa", [False, True])
 def test_thermally_coupled_fluid_wall_with_radiation(
-        actx_factory, order, use_overintegration, orthotropic_kappa,
-        visualize=False):
+        actx_factory, order, use_overintegration, visualize=False):
     """Check the thermally-coupled fluid/wall interface with radiation.
 
     Analytic solution prescribed as initial condition, then the RHS is assessed
@@ -509,7 +507,7 @@ def test_thermally_coupled_fluid_wall_with_radiation(
     # Made-up wall material
     wall_rho = 1.0
     wall_cp = 1000.0
-    wall_kappa = make_obj_array([1.0, 1.0]) if orthotropic_kappa else 1.0
+    wall_kappa = 1.0
     wall_emissivity = 1.0
 
     base_fluid_temp = 2.0
@@ -549,17 +547,17 @@ def test_thermally_coupled_fluid_wall_with_radiation(
     assert actx.to_numpy(op.norm(dcoll, solid_rhs, np.inf)) < 1e-4
 
 
-@pytest.mark.parametrize("order", [1, 3])
 @pytest.mark.parametrize("use_overintegration", [False, True])
 @pytest.mark.parametrize("use_noslip", [False, True])
 @pytest.mark.parametrize("use_radiation", [False, True])
 def test_orthotropic_flux(
-        actx_factory, order, use_overintegration, use_radiation, use_noslip,
+        actx_factory, use_overintegration, use_radiation, use_noslip,
         visualize=False):
     """Check the RHS shape for orthotropic kappa cases."""
     actx = actx_factory()
 
     dim = 2
+    order = 3
     nelems = 48
 
     global_mesh = get_box_mesh(dim, -2, 1, nelems)

--- a/test/test_multiphysics.py
+++ b/test/test_multiphysics.py
@@ -26,11 +26,7 @@ from functools import partial
 import pyopencl.array as cla  # noqa
 import pyopencl.clmath as clmath # noqa
 from pytools.obj_array import make_obj_array
-import pymbolic as pmbl
 import grudge.op as op
-from mirgecom.symbolic import (
-    grad as sym_grad,
-    evaluate)
 from mirgecom.simutil import (
     max_component_norm,
     get_box_mesh
@@ -63,6 +59,10 @@ import pytest
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+import os  # noqa
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # noqa
 
 
 @pytest.mark.parametrize("order", [1, 2, 3])
@@ -154,8 +154,10 @@ def test_independent_volumes(actx_factory, order, visualize=False):
 
 @pytest.mark.parametrize("order", [2, 3])
 @pytest.mark.parametrize("use_overintegration", [False, True])
+@pytest.mark.parametrize("orthotropic_kappa", [False, True])
 def test_thermally_coupled_fluid_wall(
-        actx_factory, order, use_overintegration, visualize=False):
+        actx_factory, order, use_overintegration, orthotropic_kappa,
+        visualize=False):
     """Check the thermally-coupled fluid/wall interface."""
     actx = actx_factory()
 
@@ -222,7 +224,12 @@ def test_thermally_coupled_fluid_wall(
         # Made-up wall material
         wall_density = 10*fluid_density
         wall_heat_capacity = fluid_heat_capacity
-        wall_kappa = 10*fluid_kappa
+        if orthotropic_kappa:
+            wall_kappa = make_obj_array([10*fluid_kappa, 10*fluid_kappa])
+            _wall_kappa = wall_kappa[0]  # dummy variable to simplify the test
+        else:
+            wall_kappa = 10*fluid_kappa
+            _wall_kappa = wall_kappa  # dummy variable to simplify the test
 
         base_wall_temp = 600
 
@@ -241,19 +248,20 @@ def test_thermally_coupled_fluid_wall(
         }
 
         interface_temp = (
-            (fluid_kappa * base_fluid_temp + wall_kappa * base_wall_temp)
-            / (fluid_kappa + wall_kappa))
+            (fluid_kappa * base_fluid_temp + _wall_kappa * base_wall_temp)
+            / (fluid_kappa + _wall_kappa))
         interface_flux = (
-            -fluid_kappa * wall_kappa / (fluid_kappa + wall_kappa)
+            -fluid_kappa * _wall_kappa / (fluid_kappa + _wall_kappa)
             * (base_fluid_temp - base_wall_temp))
+
         fluid_alpha = fluid_kappa/(fluid_density * fluid_heat_capacity)
-        wall_alpha = wall_kappa/(wall_density * wall_heat_capacity)
+        wall_alpha = _wall_kappa/(wall_density * wall_heat_capacity)
 
         def steady_func(kappa, x, t):
             return interface_temp - interface_flux/kappa * x[1]
 
         fluid_steady_func = partial(steady_func, fluid_kappa)
-        wall_steady_func = partial(steady_func, wall_kappa)
+        wall_steady_func = partial(steady_func, _wall_kappa)
 
         def perturb_func(alpha, x, t):
             w = 1.5 * np.pi
@@ -262,7 +270,7 @@ def test_thermally_coupled_fluid_wall(
         # This perturbation function is nonzero at the interface, so the two alphas
         # need to be the same (otherwise the perturbations will decay at different
         # rates and a discontinuity will form)
-        assert abs(fluid_alpha - wall_alpha) < 1e-12
+        assert abs(fluid_alpha - np.max(actx.to_numpy(wall_alpha))) < 1e-12
 
         fluid_perturb_func = partial(perturb_func, fluid_alpha)
         wall_perturb_func = partial(perturb_func, wall_alpha)
@@ -297,14 +305,6 @@ def test_thermally_coupled_fluid_wall(
                     ("temp", wall_temp),
                     ])
 
-        # Add a source term to the momentum equations to cancel out the pressure term
-        sym_fluid_temp = fluid_func(pmbl.var("x"), pmbl.var("t"))
-        sym_fluid_pressure = fluid_density * r * sym_fluid_temp
-        sym_momentum_source = sym_grad(2, sym_fluid_pressure)
-
-        def momentum_source_func(x, t):
-            return evaluate(sym_momentum_source, x=x, t=t)
-
         def get_rhs(t, state):
             fluid_state = make_fluid_state(cv=state[0], gas_model=gas_model)
             wall_temperature = state[1]
@@ -315,10 +315,8 @@ def test_thermally_coupled_fluid_wall(
                 fluid_boundaries, wall_boundaries,
                 fluid_state, wall_kappa, wall_temperature,
                 time=t,
-                quadrature_tag=quadrature_tag)
-            fluid_rhs = replace(
-                fluid_rhs,
-                momentum=fluid_rhs.momentum + momentum_source_func(fluid_nodes, t))
+                quadrature_tag=quadrature_tag,
+                inviscid_terms_on=False)
             wall_rhs = wall_energy_rhs / (wall_density * wall_heat_capacity)
             return make_obj_array([fluid_rhs, wall_rhs])
 
@@ -410,7 +408,6 @@ def test_thermally_coupled_fluid_wall(
                 expected_fluid_temp = fluid_func(fluid_nodes, t)
                 expected_wall_temp = wall_func(wall_nodes, t)
                 rhs = get_rhs(t, state)
-                momentum_source = momentum_source_func(fluid_nodes, t)
                 viz_fluid.write_vtk_file(
                     "thermally_coupled_accuracy_"
                     f"{viz_suffix}_fluid_{step}.vtu", [
@@ -418,7 +415,6 @@ def test_thermally_coupled_fluid_wall(
                         ("dv", fluid_state.dv),
                         ("expected_temp", expected_fluid_temp),
                         ("rhs", rhs[0]),
-                        ("momentum_source", momentum_source),
                         ])
                 viz_wall.write_vtk_file(
                     "thermally_coupled_accuracy_"
@@ -461,10 +457,12 @@ def test_thermally_coupled_fluid_wall(
         or eoc_rec_wall.max_error() < 1e-11)
 
 
-@pytest.mark.parametrize("order", [1, 3])
+@pytest.mark.parametrize("order", [2, 3])
 @pytest.mark.parametrize("use_overintegration", [False, True])
+@pytest.mark.parametrize("orthotropic_kappa", [False, True])
 def test_thermally_coupled_fluid_wall_with_radiation(
-        actx_factory, order, use_overintegration, visualize=False):
+        actx_factory, order, use_overintegration, orthotropic_kappa,
+        visualize=False):
     """Check the thermally-coupled fluid/wall interface with radiation.
 
     Analytic solution prescribed as initial condition, then the RHS is assessed
@@ -523,7 +521,7 @@ def test_thermally_coupled_fluid_wall_with_radiation(
     # Made-up wall material
     wall_rho = 1.0
     wall_cp = 1000.0
-    wall_kappa = 1.0
+    wall_kappa = make_obj_array([1.0, 1.0]) if orthotropic_kappa else 1.0
     wall_emissivity = 1.0
 
     base_fluid_temp = 2.0


### PR DESCRIPTION
- Include normal projection of thermal conductivity for orthotropic cases.
- Add extra option to test in `test_multiphysics`
- ~Force thermal conductivity to be DOFArray sooner for diffusion operator.~

**Questions for the review**:
- [x] Is the scope and purpose of the PR clear?
  - [x] The PR should have a description.
  - [x] The PR should have a guide if needed (e.g., an ordering).
- [x] Is every top-level method and class documented? Are things that should be documented actually so?
- [x] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [x] Does the implementation do what the docstring claims?
- [x] Is everything that is implemented covered by tests?
- [x] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
