### PR TITLE
remove comm arg types to fix RTD build

### DIFF
--- a/mirgecom/array_context.py
+++ b/mirgecom/array_context.py
@@ -32,15 +32,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from typing import Type, Optional, Dict, Any, TYPE_CHECKING
+from typing import Type, Dict, Any
 
 import pyopencl as cl
 from arraycontext import ArrayContext
-import sys
-
-if TYPE_CHECKING or getattr(sys, "_BUILDING_SPHINX_DOCS", False):
-    # pylint: disable=no-name-in-module
-    from mpi4py.MPI import Comm
 
 
 def get_reasonable_array_context_class(*, lazy: bool, distributed: bool,
@@ -107,7 +102,7 @@ def actx_class_is_numpy(actx_class: Type[ArrayContext]) -> bool:
 
 def initialize_actx(
         actx_class: Type[ArrayContext],
-        comm: Optional["Comm"] = None, *,
+        comm=None, *,
         use_axis_tag_inference_fallback: bool = False,
         use_einsum_inference_fallback: bool = False) -> ArrayContext:
     """Initialize a new :class:`~arraycontext.ArrayContext` based on *actx_class*."""

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -71,9 +71,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 import logging
-import sys
 from functools import partial
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import Dict, List, Optional
 from logpyle import IntervalTimer
 
 import grudge.op as op
@@ -93,10 +92,6 @@ from mirgecom.utils import normalize_boundaries
 from mirgecom.viscous import get_viscous_timestep
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING or getattr(sys, "_BUILDING_SPHINX_DOCS", False):
-    # pylint: disable=no-name-in-module
-    from mpi4py.MPI import Comm
 
 
 class SimulationConfigurationError(RuntimeError):
@@ -297,7 +292,7 @@ def get_sim_timestep(
 
 def write_visfile(dcoll, io_fields, visualizer, vizname,
                   step=0, t=0, overwrite=False, vis_timer=None,
-                  comm: Optional["Comm"] = None):
+                  comm=None):
     """Write parallel VTK output for the fields specified in *io_fields*.
 
     This routine writes a parallel-compatible unstructured VTK visualization


### PR DESCRIPTION
This 'fixes' the readthedocs build (see https://readthedocs.org/projects/mirgecom/builds/ for context)

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
