### PR TITLE
adjust MacOS kernel disk caching wrt XDG_CACHE_HOME

### DIFF
--- a/doc/running/caching.rst
+++ b/doc/running/caching.rst
@@ -39,7 +39,7 @@ with a focus on configuring the disk-based caching.
 Loopy
 -----
 
-On Linux, :mod:`loopy` stores the source of generated PyOpenCL kernels and their
+:mod:`loopy` stores the source of generated PyOpenCL kernels and their
 invokers in ``$XDG_CACHE_HOME/pytools/pdict-*-loopy`` by default. You can export
 ``LOOPY_NO_CACHE=1`` to disable caching. See `here
 <https://github.com/inducer/loopy/blob/e21e8f85d289abbca27ac6abfd71874155fa49da/loopy/__init__.py#L402-L406>`__
@@ -54,19 +54,13 @@ for details.
 .. note::
 
    When ``$XDG_CACHE_HOME`` is not set, the cache dir defaults to
-   ``~/.cache`` on Linux.
-
-.. warning::
-
-   On MacOS, :mod:`loopy`'s disk cache is always located in ``~/Library/Caches/pytools/pdict-*-loopy``.
-   Its location can not be changed.
-
+   ``~/.cache`` on Linux and ``~/Library/Caches/`` on MacOS.
 
 
 PyOpenCL
 --------
 
-On Linux, :mod:`pyopencl` caches in ``$XDG_CACHE_HOME/pyopencl`` (kernel source
+:mod:`pyopencl` caches in ``$XDG_CACHE_HOME/pyopencl`` (kernel source
 code and binaries returned by the OpenCL runtime) and
 ``$XDG_CACHE_HOME/pytools/pdict-*-pyopencl`` (invokers, generated source code)
 by default. You can export ``PYOPENCL_NO_CACHE=1`` to disable caching. See `here
@@ -90,17 +84,11 @@ for details.
    behaviors on the first three compilations depending on how the CL runtime
    itself performs caching.
 
-.. warning::
-
-   On MacOS, :mod:`pyopencl`'s disk caches are always located in ``~/Library/Caches/pyopencl/``
-   and ``~/Library/Caches/pytools/pdict-*-pyopencl``.
-   Their locations can not be changed.
-
 
 PoCL
 ----
 
-On Linux and MacOS, *PoCL* stores compilation results (LLVM bitcode and shared
+*PoCL* stores compilation results (LLVM bitcode and shared
 libraries) in ``$POCL_CACHE_DIR`` or ``$XDG_CACHE_HOME/pocl`` by default. You
 can export ``POCL_KERNEL_CACHE=0`` to disable caching. See `here
 <http://portablecl.org/docs/html/using.html#tuning-pocl-behavior-with-env-variables>`__ for details.
@@ -109,11 +97,6 @@ can export ``POCL_KERNEL_CACHE=0`` to disable caching. See `here
 
    When ``$POCL_CACHE_DIR`` and ``$XDG_CACHE_HOME`` are not set, *PoCL*'s cache
    dir defaults to ``~/.cache/pocl`` on Linux and MacOS.
-
-.. warning::
-
-   In contrast to the :mod:`loopy` and :mod:`pyopencl` disk caches, *PoCL* honors
-   ``$XDG_CACHE_HOME`` even on MacOS.
 
 
 CUDA

--- a/mirgecom/mpi.py
+++ b/mirgecom/mpi.py
@@ -94,10 +94,7 @@ def _check_cache_dirs() -> None:
                     warn(f"Multiple ranks are sharing '{var}' on node '{hostname}'. "
                         f"Duplicate '{var}'s: {dup}.")
 
-        if sys.platform != "darwin":
-            # XDG_CACHE_HOME can't be used on MacOS, see
-            # https://github.com/illinois-ceesd/mirgecom/pull/1020
-            _check_var("XDG_CACHE_HOME")
+        _check_var("XDG_CACHE_HOME")
         _check_var("POCL_CACHE_DIR")
 
         # We haven't observed an issue yet that 'CUDA_CACHE_PATH' fixes,
@@ -202,16 +199,6 @@ def _check_mpi4py_version() -> None:
                      "scatter support.")
 
 
-def _check_xdg_env_on_macos() -> None:
-    if sys.platform == "darwin":
-        if "XDG_CACHE_HOME" in os.environ:
-            # XDG_CACHE_HOME can't be used on MacOS, see
-            # https://github.com/illinois-ceesd/mirgecom/pull/1020
-            from warnings import warn
-            warn("The XDG_CACHE_HOME environment variable is set. This "
-                 "variable is ignored on MacOS for loopy/pyopencl caches.")
-
-
 def mpi_entry_point(func) -> Callable:
     """
     Return a decorator that designates a function as the "main" function for MPI.
@@ -254,7 +241,6 @@ def mpi_entry_point(func) -> Callable:
         _check_cache_dirs()
         _check_isl_version()
         _check_mpi4py_version()
-        _check_xdg_env_on_macos()
 
         func(*args, **kwargs)
 


### PR DESCRIPTION
XDG_CACHE_HOME support for MacOS has been added to loopy and pyopencl.

This partially reverts #1020.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
