### PR TITLE
Ignore these mypy errors

### DIFF
--- a/examples/wave.py
+++ b/examples/wave.py
@@ -137,7 +137,7 @@ def main(actx_class, casename="wave",
 
     dt = actx.to_numpy(current_cfl
                        * op.nodal_min(dcoll,
-                                      "vol", nodal_dt))[()]
+                                      "vol", nodal_dt))[()]  # type: ignore[index]
 
     t_final = 1
 

--- a/examples/wave.py
+++ b/examples/wave.py
@@ -135,9 +135,9 @@ def main(actx_class, casename="wave",
     from grudge.dt_utils import characteristic_lengthscales
     nodal_dt = characteristic_lengthscales(actx, dcoll) / wave_speed
 
-    dt = actx.to_numpy(current_cfl
-                       * op.nodal_min(dcoll,
-                                      "vol", nodal_dt))[()]
+    dt = actx.to_numpy(  # type: ignore[index]
+        current_cfl * op.nodal_min(
+            dcoll, "vol", nodal_dt))[()]
 
     t_final = 1
 

--- a/examples/wave.py
+++ b/examples/wave.py
@@ -135,9 +135,9 @@ def main(actx_class, casename="wave",
     from grudge.dt_utils import characteristic_lengthscales
     nodal_dt = characteristic_lengthscales(actx, dcoll) / wave_speed
 
-    dt = actx.to_numpy(  # type: ignore[index]
-        current_cfl * op.nodal_min(
-            dcoll, "vol", nodal_dt))[()]
+    dt = actx.to_numpy(current_cfl
+                       * op.nodal_min(dcoll,
+                                      "vol", nodal_dt))[()]
 
     t_final = 1
 

--- a/mirgecom/limiter.py
+++ b/mirgecom/limiter.py
@@ -90,8 +90,8 @@ def bound_preserving_limiter(dcoll: DiscretizationCollection, field,
     if dd is None:
         dd = DD_VOLUME_ALL
 
-    cell_vols = abs(op.elementwise_integral(dcoll, dd,
-                                            actx.np.zeros_like(field) + 1.0))
+    cell_vols = abs(op.elementwise_integral(  # type: ignore[arg-type, var-annotated]
+                    dcoll, dd, actx.np.zeros_like(field) + 1.0))
     cell_avgs = op.elementwise_integral(dcoll, dd, field)/cell_vols
 
     # Bound cell average in case it doesn't respect the realizability

--- a/mirgecom/limiter.py
+++ b/mirgecom/limiter.py
@@ -90,8 +90,11 @@ def bound_preserving_limiter(dcoll: DiscretizationCollection, field,
     if dd is None:
         dd = DD_VOLUME_ALL
 
-    cell_vols = abs(op.elementwise_integral(dcoll, dd,
-                                            actx.np.zeros_like(field) + 1.0))
+    cell_vols = \  # type: ignore[var-annotated,arg-type]
+        abs(op.elementwise_integral(
+            dcoll, dd,
+            actx.np.zeros_like(field) + 1.0))
+
     cell_avgs = op.elementwise_integral(dcoll, dd, field)/cell_vols
 
     # Bound cell average in case it doesn't respect the realizability

--- a/mirgecom/limiter.py
+++ b/mirgecom/limiter.py
@@ -90,11 +90,8 @@ def bound_preserving_limiter(dcoll: DiscretizationCollection, field,
     if dd is None:
         dd = DD_VOLUME_ALL
 
-    cell_vols = \  # type: ignore[var-annotated,arg-type]
-        abs(op.elementwise_integral(
-            dcoll, dd,
-            actx.np.zeros_like(field) + 1.0))
-
+    cell_vols = abs(op.elementwise_integral(dcoll, dd,
+                                            actx.np.zeros_like(field) + 1.0))
     cell_avgs = op.elementwise_integral(dcoll, dd, field)/cell_vols
 
     # Bound cell average in case it doesn't respect the realizability

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -480,9 +480,9 @@ def check_range_local(dcoll: DiscretizationCollection, dd: str, field: DOFArray,
                       min_value: float, max_value: float) -> List[float]:
     """Return the values that are outside the range [min_value, max_value]."""
     actx = field.array_context
-    local_min = actx.to_numpy(  # type: ignore[union-attr]
+    local_min = actx.to_numpy(
         op.nodal_min_loc(dcoll, dd, field)).item()
-    local_max = actx.to_numpy(  # type: ignore[union-attr]
+    local_max = actx.to_numpy(
         op.nodal_max_loc(dcoll, dd, field)).item()
 
     failing_values = []

--- a/mirgecom/simutil.py
+++ b/mirgecom/simutil.py
@@ -480,9 +480,9 @@ def check_range_local(dcoll: DiscretizationCollection, dd: str, field: DOFArray,
                       min_value: float, max_value: float) -> List[float]:
     """Return the values that are outside the range [min_value, max_value]."""
     actx = field.array_context
-    local_min = actx.to_numpy(
+    local_min = actx.to_numpy(  # type: ignore[union-attr]
         op.nodal_min_loc(dcoll, dd, field)).item()
-    local_max = actx.to_numpy(
+    local_max = actx.to_numpy(  # type: ignore[union-attr]
         op.nodal_max_loc(dcoll, dd, field)).item()
 
     failing_values = []

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ convention=numpy
 
 [mypy]
 warn_unused_ignores = True
+disable_error_code = var-annotated,arg-type,union-attr
 
 [mypy-mirgecom.profiling]
 ignore_errors = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ convention=numpy
 
 [mypy]
 warn_unused_ignores = True
-disable_error_code = var-annotated,arg-type,union-attr
 
 [mypy-mirgecom.profiling]
 ignore_errors = True


### PR DESCRIPTION
These errors are coming with the imminent update to latest inducer@main upstream pkgs.  Tried, but didn't figure out how to get around them instance-by-instance.

https://github.com/illinois-ceesd/mirgecom/actions/runs/12190311488/job/34010485460?pr=926

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
