### PR TITLE
Remove null terminator from `MPI.Get_library_version` output

### DIFF
--- a/mirgecom/mpi.py
+++ b/mirgecom/mpi.py
@@ -100,7 +100,11 @@ def _check_mpi4py_version() -> None:
 
     mpi_ver = MPI.Get_version()
 
-    logger.info(f"mpi4py is using '{MPI.Get_library_version()}' "
+    mpi_ver_descr = MPI.Get_library_version()
+    # Get_library_version returns a null-terminated string
+    mpi_ver_descr = mpi_ver_descr.split("\x00")[0]
+
+    logger.info(f"mpi4py is using '{mpi_ver_descr}' "
                 f"with MPI v{mpi_ver[0]}.{mpi_ver[1]}.")
 
 


### PR DESCRIPTION
grep has been treating mirgecom output files as binary recently. This seems to be the culprit.

**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
