### PR TITLE
Allow limiter to optionally pass back p,T

### DIFF
--- a/mirgecom/gas_model.py
+++ b/mirgecom/gas_model.py
@@ -373,14 +373,22 @@ def make_fluid_state(cv, gas_model,
                         is None else smoothness_d)
 
     if isinstance(gas_model, GasModel):
+        pressure = None
+        temperature = None
 
         if limiter_func:
-            cv = limiter_func(cv=cv, temperature_seed=temperature_seed,
+            rv = limiter_func(cv=cv, temperature_seed=temperature_seed,
                               gas_model=gas_model, dd=limiter_dd)
+            if isinstance(rv, np.ndarray):
+                cv, pressure, temperature = rv
+            else:
+                cv = rv
 
-        temperature = gas_model.eos.temperature(
-            cv=cv, temperature_seed=temperature_seed)
-        pressure = gas_model.eos.pressure(cv=cv, temperature=temperature)
+        if temperature is None:
+            temperature = gas_model.eos.temperature(
+                cv=cv, temperature_seed=temperature_seed)
+        if pressure is None:
+            pressure = gas_model.eos.pressure(cv=cv, temperature=temperature)
 
         dv = GasDependentVars(
             temperature=temperature,


### PR DESCRIPTION
Allow limiter to optionally pass back p, T.  This can break things if the limiter passes back invalid p, T , but it is a performance bottleneck to disallow it when we trust that the driver-implemented limiter is returning the correct p, T.

(This is not adding a new behavior, it is optionally allowing the old behavior)

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
