### PR TITLE
Fix doc reference

### DIFF
--- a/doc/running/device-selection.rst
+++ b/doc/running/device-selection.rst
@@ -27,7 +27,7 @@ There are multiple ways in which this selection can happen:
    The device selection functionality described here is provided by the
    :func:`pyopencl.create_some_context`,
    :func:`pyopencl.tools.pytest_generate_tests_for_pyopencl`, and
-   :func:`arraycontext.pytest_generate_tests_for_pyopencl_array_context`
+   :func:`arraycontext.pytest_generate_tests_for_array_contexts`
    functions used in the default simulation drivers and tests. It is also
    possible to write your own device selection code with
    :func:`pyopencl.get_platforms`, :meth:`pyopencl.Platform.get_devices`, and


### PR DESCRIPTION
`pytest_generate_tests_for_pyopencl_array_context` was removed in https://github.com/inducer/arraycontext/pull/278.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
