### PR TITLE
Add option to compile the full timestepper in `advance_state`

### DIFF
--- a/mirgecom/integrators/lsrk.py
+++ b/mirgecom/integrators/lsrk.py
@@ -64,7 +64,12 @@ EulerCoefs = LSRKCoefficients(
 
 def euler_step(state, t, dt, rhs):
     """Take one step using the explicit, 1st-order accurate, Euler method."""
-    return lsrk_step(EulerCoefs, state, t, dt, rhs)
+    # Full-timestepper compilation doesn't like this version; triggers loop
+    # nest error in meshmode array context:
+    #     NotImplementedError: Cannot fit loop nest 'frozenset()' into known
+    #         set of loop-nest patterns.
+    # return lsrk_step(EulerCoefs, state, t, dt, rhs)
+    return state + dt * rhs(t, state)
 
 
 LSRK54CarpenterKennedyCoefs = LSRKCoefficients(


### PR DESCRIPTION
Adds an option to compile the whole timestepper in `advance_state` instead of just the RHS. Lowers the performance floor somewhat for prediction on lassen when using Euler timestepping (0.04s -> 0.014s).

Might be useful @mtcam @anderson2981. It's not without its pitfalls though: only use it with Euler integration (integrators with multiple RHS calls will construct a mega-DAG with multiple RHSes), and it's probably not going to play well with filtering as it's currently implemented in the prediction driver. Turn off the RHS compile in the driver before using this.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
