### PR TITLE
Use flat_norm after support for dof_arrays in actx.linalg.np.norm was…

### DIFF
--- a/test/test_diffusion.py
+++ b/test/test_diffusion.py
@@ -626,7 +626,8 @@ def test_diffusion_compare_to_nodal_dg(actx_factory, problem, order,
             diffusion_u_ndg = ndgctx.pull_dof_array(actx, "rhs")
 
             def inf_norm(f):
-                return actx.np.linalg.norm(f, np.inf)
+                from meshmode.dof_array import flat_norm
+                return flat_norm(f, np.inf)
 
             err = (inf_norm(diffusion_u_mirgecom-diffusion_u_ndg)
                         / inf_norm(diffusion_u_ndg))


### PR DESCRIPTION
Support for DOFArrays in `actx.np.linalg.norm` has been removed upstream.  This fixes the use of deprecated functionality triggered in the diffustion testing suite.

https://github.com/illinois-ceesd/mirgecom/actions/runs/15175382713/job/42674585317#step:4:341


**Questions for the review**:
- [ ] Is the scope and purpose of the PR clear?
  - [ ] The PR should have a description.
  - [ ] The PR should have a guide if needed (e.g., an ordering).
- [ ] Is every top-level method and class documented? Are things that should be documented actually so?
- [ ] Is the interface understandable? (I.e. can someone figure out what stuff does?) Is it well-defined?
- [ ] Does the implementation do what the docstring claims?
- [ ] Is everything that is implemented covered by tests?
- [ ] Do you see any immediate risks or performance disadvantages with the design? Example: what do interface normals attach to?
