### PR TITLE
Add __array_ufunc__=None to relevant dataclasses

### DIFF
--- a/examples/mixture-tpe.py
+++ b/examples/mixture-tpe.py
@@ -283,7 +283,8 @@ def main(actx_class, use_esdg=False,
             exact = initializer(x_vec=nodes, eos=eos, time=t)
         if resid is None:
             resid = state - exact
-        viz_fields = [("cv", state), ("dv", dv)]
+        viz_fields = [("cv", state), ("dv", dv),
+                      ("resid", resid), ("exact", exact)]
         from mirgecom.simutil import write_visfile
         write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,
@@ -356,7 +357,7 @@ def main(actx_class, use_esdg=False,
             if do_viz:
                 if exact is None:
                     exact = initializer(x_vec=nodes, eos=eos, time=t)
-                resid = state - exact
+                resid = fluid_state.cv - exact
                 my_write_viz(step=step, t=t, state=cv, dv=dv, exact=exact,
                              resid=resid)
 

--- a/examples/mixture.py
+++ b/examples/mixture.py
@@ -277,7 +277,8 @@ def main(actx_class, use_esdg=False,
             exact = initializer(x_vec=nodes, eos=eos, time=t)
         if resid is None:
             resid = state - exact
-        viz_fields = [("cv", state), ("dv", dv)]
+        viz_fields = [("cv", state), ("dv", dv),
+                      ("resid", cv), ("exact", exact)]
         from mirgecom.simutil import write_visfile
         write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,
@@ -350,7 +351,7 @@ def main(actx_class, use_esdg=False,
             if do_viz:
                 if exact is None:
                     exact = initializer(x_vec=nodes, eos=eos, time=t)
-                resid = state - exact
+                resid = fluid_state.cv - exact
                 my_write_viz(step=step, t=t, state=cv, dv=dv, exact=exact,
                              resid=resid)
 

--- a/examples/mixture.py
+++ b/examples/mixture.py
@@ -278,7 +278,7 @@ def main(actx_class, use_esdg=False,
         if resid is None:
             resid = state - exact
         viz_fields = [("cv", state), ("dv", dv),
-                      ("resid", cv), ("exact", exact)]
+                      ("resid", resid), ("exact", exact)]
         from mirgecom.simutil import write_visfile
         write_visfile(dcoll, viz_fields, visualizer, vizname=casename,
                       step=step, t=t, overwrite=True, vis_timer=vis_timer,

--- a/mirgecom/fluid.py
+++ b/mirgecom/fluid.py
@@ -272,6 +272,8 @@ class ConservedVars:
         from dataclasses import replace
         return replace(self, **kwargs)
 
+    __array_ufunc__ = None
+
 
 def _aux_shape(ary, leading_shape):
     """:arg leading_shape: a tuple with which ``ary.shape`` is expected to begin."""

--- a/mirgecom/wall_model.py
+++ b/mirgecom/wall_model.py
@@ -105,6 +105,8 @@ class SolidWallConservedVars:
         """Return an array context for the :class:`SolidWallConservedVars` object."""
         return get_container_context_recursively(self.mass)
 
+    __array_ufunc__ = False
+
 
 @dataclass_array_container
 @dataclass(frozen=True, eq=False)


### PR DESCRIPTION
Avoids warnings of the type:
```
mirgecom/fluid.py:49: UserWarning: <class 'mirgecom.fluid.ConservedVars'> does not have __array_ufunc__ set. This will cause numpy to attempt broadcasting, in a way that is likely undesired. To avoid this, set __array_ufunc__ = None in <class 'mirgecom.fluid.ConservedVars'>.
```
**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
